### PR TITLE
fix(bootstrapper): drop C# 6 read-only auto-property syntax in WpfOwnerShim

### DIFF
--- a/packaging/windows/bootstrapper/LuminalShineInstaller.cs
+++ b/packaging/windows/bootstrapper/LuminalShineInstaller.cs
@@ -5281,10 +5281,20 @@ namespace LuminalShineInstaller {
     }
 
     private sealed class WpfOwnerShim : System.Windows.Forms.IWin32Window {
+      // Explicit backing field + get-only accessor rather than C# 6's
+      // read-only auto-property syntax. The .NET Framework 4.x csc.exe
+      // that build_bootstrapper.ps1 invokes rejects
+      // `public IntPtr Handle { get; }` with CS0840 ("Automatically
+      // implemented properties must define both get and set accessors").
+      // The older form below compiles on every C# version we might
+      // pick up across .NET 4 host configurations.
+      private readonly IntPtr _handle;
       public WpfOwnerShim(IntPtr handle) {
-        Handle = handle;
+        _handle = handle;
       }
-      public IntPtr Handle { get; }
+      public IntPtr Handle {
+        get { return _handle; }
+      }
     }
 
     private static string NormalizeExistingFolder(string path) {


### PR DESCRIPTION
## Summary

Fixes the 26.05.0-rc3.hfx1 build failure (run [26338686534](https://github.com/NortheBridge/luminalshine/actions/runs/26338686534)). My PR #14 introduced a small `WpfOwnerShim` helper class for the Browse-button WinForms fallback that used C# 6's read-only auto-property syntax:

```csharp
public IntPtr Handle { get; }
```

`build_bootstrapper.ps1` invokes `C:\Windows\Microsoft.NET\Framework64\v4.0.30319\csc.exe` to compile the bootstrapper. That compiler version rejects the C# 6 syntax with **CS0840**: *"Automatically implemented properties must define both get and set accessors."*

This PR replaces it with the older explicit-backing-field form, which compiles on every C# version we might pick up across .NET 4 host configurations:

```csharp
private readonly IntPtr _handle;
public WpfOwnerShim(IntPtr handle) { _handle = handle; }
public IntPtr Handle { get { return _handle; } }
```

12-line change, single class. No behaviour change.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, re-trigger the CI workflow with `release_version: 26.05.0-rc3.hfx2`
- [ ] Bootstrapper build (uninstall.exe + LuminalShineSetup.exe) compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
