### PR TITLE
feat(windows): move install path to C:\Program Files\NortheBridge\LuminalShine

### DIFF
--- a/cmake/packaging/windows.cmake
+++ b/cmake/packaging/windows.cmake
@@ -243,9 +243,21 @@ endif()
 
 set(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}\\\\sunshine.ico")
 
-# The name of the directory that will be created in C:/Program files/
-# Keep install directory as Sunshine regardless of displayed product name
-set(CPACK_PACKAGE_INSTALL_DIRECTORY "Sunshine")
+# The directory hierarchy created in C:\Program Files\.
+# Nested form "NortheBridge\LuminalShine" yields:
+#   C:\Program Files\NortheBridge\LuminalShine\
+# CPack generates the intermediate `NortheBridge` Directory entry alongside
+# the leaf `INSTALL_ROOT` in the WiX template, so MSI tracks both and the
+# standard RemoveFolders action removes the empty `NortheBridge\` parent
+# during uninstall provided no other NortheBridge product still owns it.
+#
+# Prior to 26.05.1 the install directory was "Sunshine"; users upgrading
+# from those builds have their pinned/desktop shortcut targets rewritten
+# to the new path by `Repoint-LegacyShortcuts` in
+# src_assets/windows/misc/migration/installer-migrations.ps1. MSI's own
+# MajorUpgrade machinery handles the file move (RemoveExistingProducts
+# uninstalls from the old path, the new install lays down at the new one).
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "NortheBridge\\LuminalShine")
 
 # Setting components groups and dependencies
 set(CPACK_COMPONENT_GROUP_CORE_EXPANDED true)

--- a/src_assets/windows/misc/migration/installer-migrations.ps1
+++ b/src_assets/windows/misc/migration/installer-migrations.ps1
@@ -95,6 +95,144 @@ function Test-JsonFileParseable {
     }
 }
 
+function Repoint-LegacyShortcuts {
+    <#
+    .SYNOPSIS
+        Rewrite .lnk files whose target points at the pre-26.05.1 install root.
+
+    .DESCRIPTION
+        The MSI's MajorUpgrade machinery uninstalls files from the old install
+        directory (C:\Program Files\Sunshine\) and re-lays them down at the new
+        location (C:\Program Files\NortheBridge\LuminalShine\). MSI-authored
+        shortcuts (Start Menu, etc.) are re-created automatically as part of
+        the install, but USER-pinned shortcuts (taskbar, Desktop, manual Start
+        Menu entries) embed an absolute target path and would break silently.
+
+        This function walks every user profile on the machine and rewrites any
+        .lnk whose TargetPath (and WorkingDirectory) begins with the old root.
+        It runs from the RunInstallerMigrations custom action which is flagged
+        Return="ignore" in WiX, so any failure here is non-fatal to the
+        install transaction. Per-file failures are logged and we continue.
+
+        The custom action runs as SYSTEM (Impersonate="no"), which is why we
+        enumerate `C:\Users\<profile>\...` directly instead of using
+        [Environment]::GetFolderPath — that would resolve relative to the
+        SYSTEM profile, not the user.
+
+    .PARAMETER OldInstallRoot
+        Absolute path of the pre-migration install directory.
+
+    .PARAMETER NewInstallRoot
+        Absolute path of the post-migration install directory.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$OldInstallRoot,
+        [Parameter(Mandatory = $true)]
+        [string]$NewInstallRoot
+    )
+
+    # Append a trailing backslash so a path like "C:\Program Files\Sunshine"
+    # matches the prefix of "C:\Program Files\Sunshine\sunshine.exe" but
+    # NOT of "C:\Program Files\Sunshine2\..." (any sibling that happens to
+    # share a name prefix).
+    $oldPrefix = ($OldInstallRoot.TrimEnd('\', '/')) + '\'
+    $newPrefix = ($NewInstallRoot.TrimEnd('\', '/')) + '\'
+
+    $shortcutHosts = New-Object System.Collections.Generic.List[string]
+    try {
+        $usersRoot = Join-Path $env:SystemDrive 'Users'
+        if (Test-Path -LiteralPath $usersRoot) {
+            foreach ($profile in Get-ChildItem -LiteralPath $usersRoot -Directory -ErrorAction SilentlyContinue) {
+                $candidates = @(
+                    (Join-Path $profile.FullName 'Desktop'),
+                    (Join-Path $profile.FullName 'AppData\Roaming\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar'),
+                    (Join-Path $profile.FullName 'AppData\Roaming\Microsoft\Windows\Start Menu\Programs')
+                )
+                foreach ($c in $candidates) {
+                    if (Test-Path -LiteralPath $c) { $shortcutHosts.Add($c) }
+                }
+            }
+        }
+        # Public Desktop: shortcuts visible to every user, owned by no one user.
+        $publicDesktop = Join-Path $env:SystemDrive 'Users\Public\Desktop'
+        if (Test-Path -LiteralPath $publicDesktop) { $shortcutHosts.Add($publicDesktop) }
+        # Machine-wide Start Menu — MSI re-creates its own entries here on
+        # upgrade, but third-party install managers and group-policy
+        # deployments sometimes place .lnks here too.
+        $machineStartMenu = Join-Path $env:ProgramData 'Microsoft\Windows\Start Menu\Programs'
+        if (Test-Path -LiteralPath $machineStartMenu) { $shortcutHosts.Add($machineStartMenu) }
+    } catch {
+        Write-Output ("Repoint-LegacyShortcuts: host enumeration failed: {0}" -f $_.Exception.Message)
+        return
+    }
+
+    $shortcutHosts = $shortcutHosts | Select-Object -Unique
+    if (-not $shortcutHosts) {
+        Write-Output 'Repoint-LegacyShortcuts: no shortcut directories found to scan.'
+        return
+    }
+
+    $shell = $null
+    try {
+        $shell = New-Object -ComObject WScript.Shell
+    } catch {
+        Write-Output ("Repoint-LegacyShortcuts: WScript.Shell unavailable ({0}); skipping." -f $_.Exception.Message)
+        return
+    }
+
+    $rewritten = 0
+    try {
+        foreach ($dir in $shortcutHosts) {
+            $links = $null
+            try {
+                $links = Get-ChildItem -LiteralPath $dir -Filter '*.lnk' -File -Recurse -ErrorAction SilentlyContinue
+            } catch {
+                Write-Output ("Repoint-LegacyShortcuts: could not enumerate {0}: {1}" -f $dir, $_.Exception.Message)
+                continue
+            }
+            foreach ($link in $links) {
+                try {
+                    $sc = $shell.CreateShortcut($link.FullName)
+                    $target = [string]$sc.TargetPath
+                    if ([string]::IsNullOrEmpty($target)) { continue }
+                    if (-not $target.StartsWith($oldPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                        continue
+                    }
+                    $relative = $target.Substring($oldPrefix.Length)
+                    $newTarget = Join-Path $newPrefix $relative
+
+                    $workdir = [string]$sc.WorkingDirectory
+                    $newWorkdir = $workdir
+                    if (-not [string]::IsNullOrEmpty($workdir) -and
+                        $workdir.StartsWith($oldPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                        $newWorkdir = Join-Path $newPrefix $workdir.Substring($oldPrefix.Length)
+                    }
+
+                    $sc.TargetPath = $newTarget
+                    $sc.WorkingDirectory = $newWorkdir
+                    $sc.Save()
+                    $rewritten++
+                    Write-Output ("Repoint-LegacyShortcuts: repointed {0}: {1} -> {2}" -f $link.FullName, $target, $newTarget)
+                } catch {
+                    Write-Output ("Repoint-LegacyShortcuts: failed to repoint {0}: {1}" -f $link.FullName, $_.Exception.Message)
+                    continue
+                }
+            }
+        }
+    } finally {
+        if ($shell) {
+            try { [System.Runtime.InteropServices.Marshal]::ReleaseComObject($shell) | Out-Null } catch {}
+        }
+    }
+
+    if ($rewritten -gt 0) {
+        Write-Output ("Repoint-LegacyShortcuts: rewrote {0} legacy-install-path shortcut(s)." -f $rewritten)
+    } else {
+        Write-Output 'Repoint-LegacyShortcuts: no shortcuts referenced the legacy install path.'
+    }
+}
+
 function Update-SplitFrameEncodingInConfig {
     param(
         [Parameter(Mandatory = $true)]
@@ -316,6 +454,20 @@ foreach ($jsonPath in $candidateJsonFiles) {
 
 if (-not $changedAny) {
     Write-Output 'No installer config migrations were needed.'
+}
+
+# Repoint pinned/desktop/start-menu shortcuts left over from the
+# pre-26.05.1 install layout at C:\Program Files\Sunshine\. This
+# only rewrites .lnk files; MSI re-creates its own shortcuts on
+# upgrade automatically, and the C++ runtime carries the same logic
+# on first launch for anything we miss here (e.g. user logged out
+# during the install).
+try {
+    Repoint-LegacyShortcuts `
+        -OldInstallRoot 'C:\Program Files\Sunshine' `
+        -NewInstallRoot 'C:\Program Files\NortheBridge\LuminalShine'
+} catch {
+    Write-Output ("Repoint-LegacyShortcuts top-level failure: {0}" -f $_.Exception.Message)
 }
 
 if ($transcriptPath) {


### PR DESCRIPTION
## Summary

Second of five PRs for the LuminalShine brand migration (26.05.1). Relocates the Windows install layout from `C:\Program Files\Sunshine\` to `C:\Program Files\NortheBridge\LuminalShine\`. MSI MajorUpgrade handles the file move automatically; this PR adds a shortcut-rewriter to cover the only thing MSI cannot reach — `.lnk` files users have pinned to the taskbar, dropped on the Desktop, or otherwise authored outside the installer component tree.

## Migration mechanics

1. The new MSI starts with the same `Upgrade GUID` (`{C2C36624-...}`) as prior releases, so MSI recognizes the pre-26.05.1 install and triggers `MajorUpgrade Schedule="afterInstallValidate"`.
2. `RemoveExistingProducts` uninstalls files from `C:\Program Files\Sunshine\`. Empty subdirectories are removed by the standard `RemoveFolders` action.
3. The new install lays down at `C:\Program Files\NortheBridge\LuminalShine\`. CPack auto-generates Directory table entries for both `NortheBridge` and `LuminalShine` levels, so MSI tracks both and cleans up the empty `NortheBridge\` parent on uninstall (assuming no other NortheBridge products own it).
4. Everything inside the WiX schema is `[INSTALL_ROOT]`-relative — firewall rules, the service exe path, registry `DisplayIcon`, Start Menu shortcut targets — so all retarget without explicit edits.
5. **User-authored `.lnk` files** (pinned taskbar, Desktop shortcuts, third-party-installer Start Menu drops) embed an absolute path and would silently break. `Repoint-LegacyShortcuts` walks every user profile under `C:\Users\<profile>\` and rewrites any `.lnk` whose `TargetPath` starts with the old root.

## Things explicitly preserved across this migration

- Service autostart, paired clients, admin credentials (TPM-sealed in WCM under target `LuminalShine/AdminCredentials` — already rename/path-resilient by design)
- Config files in `%ProgramData%\LuminalShine\config\` (independent of install path)
- Live Tiles / pinned Start tiles (reference `System.AppUserModel.ID = "LuminalShine.LuminalShine"`, unchanged)
- Firewall rules (re-issued at new paths by `WixFirewallExtension`)

## Things explicitly NOT in this PR

- **Executable renames** (`sunshine.exe` to `luminalshine.exe`, etc.) — that is PR 4. `Repoint-LegacyShortcuts` rewrites only the directory portion of `.lnk` targets; PR 4 extends it to also rewrite the filename so a pinned `.lnk` to `C:\Program Files\Sunshine\sunshine.exe` becomes `C:\Program Files\NortheBridge\LuminalShine\luminalshine.exe` in one pass.
- **Log location split** to `%ProgramData%\LuminalShine\logs\` — that is PR 3.
- **eSigner signing** — `SIGN_ARTIFACTS` in `.github/workflows/ci-windows.yml` stays `'false'`. No change to that file in this PR.

## Files changed

- `cmake/packaging/windows.cmake:248` — `CPACK_PACKAGE_INSTALL_DIRECTORY` becomes `"NortheBridge\\LuminalShine"`. Comment explains the nesting and the upgrade migration.
- `src_assets/windows/misc/migration/installer-migrations.ps1` — adds `Repoint-LegacyShortcuts` function and a top-level call. SYSTEM-context enumeration over `C:\Users\<profile>\Desktop\`, `\AppData\Roaming\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\`, `\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\`, `C:\Users\Public\Desktop\`, and `%ProgramData%\Microsoft\Windows\Start Menu\Programs\`. Uses `WScript.Shell` COM via `New-Object`. Best-effort: failures logged to the existing transcript, never roll back the install.

## Test plan

- [ ] CI green on Windows
- [ ] PR 1 (#5) merged first (no code conflict, but logical sequence)
- [ ] On a VM with pre-26.05.1 LuminalShine installed:
  - [ ] Pin a taskbar shortcut to `sunshine.exe` before upgrading
  - [ ] Drop a desktop shortcut to `sunshine.exe` before upgrading
  - [ ] Run the new installer
  - [ ] Confirm `C:\Program Files\Sunshine\` is gone, `C:\Program Files\NortheBridge\LuminalShine\` exists
  - [ ] Confirm taskbar pinned shortcut still launches (target rewritten)
  - [ ] Confirm desktop shortcut still launches (target rewritten)
  - [ ] Service status: running with same image path under the new directory
  - [ ] Web UI: pairings, apps, settings preserved
  - [ ] Admin login: existing password still works (TPM-sealed creds unaffected)
- [ ] Uninstall on a VM that ONLY has LuminalShine: confirm `C:\Program Files\NortheBridge\` is removed (no orphan parent dir)
- [ ] Confirm `SIGN_ARTIFACTS` remains `'false'` in `.github/workflows/ci-windows.yml` (unchanged)

## Migration series

- PR 1 — `platf::log_dir()` abstraction (#5)
- **PR 2 (this PR)** — Install path move
- PR 3 — Log split to `%ProgramData%\LuminalShine\logs\`
- PR 4 — Executable rename + runtime identifier migration
- PR 5 — Cut release 26.05.1 via workflow_dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
