### PR TITLE
fix(rc3): three RC-blocking bugs from the brand rename (CWD, bootstrapper path, Browse button)

### DIFF
--- a/packaging/windows/bootstrapper/LuminalShineInstaller.cs
+++ b/packaging/windows/bootstrapper/LuminalShineInstaller.cs
@@ -1690,11 +1690,45 @@ namespace LuminalShineInstaller {
 
       foreach (var candidate in candidates) {
         if (!string.IsNullOrWhiteSpace(candidate)) {
+          // Normalize legacy `…\Sunshine\…` paths to the new canonical
+          // NortheBridge\LuminalShine location. Without this, an upgrade
+          // from a pre-26.05.1 install whose ARP entry still records the
+          // legacy `C:\Program Files\Sunshine\` path would render that
+          // (now-misleading) string in the bootstrapper UI even though
+          // the MSI SetProperty in custom_actions.wxs is about to
+          // relocate INSTALL_ROOT to the new path. Surfacing the actual
+          // destination here keeps the UI and the install behavior
+          // consistent — what you see in BrowseDlg is what ends up on
+          // disk.
+          if (IsLegacySunshinePath(candidate)) {
+            return InstallerRunner.DefaultInstallDirectory;
+          }
           return candidate;
         }
       }
 
       return InstallerRunner.DefaultInstallDirectory;
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="path"/> looks like the pre-26.05.1
+    /// `…\Sunshine\` install layout (case-insensitive). Matches the same
+    /// substring/equality predicate the MSI SetProperty action in
+    /// packaging/windows/wix/custom_actions.wxs uses (`INSTALL_ROOT ~&gt;&lt;
+    /// "\Sunshine\"`), so the bootstrapper UI and the MSI agree on which
+    /// candidates get relocated to the new canonical location.
+    /// </summary>
+    private static bool IsLegacySunshinePath(string path) {
+      if (string.IsNullOrWhiteSpace(path)) {
+        return false;
+      }
+      var trimmed = path.TrimEnd('\\', '/');
+      if (trimmed.EndsWith("\\Sunshine", StringComparison.OrdinalIgnoreCase) ||
+          trimmed.EndsWith("/Sunshine", StringComparison.OrdinalIgnoreCase)) {
+        return true;
+      }
+      return trimmed.IndexOf("\\Sunshine\\", StringComparison.OrdinalIgnoreCase) >= 0 ||
+             trimmed.IndexOf("/Sunshine/", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private async Task ShowLicenseDialogAsync() {
@@ -2204,18 +2238,27 @@ namespace LuminalShineInstaller {
       TryAddRecentLogs(collected, seen, tempPath, "luminalshine_preinstall_remove_*.log", 8);
       TryAddRecentLogs(collected, seen, tempPath, "luminalshine_uninstall_*.log", 4);
 
-      var programFilesLogs = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
-        "Sunshine",
-        "config",
-        "logs");
-      TryAddRecentLogs(collected, seen, programFilesLogs, "*.log", 8);
+      // Probe both the post-26.05.1 install layout and the legacy
+      // `C:\Program Files\Sunshine\` location so a diagnostics bundle
+      // collected immediately after upgrade still pulls in pre-rename
+      // logs that the user may want to attach to a bug report.
+      var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+      var luminalShineLogs = Path.Combine(programFiles, "NortheBridge", "LuminalShine", "config", "logs");
+      TryAddRecentLogs(collected, seen, luminalShineLogs, "*.log", 8);
+      var legacySunshineLogs = Path.Combine(programFiles, "Sunshine", "config", "logs");
+      TryAddRecentLogs(collected, seen, legacySunshineLogs, "*.log", 8);
 
-      var roamingLogs = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-        "Sunshine",
+      // %ProgramData%\LuminalShine\logs is the post-PR-3 service log
+      // location; the active log lives here on current installs.
+      var programDataLogs = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+        "LuminalShine",
         "logs");
-      TryAddRecentLogs(collected, seen, roamingLogs, "*.log", 8);
+      TryAddRecentLogs(collected, seen, programDataLogs, "*.log", 8);
+
+      var roamingDir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+      TryAddRecentLogs(collected, seen, Path.Combine(roamingDir, "LuminalShine", "logs"), "*.log", 8);
+      TryAddRecentLogs(collected, seen, Path.Combine(roamingDir, "Sunshine", "logs"), "*.log", 8);
 
       return collected;
     }
@@ -2562,7 +2605,7 @@ namespace LuminalShineInstaller {
       Console.WriteLine("  /?, /h, --help  Show this help message");
       Console.WriteLine();
       Console.WriteLine("Supported MSI properties:");
-      Console.WriteLine("  INSTALL_ROOT=<path>     Install to a custom directory (default: %ProgramFiles%\\Sunshine)");
+      Console.WriteLine("  INSTALL_ROOT=<path>     Install to a custom directory (default: %ProgramFiles%\\NortheBridge\\LuminalShine)");
       Console.WriteLine("  INSTALL_SUDOVDA=1|0     Install SudoVDA (default 1). Current default backend until the");
       Console.WriteLine("                          planned first-party LuminalShine VDD ships.");
       Console.WriteLine("  INSTALL_MTTVDD=1|0      Install MTT Virtual Display Driver (alternative; default 0).");
@@ -2646,9 +2689,18 @@ namespace LuminalShineInstaller {
 
     public static string DefaultInstallDirectory {
       get {
+        // Matches CPACK_PACKAGE_INSTALL_DIRECTORY = "NortheBridge\\LuminalShine"
+        // in cmake/packaging/windows.cmake. Must stay in sync with that
+        // value so the bootstrapper UI default and the MSI Directory-table
+        // default agree. The MSI's SetProperty in packaging/windows/wix/
+        // custom_actions.wxs additionally relocates any persisted
+        // pre-26.05.1 `…\Sunshine\` INSTALL_ROOT to this same path at
+        // upgrade time, so the two layers converge on the new canonical
+        // location regardless of how the user got here.
         return Path.Combine(
           Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
-          "Sunshine");
+          "NortheBridge",
+          "LuminalShine");
       }
     }
 
@@ -5074,11 +5126,59 @@ namespace LuminalShineInstaller {
     private static extern int SHCreateItemFromParsingName([MarshalAs(UnmanagedType.LPWStr)] string pszPath, IntPtr pbc, [In] ref Guid riid, [Out] out IShellItem ppv);
 
     public static string TryPickFolder(Window owner, string title, string initialPath) {
+      // Try the modern IFileOpenDialog (Vista+) path first because it
+      // matches the rest of the Windows shell UI. If anything in that
+      // path fails — COM registration missing, the dialog can't be
+      // shown (sometimes happens over certain RDP configurations),
+      // STA-thread state confused, etc. — we fall through to the
+      // classic FolderBrowserDialog from System.Windows.Forms, which
+      // works in essentially every environment that supports running
+      // a WPF app at all. Surfacing the failure cause to the caller
+      // is more useful than silently returning null and making the
+      // Browse button look broken.
+      Exception modernFailure = null;
+      try {
+        var picked = TryPickFolderModern(owner, title, initialPath);
+        if (picked != null) {
+          return picked;
+        }
+        // picked == null means the user cancelled — don't fall through
+        // to the legacy picker in that case. Tracked via a sentinel
+        // (we set modernFailure on actual exception below).
+        return null;
+      } catch (Exception ex) {
+        modernFailure = ex;
+      }
+
+      try {
+        return TryPickFolderLegacy(owner, title, initialPath);
+      } catch (Exception legacyEx) {
+        // Both pickers failed. Tell the user something instead of
+        // making the Browse button silently no-op. Aggregate both
+        // exceptions so a maintainer reading the dialog can diagnose
+        // either layer.
+        var detail = "Modern picker: " + modernFailure?.Message
+                   + "\nLegacy picker: " + legacyEx.Message;
+        try {
+          System.Windows.MessageBox.Show(
+            owner,
+            "Could not open the folder picker.\n\n" + detail,
+            "LuminalShine installer",
+            System.Windows.MessageBoxButton.OK,
+            System.Windows.MessageBoxImage.Warning);
+        } catch {
+        }
+        return null;
+      }
+    }
+
+    private static string TryPickFolderModern(Window owner, string title, string initialPath) {
       object dialogComObject = null;
       try {
         var dialogType = Type.GetTypeFromCLSID(new Guid("DC1C5A9C-E88A-4DDE-A5A1-60F82A20AEF7"));
         if (dialogType == null) {
-          return null;
+          // CLSID not registered — fall back to legacy picker via exception.
+          throw new InvalidOperationException("IFileOpenDialog CLSID is not registered on this host.");
         }
 
         dialogComObject = Activator.CreateInstance(dialogType);
@@ -5106,7 +5206,16 @@ namespace LuminalShineInstaller {
         var ownerHandle = owner == null ? IntPtr.Zero : new WindowInteropHelper(owner).Handle;
         var hr = dialog.Show(ownerHandle);
         if (hr != 0) {
-          return null;
+          // hr == 0x800704C7 (HRESULT_FROM_WIN32(ERROR_CANCELLED)) is the
+          // user cancelling — return null without raising. Any other
+          // non-success HRESULT is a real failure; propagate so the
+          // outer TryPickFolder can fall back to the legacy picker.
+          const int HRESULT_USER_CANCELLED = unchecked((int)0x800704C7);
+          if (hr == HRESULT_USER_CANCELLED) {
+            return null;
+          }
+          throw new System.Runtime.InteropServices.COMException(
+            "IFileOpenDialog.Show returned HRESULT 0x" + hr.ToString("X8"), hr);
         }
 
         IShellItem result;
@@ -5126,8 +5235,6 @@ namespace LuminalShineInstaller {
         } finally {
           Marshal.FreeCoTaskMem(pathPtr);
         }
-      } catch {
-        return null;
       } finally {
         if (dialogComObject != null) {
           try {
@@ -5136,6 +5243,48 @@ namespace LuminalShineInstaller {
           }
         }
       }
+    }
+
+    private static string TryPickFolderLegacy(Window owner, string title, string initialPath) {
+      // Classic Windows Forms FolderBrowserDialog. Ugly compared to the
+      // modern shell picker but works essentially everywhere — used as
+      // the fallback when the modern path fails for environment reasons
+      // (CLSID not registered, certain RDP configurations, etc.).
+      using (var dlg = new System.Windows.Forms.FolderBrowserDialog()) {
+        if (!string.IsNullOrWhiteSpace(title)) {
+          dlg.Description = title;
+        }
+        dlg.ShowNewFolderButton = true;
+        var normalizedInitial = NormalizeExistingFolder(initialPath);
+        if (!string.IsNullOrWhiteSpace(normalizedInitial)) {
+          dlg.SelectedPath = normalizedInitial;
+        }
+
+        // Bridge WPF owner window to WinForms IWin32Window. Some
+        // environments deadlock when a WinForms modal is shown without
+        // an owner — passing the WPF HWND keeps focus and modality
+        // attached to the bootstrapper window.
+        System.Windows.Forms.IWin32Window ownerShim = null;
+        if (owner != null) {
+          var hwnd = new WindowInteropHelper(owner).Handle;
+          if (hwnd != IntPtr.Zero) {
+            ownerShim = new WpfOwnerShim(hwnd);
+          }
+        }
+
+        var dialogResult = ownerShim == null ? dlg.ShowDialog() : dlg.ShowDialog(ownerShim);
+        if (dialogResult != System.Windows.Forms.DialogResult.OK) {
+          return null;
+        }
+        return string.IsNullOrWhiteSpace(dlg.SelectedPath) ? null : dlg.SelectedPath;
+      }
+    }
+
+    private sealed class WpfOwnerShim : System.Windows.Forms.IWin32Window {
+      public WpfOwnerShim(IntPtr handle) {
+        Handle = handle;
+      }
+      public IntPtr Handle { get; }
     }
 
     private static string NormalizeExistingFolder(string path) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <codecvt>
 #include <csignal>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 
@@ -138,6 +139,37 @@ int main(int argc, char *argv[]) {
   SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32);
 
   setlocale(LC_ALL, "C");
+
+  // Anchor the working directory to the executable's install root before any
+  // relative-path lookups run. Without this, services launched by the SCM
+  // inherit `C:\Windows\System32` as CWD, and the binary's relative asset
+  // references — `assets/web/index.html`, `assets/shaders/directx/*.hlsl`,
+  // `assets/desktop.png`, etc. — resolve against System32 and fail silently.
+  // The web UI degrades to 404s on every asset request and Platform init
+  // bails out with HRESULT 0x80070003 (ERROR_PATH_NOT_FOUND) trying to
+  // compile shaders. Was a regression introduced during the 26.05.1 brand
+  // rename: the previous launch path resolved the main exe relative to the
+  // service binary's directory, which incidentally made the spawned
+  // process's CWD coincide with the install root; the new explicit
+  // absolute-path launch in tools/sunshinesvc.cpp resolve_main_exe_path()
+  // no longer has that side effect.
+  {
+    wchar_t exe_path_w[MAX_PATH] = {};
+    DWORD len = GetModuleFileNameW(nullptr, exe_path_w, _countof(exe_path_w));
+    if (len > 0 && len < _countof(exe_path_w)) {
+      std::filesystem::path exe_dir = std::filesystem::path(exe_path_w).parent_path();
+      if (!exe_dir.empty()) {
+        std::error_code ec;
+        std::filesystem::current_path(exe_dir, ec);
+        // Failure here is non-fatal: relative asset lookups will still
+        // break, but absolute-path code paths (logging::init, appdata())
+        // are unaffected. Logging hasn't been initialised yet at this
+        // point so we can't emit a BOOST_LOG warning — but the missing
+        // assets will surface clearly enough downstream that the cause
+        // is identifiable from the resulting "Missing file:" log lines.
+      }
+    }
+  }
 #endif
 
 #pragma GCC diagnostic push


### PR DESCRIPTION
## Summary

RC-blocking hotfix for three related regressions from the brand-rename series that surfaced when 26.05.0-rc3 was actually installed on a real host. All three are downstream consequences of the rename / install-path move landing in the new binary without complementary fixes in the bootstrapper UI and the runtime CWD setup.

## The three bugs

### 1. Working directory not anchored to the install root → assets 404 → web UI broken

The SCM launches services with `C:\Windows\System32` as the working directory. The binary's asset lookups — `assets/web/index.html` for the web UI, `assets/shaders/directx/*.hlsl` for the encoder, `assets/{desktop,steam,…}.png` for app images — are **relative paths** that worked under the pre-rename launch flow because the service spawned the main exe by bare name and the CWD it inherited happened to coincide with the install root. PR #10's `resolve_main_exe_path()` change in `tools/sunshinesvc.cpp` now passes an absolute path to `CreateProcessAsUserW`, which is correct in isolation but no longer has the CWD side effect. So every relative asset reference resolves against `System32`, 404s, and:

- The web UI degrades to a broken login form that can't authenticate (this is what the user originally reported as "can't login").
- Platform init bails out compiling shaders with HRESULT `0x80070003` (`ERROR_PATH_NOT_FOUND`).
- App-image lookups for `desktop.png` / `steam.png` log warnings on every startup.

**Fix:** anchor CWD to the executable directory via `GetModuleFileNameW` + `std::filesystem::current_path()` at the top of `main()`, before any config-parsing or asset-loading runs. Failure is non-fatal — the `error_code` overload of `current_path` swallows errors and the missing-asset symptoms still surface downstream if something goes wrong, so the cause remains identifiable.

### 2. Bootstrapper UI default install path still reads `C:\Program Files\Sunshine`

`DefaultInstallDirectory` in [LuminalShineInstaller.cs:2647](packaging/windows/bootstrapper/LuminalShineInstaller.cs#L2647) was hardcoded to `%ProgramFiles%\Sunshine`. PR #6 moved the MSI layout to `NortheBridge\LuminalShine` and PR #11 added an MSI-side `SetProperty` that relocates persisted legacy `INSTALL_ROOT` values at upgrade time, but the bootstrapper UI itself was never updated. Result: BrowseDlg displays the old path even though the install lands at the new one.

`ResolvePreferredInstallDirectory` additionally returned whatever `InstallLocation` the prior ARP entry recorded as-is — surfacing `C:\Program Files\Sunshine\` even when the MSI is about to relocate it.

**Fix:**
- `DefaultInstallDirectory` → `Program Files\NortheBridge\LuminalShine`
- `ResolvePreferredInstallDirectory` applies the **same** legacy-path detection the MSI's `SetProperty` uses (`\Sunshine\` substring, case-insensitive) and returns the new default when a candidate matches. UI and actual install behaviour now converge on the same path.

### 3. Browse button silently no-ops in some environments

`ModernFolderPicker.TryPickFolder` wrapped its entire body in a `catch { return null; }`. Any failure mode — `IFileOpenDialog` CLSID unregistered, RDP configurations that refuse to render the shell folder picker, COM threading state confused, anything — produced an invisible no-op. The user clicks Browse, nothing happens, the button looks broken.

**Fix:** split the picker into `TryPickFolderModern` + `TryPickFolderLegacy`. The modern shell picker is tried first (visual parity with the rest of Windows); on exception, fall through to a `System.Windows.Forms.FolderBrowserDialog` bridged to the WPF window via a small `IWin32Window` shim. If both fail, surface a `MessageBox` with **both** failure messages so the user has a diagnosable error instead of a dead button.

Also distinguishes the user-cancelled HRESULT (`0x800704C7`) from real failures so cancellation doesn't unnecessarily fall through to the legacy picker.

## Bonus cleanup

- Log-collection helper at [LuminalShineInstaller.cs:2245](packaging/windows/bootstrapper/LuminalShineInstaller.cs#L2245) now probes both `%ProgramFiles%\NortheBridge\LuminalShine\config\logs\` and the legacy `%ProgramFiles%\Sunshine\config\logs\`, plus `%ProgramData%\LuminalShine\logs\` (the post-PR-3 service log location). A diagnostics bundle collected immediately after upgrade picks up logs from any era.
- Console `--help` output updated to reference the new default install path.

## Files changed

- [src/main.cpp](src/main.cpp) — `<filesystem>` include + CWD-anchor block in `main()`. +32 lines.
- [packaging/windows/bootstrapper/LuminalShineInstaller.cs](packaging/windows/bootstrapper/LuminalShineInstaller.cs) — bootstrapper fixes per the three points above. +166/−16 lines.

## Test plan

- [ ] CI green
- [ ] After merge + new RC build, install over a 26.05.0-rc3 host and verify:
  - [ ] BrowseDlg shows `C:\Program Files\NortheBridge\LuminalShine` (not `\Sunshine`)
  - [ ] Browse button opens a working folder picker (modern OR legacy fallback)
  - [ ] Web UI loads correctly (no `Missing file:` log lines)
  - [ ] First-time setup / login form actually authenticates
  - [ ] `Platform failed to initialize` and shader compile errors are gone
- [ ] Confirm `SIGN_ARTIFACTS` remains `'false'` in `.github/workflows/ci-windows.yml` (unchanged this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
