### PR TITLE
refactor(platform): add platf::log_dir() abstraction

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -933,7 +933,11 @@ namespace config {
     .config_file = platf::appdata().string() + "/sunshine.conf",
     .port = 47989,
     .address_family = "ipv4",
-    .log_file = platf::appdata().string() + "/sunshine.log",
+    // Route through `platf::log_dir()` instead of `platf::appdata()` so the
+    // future move of log files into a dedicated logs/ subtree is a one-line
+    // platform-implementation flip rather than touching this default.
+    // Today both accessors return the same path.
+    .log_file = platf::log_dir().string() + "/sunshine.log",
     .notify_pre_releases = true,  // default-on so Insider Preview hosts get prerelease fixes; falls back to GA when none newer exists
     .system_tray = true,
     .session_token_ttl = std::chrono::hours {2},

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -574,6 +574,22 @@ namespace platf {
 
   std::filesystem::path appdata();
 
+  /**
+   * @brief Root directory for log files.
+   *
+   * Today this returns the same path as `appdata()` — log files have always
+   * been colocated with config inside the appdata directory, so existing
+   * deployments and the log viewer / log-export endpoints keep working
+   * unchanged. The dedicated accessor exists so a future migration can
+   * relocate logs (e.g. to `%ProgramData%\LuminalShine\logs\` on Windows)
+   * by flipping a single platform implementation, instead of editing every
+   * call site that builds a log path.
+   *
+   * Callers that need the "where do logs live" answer should prefer this
+   * over `appdata()` so the future split lands without churn.
+   */
+  std::filesystem::path log_dir();
+
   std::string get_mac_address(const std::string_view &address);
 
   std::string from_sockaddr(const sockaddr *const);

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -204,6 +204,12 @@ namespace platf {
     return config_path;
   }
 
+  fs::path log_dir() {
+    // Linux keeps logs colocated with config under the resolved appdata path.
+    // The accessor exists so cross-platform callers can use a single API.
+    return appdata();
+  }
+
   std::string from_sockaddr(const sockaddr *const ip_addr) {
     char data[INET6_ADDRSTRLEN] = {};
 

--- a/src/platform/macos/misc.mm
+++ b/src/platform/macos/misc.mm
@@ -98,6 +98,12 @@ namespace platf {
     return fs::path {homedir} / ".config/sunshine"sv;
   }
 
+  fs::path log_dir() {
+    // macOS keeps logs colocated with config under the resolved appdata path.
+    // The accessor exists so cross-platform callers can use a single API.
+    return appdata();
+  }
+
   using ifaddr_t = util::safe_ptr<ifaddrs, freeifaddrs>;
 
   ifaddr_t get_ifaddrs() {

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -254,6 +254,15 @@ namespace platf {
     return resolved;
   }
 
+  std::filesystem::path log_dir() {
+    // Currently colocated with config under `appdata()`. Kept as a separate
+    // accessor so a future migration can point logs at a dedicated
+    // `%ProgramData%\LuminalShine\logs\` subtree without touching every
+    // caller that constructs a log path. See `platf::log_dir()` in
+    // src/platform/common.h for the contract.
+    return appdata();
+  }
+
   std::string from_sockaddr(const sockaddr *const socket_address) {
     char data[INET6_ADDRSTRLEN] = {};
 


### PR DESCRIPTION
## Summary

First of five PRs for the LuminalShine brand migration (26.05.1). Introduces a `platf::log_dir()` accessor that returns the directory where log files should live. All three platforms (Windows / Linux / macOS) currently forward it to `platf::appdata()` — **behavior is unchanged** in this PR. The abstraction exists so PR 3 (log split) can relocate logs to `%ProgramData%\LuminalShine\logs\` by editing one function, instead of touching every call site that builds a log path.

This is the foundation PR for the migration series — by itself it does nothing user-visible.

## Why a separate refactor PR

The migration series will land four functional changes (install path, log split, exe rename, release cut) on top of this one. Doing the abstraction in its own PR means:
- Reviewers can verify the rename is mechanical and side-effect-free
- The follow-up flips (PR 3) are minimal: one platform function change instead of a 20-file sweep
- If anything goes wrong with the migration later, this refactor doesn't need to be reverted with it

## Migration series

- **PR 1 (this PR)** — `platf::log_dir()` abstraction
- PR 2 — Install path move to `C:\Program Files\NortheBridge\LuminalShine`
- PR 3 — Log split to `%ProgramData%\LuminalShine\logs\`
- PR 4 — Executable rename + runtime identifier migration (service name, pipes, mutexes, window class, NVIDIA profile clone)
- PR 5 — Cut release 26.05.1 via workflow_dispatch

The SSL.com eSigner Cloud signing scaffold (committed in e40c6bb1) stays gated `SIGN_ARTIFACTS='false'` throughout the entire series. No PR in this migration touches signing — that flip is independent and waits on the OV certificate.

## Files changed

- [src/platform/common.h](src/platform/common.h) — declare `platf::log_dir()`
- [src/platform/windows/misc.cpp](src/platform/windows/misc.cpp) — Windows impl, returns `appdata()`
- [src/platform/linux/misc.cpp](src/platform/linux/misc.cpp) — Linux impl, returns `appdata()`
- [src/platform/macos/misc.mm](src/platform/macos/misc.mm) — macOS impl, returns `appdata()`
- [src/config.cpp:936](src/config.cpp#L936) — route the default `log_file` through `log_dir()` instead of `appdata()`

## Test plan

- [ ] CI green on Windows
- [ ] CI green on Linux (config CMake)
- [ ] Verify default `log_file` still resolves to the same path on each platform (manually confirm `platf::log_dir() == platf::appdata()` in all three implementations)
- [ ] Confirm `SIGN_ARTIFACTS` remains `'false'` in `.github/workflows/ci-windows.yml` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)