### PR TITLE
feat(windows): split logs into %ProgramData%\LuminalShine\logs\

### DIFF
--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -255,12 +255,124 @@ namespace platf {
   }
 
   std::filesystem::path log_dir() {
-    // Currently colocated with config under `appdata()`. Kept as a separate
-    // accessor so a future migration can point logs at a dedicated
-    // `%ProgramData%\LuminalShine\logs\` subtree without touching every
-    // caller that constructs a log path. See `platf::log_dir()` in
-    // src/platform/common.h for the contract.
-    return appdata();
+    // Resolved exactly once per process, same pattern as `appdata()` above.
+    // Logs live at `%ProgramData%\LuminalShine\logs\` — a sibling of the
+    // `config\` directory that `appdata()` returns. Splitting the two lets
+    // `KEEPLOGS=0` / `KEEPADMINCREDENTIALS=0` uninstalls target them
+    // independently, and gives users an obvious place to look without
+    // wading through configuration files.
+    //
+    // Migration warnings are emitted via `BOOST_LOG`; the default sink
+    // silently drops them when logging::init hasn't yet run (which is
+    // the case here, since this accessor is invoked from `config::sunshine`
+    // defaults during config parse — strictly before `logging::init` in
+    // main.cpp). That's no worse than not logging at all and far better
+    // than swallowing real Access Denied / sharing-violation failures.
+    static const std::filesystem::path resolved = [] {
+      std::filesystem::path target;
+      PWSTR program_data_w = nullptr;
+      if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_ProgramData, KF_FLAG_CREATE, nullptr, &program_data_w)) && program_data_w) {
+        target = std::filesystem::path {program_data_w} / L"LuminalShine" / L"logs"sv;
+        CoTaskMemFree(program_data_w);
+      }
+
+      // Fallback: if `FOLDERID_ProgramData` lookup failed for any reason,
+      // co-locate with config rather than returning an empty path. This
+      // degrades to the pre-PR-3 layout — strictly worse organization, but
+      // every log write still lands on disk somewhere reachable.
+      if (target.empty()) {
+        return appdata();
+      }
+
+      std::error_code ec;
+      std::filesystem::create_directories(target, ec);
+      if (ec) {
+        BOOST_LOG(warning) << "log_dir: failed to create "sv << target.string()
+                           << ": "sv << ec.message();
+        return target;
+      }
+
+      // One-time migration: move any existing `*.log` / `*.log.N` files
+      // from the legacy colocated location at `appdata()` into the
+      // dedicated `logs\` subtree. Idempotent across re-runs because
+      // `rename` is a no-op once the source dir no longer contains log
+      // files, and `skip_existing` on the cross-volume copy fallback
+      // means a transient lock that survives one boot is harmless.
+      //
+      // The active log file is NOT held open at this point: `log_dir()`
+      // is called from `config.cpp`'s defaults during config parse,
+      // which precedes `logging::init`. No contention with the rotating
+      // sink.
+      const auto legacy = appdata();
+      if (legacy == target || !std::filesystem::exists(legacy, ec)) {
+        return target;
+      }
+
+      for (auto it = std::filesystem::directory_iterator(legacy, ec);
+           !ec && it != std::filesystem::directory_iterator();
+           it.increment(ec)) {
+        const auto &src_path = it->path();
+        const auto src_name = src_path.filename().wstring();
+
+        // Match anything containing `.log` anywhere in the filename —
+        // covers `sunshine.log`, `sunshine.log.1` (numeric rollover),
+        // `sunshine_display_helper.log`, and the post-PR-4 `luminalshine_*`
+        // variants. False positives are acceptable: a user-authored file
+        // they happen to put in the service config dir with `.log` in
+        // its name is moving to a sibling directory, not vanishing.
+        if (src_name.find(L".log"sv) == std::wstring::npos) {
+          continue;
+        }
+
+        std::error_code stat_ec;
+        if (!std::filesystem::is_regular_file(src_path, stat_ec)) {
+          continue;
+        }
+
+        const auto dst_path = target / src_path.filename();
+
+        // Prefer `rename` (atomic within a volume); fall back to
+        // copy+remove on cross-volume errors or transient locks.
+        std::error_code rename_ec;
+        std::filesystem::rename(src_path, dst_path, rename_ec);
+        if (!rename_ec) {
+          continue;
+        }
+
+        std::error_code copy_ec;
+        std::filesystem::copy_file(
+          src_path,
+          dst_path,
+          std::filesystem::copy_options::skip_existing,
+          copy_ec
+        );
+        if (copy_ec) {
+          BOOST_LOG(warning) << "log_dir: failed to migrate "sv << src_path.string()
+                             << " -> "sv << dst_path.string()
+                             << ": rename="sv << rename_ec.message()
+                             << ", copy="sv << copy_ec.message();
+          continue;
+        }
+
+        std::error_code remove_ec;
+        std::filesystem::remove(src_path, remove_ec);
+        // If `remove` fails (lingering antivirus handle, e.g.), the next
+        // process start re-attempts migration. `skip_existing` on
+        // copy_file above keeps that a safe no-op on the destination.
+        if (remove_ec) {
+          BOOST_LOG(warning) << "log_dir: copied "sv << src_path.string()
+                             << " but could not delete source: "sv
+                             << remove_ec.message();
+        }
+      }
+      if (ec) {
+        BOOST_LOG(warning) << "log_dir: directory iteration of "sv << legacy.string()
+                           << " ended with: "sv << ec.message();
+      }
+
+      return target;
+    }();
+    return resolved;
   }
 
   std::string from_sockaddr(const sockaddr *const socket_address) {


### PR DESCRIPTION
## Summary

Third of five PRs for the LuminalShine brand migration (26.05.1). Splits log files out of the config directory into their own sibling subtree under `%ProgramData%\LuminalShine\logs\`. Existing log files are migrated transparently on first launch after the upgrade — the log viewer, log-export endpoints, and helper-log enumeration all flow through `logging::log_directory()` (derived from the configured log path), so no UI or endpoint code needs to change.

## Stacked on PR 1

This PR depends on `platf::log_dir()` from PR 1 (#5). The base branch is `refactor/log-dir-abstraction`; GitHub will auto-retarget to `main` when #5 merges.

## Mechanics

1. `platf::log_dir()` on Windows now resolves to `%ProgramData%\LuminalShine\logs\` via `SHGetKnownFolderPath(FOLDERID_ProgramData, ...)`, mirroring the resolution pattern in `appdata()` directly above it.
2. On first launch after upgrade, the same `static const ... = []{}()` lambda runs a one-time migration: enumerate the legacy colocated location (`%ProgramData%\LuminalShine\config\`) and move every `*.log` / `*.log.N` file into the new dedicated subtree. Strategy is `rename`-first (atomic within a volume) with a `copy_file + remove` fallback for cross-volume errors or transient antivirus locks.
3. Idempotent across re-runs — `rename` is a no-op once the source dir is clean, and `skip_existing` on the copy fallback means a partial migration that survives one boot is harmless to retry.
4. The active log file is **not** held open during migration: `log_dir()` is invoked from `config::sunshine` defaults during config parse in `config.cpp:936`, which is strictly before `logging::init` in `main.cpp:156`. No contention with the rotating sink.
5. **Fallback**: if `FOLDERID_ProgramData` lookup fails for any reason (a known-folder API outage, malformed registry, sandbox), `log_dir()` co-locates with config rather than returning an empty path. Strictly worse organization, but every log write still lands on disk somewhere reachable.

## Log viewer & log export — unchanged, free ride

`logging::log_directory()` in `src/logging.cpp:747` returns `detail::log_root`, set from `log_path.parent_path()` when logging initializes. Every UI/export caller — `recent_session_logs()`, `session_log_directory()`, the helper-log enumeration in `confighttp_playnite.cpp:1011-1049` — goes through that accessor. They follow the new root automatically the moment `config.cpp`'s default `log_file` resolves to the new location. No endpoint or web-UI changes needed.

## Things explicitly NOT in this PR

- **Log filename renames** (`sunshine.log` → `luminalshine.log`, `sunshine_display_helper.log` → `luminalshine_display_helper.log`, etc.) — that is PR 4, where the filenames change alongside the executable rename. PR 3 migrates files **in place by name** so `sunshine.log` continues to be called `sunshine.log` at the new path. PR 4 will extend the migration to also rename during the move so users experience one migration event for log files, not two.
- **Helper tool log paths** (`tools/display_settings_helper.cpp:5107`, `tools/playnite_launcher/launcher.cpp:87`) — those helpers compute their own log directory because they don't link the full Sunshine platform layer. PR 4 reroutes them as part of the exe-rename pass.
- **Per-user `%APPDATA%\Sunshine\` log enumeration** at `confighttp_playnite.cpp:1043-1064` — that surface enumerates user-context tool logs (different from the service log dir). Renamed alongside the exe rename in PR 4.
- **Linux and macOS log_dir()** — unchanged in this PR. Both forward to `appdata()` as PR 1 established. If we ever want a similar split on those platforms it should be a separate Calver decision.
- **eSigner signing** — `SIGN_ARTIFACTS` in `.github/workflows/ci-windows.yml` stays `'false'`. No change to that file in this PR.

## File changed

- `src/platform/windows/misc.cpp` — replaces the PR 1 `log_dir()` stub with the actual `\logs\` subtree resolution + migration loop. +118/−6.

## Test plan

- [ ] CI green on Windows
- [ ] PR 1 (#5) merged first (PR 3 cannot stand alone — it depends on `platf::log_dir()` declared by PR 1)
- [ ] On a VM with pre-26.05.1 LuminalShine installed:
  - [ ] Verify `C:\ProgramData\LuminalShine\config\sunshine.log` exists and is being written to
  - [ ] Pre-create a `sunshine.log.1` rollover file in the config dir to confirm rollover migration
  - [ ] Run the new installer
  - [ ] Confirm `C:\ProgramData\LuminalShine\logs\sunshine.log` exists post-upgrade
  - [ ] Confirm `C:\ProgramData\LuminalShine\config\sunshine.log` is gone (or only has files written *after* migration completed)
  - [ ] Confirm log rollover file `sunshine.log.1` also moved
  - [ ] Web UI → Logs panel renders the current session log from the new path
  - [ ] Web UI → Log Export downloads a zip whose contents reflect the new path layout
- [ ] On a clean install (no prior LuminalShine): confirm `logs\` directory created at first run, no migration warnings emitted
- [ ] Manually edit `sunshine.conf` to set `log_path = C:\custom\path\custom.log` — confirm the user override still wins and the migration doesn't touch unrelated paths
- [ ] Confirm `SIGN_ARTIFACTS` remains `'false'` in `.github/workflows/ci-windows.yml` (unchanged)

## Migration series

- PR 1 — `platf::log_dir()` abstraction (#5)
- PR 2 — Install path move to `C:\Program Files\NortheBridge\LuminalShine` (#6)
- **PR 3 (this PR)** — Log split to `%ProgramData%\LuminalShine\logs\`
- PR 4 — Executable rename + runtime identifier migration
- PR 5 — Cut release 26.05.1 via workflow_dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
