### PR TITLE
fix(windows): relocate INSTALL_ROOT off the legacy Sunshine path on upgrade

### DIFF
--- a/packaging/windows/wix/custom_actions.wxs
+++ b/packaging/windows/wix/custom_actions.wxs
@@ -91,6 +91,63 @@
                  Sequence="execute"
                  After="SetPowerShell5AsPath">PWSH7_FOUND_PATH</SetProperty>
 
+    <!-- ─────────────────────────────────────────────────────────────────
+         Brand-migration: force INSTALL_ROOT to the new
+         C:\Program Files\NortheBridge\LuminalShine\ tree when upgrading
+         from a pre-26.05.1 install whose ARPINSTALLLOCATION still points
+         at a `…\Sunshine\` directory.
+
+         Why this exists:
+         WIX.template.in declares `<Property Id="WIXUI_INSTALLDIR"
+         Value="INSTALL_ROOT"/>`, which tells Windows Installer to persist
+         INSTALL_ROOT across upgrades — AppSearch reads the prior install's
+         ARPINSTALLLOCATION out of the Add/Remove Programs registry entry
+         and seeds INSTALL_ROOT with it. That's the standard MSI semantic
+         and the right behavior most of the time: it preserves a user's
+         explicit non-default install path through subsequent upgrades.
+         But it bites us on a brand-relocation upgrade — the new MSI's
+         Directory table default (NortheBridge\LuminalShine) gets silently
+         overridden by the legacy `Sunshine` path, the BrowseDlg shows the
+         OLD location as the suggested target, and a quiet
+         `msiexec /quiet` upgrade lays the new binaries down at
+         `C:\Program Files\Sunshine\luminalshine.exe` — the worst of
+         both worlds (new brand, legacy location).
+
+         How this works:
+         SetProperty (Type-51 custom action) fires immediately after
+         AppSearch, before the UI sequence reads INSTALL_ROOT and before
+         CostFinalize stages files. The condition is a case-insensitive
+         substring match for `\Sunshine\` in the resolved path, so:
+
+           - Fresh install            INSTALL_ROOT seeded from the
+                                      Directory table default; condition
+                                      false; SetProperty no-ops.
+           - Upgrade from legacy      INSTALL_ROOT = …\Sunshine\…;
+                                      condition true; relocated to the
+                                      new canonical NortheBridge tree.
+           - Upgrade post-26.05.1     INSTALL_ROOT = …\NortheBridge\…;
+                                      condition false; no-op (this
+                                      relocator quietly retires once all
+                                      installs are on the new path).
+
+         A user who explicitly installed to a non-default location whose
+         path *also* contains `\Sunshine\` (e.g. `D:\Games\Sunshine\`)
+         will be relocated to the standard Program Files location. We
+         accept this trade-off — a brand migration is the right time to
+         consolidate paths, and the relocate is one-shot. Users with
+         non-default paths that DON'T contain `\Sunshine\` keep their
+         explicit choice unchanged.
+
+         Sequence="both" puts this in BOTH InstallUISequence (so the
+         BrowseDlg in interactive installs displays the new path) AND
+         InstallExecuteSequence (so silent / unattended installs see the
+         override too). -->
+    <SetProperty Id="INSTALL_ROOT"
+                 Action="RelocateLegacyInstallRoot"
+                 Value="[ProgramFiles64Folder]NortheBridge\LuminalShine\"
+                 Sequence="both"
+                 After="AppSearch"><![CDATA[INSTALL_ROOT ~>< "\Sunshine\"]]></SetProperty>
+
   </Fragment>
 
   <!-- Define a stable tools directory under INSTALL_ROOT for WiX-authored payloads -->


### PR DESCRIPTION
## Summary

Caught during RC review: the install-path relocation merged in #6 + #10 doesn't survive the MSI upgrade dialog. Users running the new installer over a pre-26.05.1 `C:\Program Files\Sunshine\` install see the old path as the suggested target in BrowseDlg, and silent (`msiexec /quiet`) upgrades lay the new binaries down at `C:\Program Files\Sunshine\luminalshine.exe` — new brand, legacy location. This patch forces `INSTALL_ROOT` back to the new `NortheBridge\LuminalShine` default during that one specific upgrade scenario.

## Why this happens (and why PR 2 didn't catch it)

`packaging/windows/wix/WIX.template.in` declares:

```xml
<Property Id="WIXUI_INSTALLDIR" Value="INSTALL_ROOT"/>
```

That single line wires `INSTALL_ROOT` into WixUI's directory-selection mechanism and — load-bearing — tells MSI to *persist* `INSTALL_ROOT` across upgrades via `ARPINSTALLLOCATION` in the Add/Remove Programs registry entry. On upgrade, `AppSearch` reads that prior value back and seeds `INSTALL_ROOT` with it, overriding the Directory-table default that CMake now sets to `NortheBridge\LuminalShine`.

This is standard MSI semantics — it preserves a user's explicit non-default install path through future upgrades, which is the right default behavior. But for a brand-relocation it's exactly the wrong default.

PR 2's design review concluded "files inside the schema are `[INSTALL_ROOT]`-relative, so they retarget automatically." That's correct *mechanically* — `[INSTALL_ROOT]` does follow `INSTALL_ROOT`'s value. The miss was assuming `INSTALL_ROOT`'s *value* would also follow the new CMake default. It doesn't, because `WIXUI_INSTALLDIR` persistence wins over Directory-table defaults whenever a prior install exists.

## The fix

A Type-51 `SetProperty` action that fires `After="AppSearch"` (so it overrides whatever AppSearch just persisted) with `Sequence="both"` (so both interactive UI and silent `msiexec /quiet` upgrades pick it up). The condition is a case-insensitive substring match for `\Sunshine\`, so:

| Scenario | `INSTALL_ROOT` before SetProperty | Condition | After |
|---|---|---|---|
| Fresh install (no prior) | `[ProgramFiles64Folder]NortheBridge\LuminalShine\` (Directory-table default) | false | unchanged |
| Upgrade from default legacy path | `C:\Program Files\Sunshine\` | true | `C:\Program Files\NortheBridge\LuminalShine\` |
| Upgrade from non-default legacy path | e.g. `D:\Games\Sunshine\` | true | `C:\Program Files\NortheBridge\LuminalShine\` |
| Upgrade post-26.05.1 (future) | `C:\Program Files\NortheBridge\LuminalShine\` | false | unchanged |
| Custom path without "Sunshine" in name | e.g. `D:\Apps\foo\` | false | unchanged (user's explicit choice preserved) |

Trade-off: a user who deliberately installed to a non-default location whose path *also* contains `\Sunshine\` (the third row) gets relocated to the standard Program Files tree. We accept this — a brand migration is the right time to consolidate paths, the relocation is one-shot, and the alternative (keep the legacy path forever) is worse for SmartScreen reputation and brand consistency. Users whose custom paths don't contain `\Sunshine\` keep their explicit choice unchanged.

Once 26.05.1 is rolled out and the legacy path is no longer in circulation, the SetProperty quietly retires (its condition is false for every post-migration install). No harm in leaving it indefinitely; it's a single line in `custom_actions.wxs`.

## Files changed

- [packaging/windows/wix/custom_actions.wxs](packaging/windows/wix/custom_actions.wxs) — adds the `SetProperty Id="INSTALL_ROOT"` action plus a long explanatory comment block documenting the MSI semantics, the trade-off, and why this SetProperty exists. +57/−0.

## Test plan

- [ ] CI green
- [ ] On a VM with pre-26.05.1 LuminalShine installed (default `C:\Program Files\Sunshine\`):
  - [ ] Run the new installer interactively — confirm BrowseDlg shows `C:\Program Files\NortheBridge\LuminalShine\` (not `\Sunshine\`)
  - [ ] Click Install — confirm files land at the new path, old `\Sunshine\` tree is empty / removed by `RemoveExistingProducts`
  - [ ] Run `msiexec /i LuminalShine_x64-installer.msi /quiet` against the same starting state — confirm files at the new path post-silent-install
- [ ] On a VM with the upcoming 26.05.1 installed:
  - [ ] Re-run the same MSI as a reinstall — confirm BrowseDlg keeps the new path (SetProperty no-ops because condition is false)
- [ ] On a clean VM (no prior install):
  - [ ] Confirm BrowseDlg defaults to `C:\Program Files\NortheBridge\LuminalShine\` (Directory-table default, SetProperty no-ops)
- [ ] Confirm `SIGN_ARTIFACTS` remains `'false'` in `.github/workflows/ci-windows.yml` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
