### PR TITLE
ci(windows): split submodule init out of checkout with retry/backoff

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -78,19 +78,66 @@ jobs:
             toolchain: ucrt-x86_64
     steps:
       - name: Checkout
-        # Recursive submodule init is required because the Moonlight
-        # protocol layer's networking depends on enet, which sits at
-        # third-party/moonlight-common-c/enet as a NESTED submodule.
-        # Without recursion CMake fails at the
-        # `add_subdirectory(.../moonlight-common-c/enet)` step in
-        # cmake/dependencies/common.cmake:10 with "does not contain a
-        # CMakeLists.txt file". The previously-broken nested submodule
-        # (doxyconfig/doxygen-awesome-css) is no longer walked because
-        # the top-level doxyconfig entry was commented out in
-        # .gitmodules.
+        # Main repo only. Submodule init is deferred to the next step so we
+        # can wrap it in retry/backoff — see "Initialize submodules" below
+        # for the rationale.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          submodules: recursive
+          submodules: false
+
+      - name: Initialize submodules
+        # Replaces actions/checkout's built-in `submodules: recursive`
+        # mechanism with a retry loop, because git submodule clones over
+        # https://github.com/ are sensitive to transient GHA-side
+        # authentication flakes that the bundled checkout action has no
+        # retry semantics for. A single 401 on any submodule's clone
+        # exit-codes 128 and kills the whole checkout, even though other
+        # submodules in the same call succeeded. We hit this twice in a
+        # row on 2026-05-23 (run 26332388835) — once on the main-repo
+        # fetch, once partway through submodule init where some public
+        # repos cloned and others got "could not read Username".
+        #
+        # The actual `git submodule update --init --force --depth=1
+        # --recursive` invocation is identical to what `actions/checkout
+        # submodules: recursive` would run internally — including the
+        # recursive descent that pulls in nested submodules (notably
+        # `third-party/moonlight-common-c/enet`, which the Moonlight
+        # protocol's networking depends on; without it CMake fails at
+        # `add_subdirectory(.../moonlight-common-c/enet)` in
+        # cmake/dependencies/common.cmake:10). The historically-broken
+        # nested `doxyconfig/doxygen-awesome-css` is no longer walked
+        # because the top-level `doxyconfig` entry is commented out in
+        # .gitmodules.
+        #
+        # `actions/checkout` already wired up the AUTHORIZATION header
+        # via `git config --global include.path …` in the previous
+        # step, so this manual `git submodule update` inherits the same
+        # token-backed credentials — no extra plumbing needed.
+        #
+        # `git submodule deinit --all --force` between attempts strips
+        # any partial state from the failed clone so each retry starts
+        # from a clean slate. Without it, a half-cloned submodule
+        # directory can survive into the next attempt and trigger
+        # "destination path already exists" failures that have nothing
+        # to do with the original flake.
+        shell: bash
+        run: |
+          set +e
+          for attempt in 1 2 3 4 5; do
+            git submodule update --init --force --depth=1 --recursive
+            rc=$?
+            if [ "${rc}" -eq 0 ]; then
+              echo "Submodules initialised on attempt ${attempt}."
+              exit 0
+            fi
+            echo "::warning::Submodule init failed on attempt ${attempt} (exit ${rc}); cleaning partial state and retrying."
+            git submodule deinit --all --force >/dev/null 2>&1 || true
+            sleep_secs=$((attempt * 10))
+            echo "Sleeping ${sleep_secs}s before next attempt..."
+            sleep "${sleep_secs}"
+          done
+          echo "::error::Submodule init failed after 5 attempts."
+          exit 1
 
       - name: Setup Dependencies Windows
         # if a dependency needs to be pinned, see https://github.com/LizardByte/build-deps/pull/186

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -35,22 +35,68 @@ jobs:
       TOOLCHAIN: ucrt-x86_64
     steps:
       - name: Checkout
-        # Recursive submodule init is required because the Moonlight
-        # protocol layer's networking depends on enet, which sits at
-        # third-party/moonlight-common-c/enet as a NESTED submodule.
-        # Without recursion CMake fails at the
-        # `add_subdirectory(.../moonlight-common-c/enet)` step in
-        # cmake/dependencies/common.cmake:10 with "does not contain a
-        # CMakeLists.txt file". The previously-broken nested submodule
-        # (doxyconfig/doxygen-awesome-css) is no longer walked because
-        # the top-level doxyconfig entry was commented out in
-        # .gitmodules.
+        # Main repo only. Submodule init is deferred to the next step so we
+        # can wrap it in retry/backoff — see "Initialize submodules" below
+        # in this file and the matching block in ci-windows.yml for the
+        # rationale.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          submodules: recursive
+          submodules: false
           # Codecov resolves PR context from commit history; depth 0 keeps it
           # reliable for PRs from forks and re-runs.
           fetch-depth: 0
+
+      - name: Initialize submodules
+        # Mirror of the matching step in ci-windows.yml — keep the two in
+        # sync. Replaces actions/checkout's built-in `submodules: recursive`
+        # with a retry loop, because git submodule clones over
+        # https://github.com/ are sensitive to transient GHA-side
+        # authentication flakes that the bundled checkout action has no
+        # retry semantics for. A single 401 on any submodule's clone
+        # exit-codes 128 and kills the whole checkout, even though other
+        # submodules in the same call succeeded.
+        #
+        # The actual `git submodule update --init --force --depth=1
+        # --recursive` invocation is identical to what `actions/checkout
+        # submodules: recursive` would run internally — including the
+        # recursive descent that pulls in nested submodules (notably
+        # `third-party/moonlight-common-c/enet`, which the Moonlight
+        # protocol's networking depends on; without it CMake fails at
+        # `add_subdirectory(.../moonlight-common-c/enet)` in
+        # cmake/dependencies/common.cmake:10). The historically-broken
+        # nested `doxyconfig/doxygen-awesome-css` is no longer walked
+        # because the top-level `doxyconfig` entry is commented out in
+        # .gitmodules.
+        #
+        # `actions/checkout` already wired up the AUTHORIZATION header
+        # via `git config --global include.path …` in the previous
+        # step, so this manual `git submodule update` inherits the same
+        # token-backed credentials — no extra plumbing needed.
+        #
+        # `git submodule deinit --all --force` between attempts strips
+        # any partial state from the failed clone so each retry starts
+        # from a clean slate. Without it, a half-cloned submodule
+        # directory can survive into the next attempt and trigger
+        # "destination path already exists" failures that have nothing
+        # to do with the original flake.
+        shell: bash
+        run: |
+          set +e
+          for attempt in 1 2 3 4 5; do
+            git submodule update --init --force --depth=1 --recursive
+            rc=$?
+            if [ "${rc}" -eq 0 ]; then
+              echo "Submodules initialised on attempt ${attempt}."
+              exit 0
+            fi
+            echo "::warning::Submodule init failed on attempt ${attempt} (exit ${rc}); cleaning partial state and retrying."
+            git submodule deinit --all --force >/dev/null 2>&1 || true
+            sleep_secs=$((attempt * 10))
+            echo "Sleeping ${sleep_secs}s before next attempt..."
+            sleep "${sleep_secs}"
+          done
+          echo "::error::Submodule init failed after 5 attempts."
+          exit 1
 
       - name: Setup MSYS2
         uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2.31.1


### PR DESCRIPTION
## Summary

Caught during RC `26.05.0-rc3` dispatch: `actions/checkout` with `submodules: recursive` has no retry semantics, so a single transient 401 on any submodule clone exit-codes 128 and kills the entire checkout step — even when other submodules in the same call succeeded. We hit this twice in a row earlier today on run [26332388835](https://github.com/NortheBridge/luminalshine/actions/runs/26332388835) (once on main-repo fetch, once partway through submodule init where some public repos cloned fine and others got `could not read Username for 'https://github.com'` in the same invocation).

This PR splits submodule init out of `actions/checkout` and into a dedicated step with a retry loop, on both Windows workflows.

## Why this happens

`actions/checkout` runs `git submodule update --init --force --depth=1 --recursive` under the hood when you set `submodules: recursive`. The action retries the main-repo fetch on failure but the submodule init has no retry layer — the call either succeeds entirely or aborts the step. When GitHub's git backend has a brief hiccup mid-clone (the "expected flush after ref listing" + `could not read Username` pair we observed), the partial-state cleanup leaves a half-cloned submodule directory behind, and even a manual re-run can't easily get past it without a fresh `git submodule deinit --all --force`.

## What this PR does

For both `ci-windows.yml` and `coverage-windows.yml`:

1. **Checkout step** — change `submodules: recursive` → `submodules: false`. Main repo only.
2. **New "Initialize submodules" step** — runs the *same* `git submodule update --init --force --depth=1 --recursive` invocation `actions/checkout` would have run internally (preserving the recursive descent that pulls in nested submodules like `third-party/moonlight-common-c/enet` that the Moonlight protocol layer's networking depends on), but wraps it in:
   - 5 attempts with exponential backoff (10s, 20s, 30s, 40s, 50s between attempts)
   - `git submodule deinit --all --force` between attempts to strip any partial-clone state from the failed try so the retry starts from a clean slate
   - Loud `::warning::` / `::error::` annotations so the Actions UI surfaces the retry pattern

3. `actions/checkout` already wires up the AUTHORIZATION header via `git config --global include.path …` in the previous step, so the manual `git submodule update` inherits the same token-backed credentials with no extra plumbing.

## What's preserved

- **Recursive submodule init** — exactly the same `--recursive` flag, so nested submodules (notably `moonlight-common-c/enet`) still get fetched in the same pass. The commented-out `doxyconfig` in `.gitmodules` continues to prevent the historically-broken `doxyconfig/doxygen-awesome-css` from being walked.
- **Shallow clones** — `--depth=1` matches `actions/checkout`'s default behaviour.
- **`fetch-depth: 0`** on the coverage workflow (Codecov needs the full main-repo history for PR context resolution); this option only affects the main-repo fetch, not submodules, so it's preserved verbatim.
- **`SIGN_ARTIFACTS` gate** in `ci-windows.yml` stays `'false'`. No change to the eSigner setup.

## Files changed

- [.github/workflows/ci-windows.yml](.github/workflows/ci-windows.yml) — Checkout step + new Initialize submodules step. +57/−11.
- [.github/workflows/coverage-windows.yml](.github/workflows/coverage-windows.yml) — same pattern, mirrored. +58/−11.

## Test plan

- [ ] CI green on this PR (both `coverage-windows.yml` will exercise the new path on this branch's push)
- [ ] After merge, dispatch `CI` workflow with `release_version=26.05.0-rc3` and confirm:
  - [ ] `Initialize submodules` step runs after `Checkout` and completes with "Submodules initialised on attempt 1." (or a small N on a flake day)
  - [ ] `third-party/moonlight-common-c/enet` is present after the step
  - [ ] CMake's `add_subdirectory(.../moonlight-common-c/enet)` succeeds (this fails immediately if the nested submodule isn't initialised)
  - [ ] Build artifacts (MSI, bootstrapper EXE, portable ZIP) are produced as before
- [ ] Confirm `SIGN_ARTIFACTS` remains `'false'` in `.github/workflows/ci-windows.yml` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
