### PR TITLE
build(bootstrapper): use Roslyn csc with C# 7.3 langversion

### DIFF
--- a/packaging/windows/bootstrapper/LuminalShineInstaller.cs
+++ b/packaging/windows/bootstrapper/LuminalShineInstaller.cs
@@ -5156,14 +5156,8 @@ namespace LuminalShineInstaller {
         // Both pickers failed. Tell the user something instead of
         // making the Browse button silently no-op. Aggregate both
         // exceptions so a maintainer reading the dialog can diagnose
-        // either layer. Explicit null check rather than C# 6's `?.`
-        // operator — the .NET Framework 4.x csc.exe that
-        // build_bootstrapper.ps1 uses rejects null-conditional
-        // syntax with CS1525 ("Invalid expression term '.'") /
-        // CS1003 ("Syntax error, ':' expected"). Same compat lane
-        // as the WpfOwnerShim read-only auto-property fix in #15.
-        var modernMessage = modernFailure == null ? "(none)" : modernFailure.Message;
-        var detail = "Modern picker: " + modernMessage
+        // either layer.
+        var detail = "Modern picker: " + (modernFailure?.Message ?? "(none)")
                    + "\nLegacy picker: " + legacyEx.Message;
         try {
           System.Windows.MessageBox.Show(
@@ -5287,20 +5281,10 @@ namespace LuminalShineInstaller {
     }
 
     private sealed class WpfOwnerShim : System.Windows.Forms.IWin32Window {
-      // Explicit backing field + get-only accessor rather than C# 6's
-      // read-only auto-property syntax. The .NET Framework 4.x csc.exe
-      // that build_bootstrapper.ps1 invokes rejects
-      // `public IntPtr Handle { get; }` with CS0840 ("Automatically
-      // implemented properties must define both get and set accessors").
-      // The older form below compiles on every C# version we might
-      // pick up across .NET 4 host configurations.
-      private readonly IntPtr _handle;
       public WpfOwnerShim(IntPtr handle) {
-        _handle = handle;
+        Handle = handle;
       }
-      public IntPtr Handle {
-        get { return _handle; }
-      }
+      public IntPtr Handle { get; }
     }
 
     private static string NormalizeExistingFolder(string path) {

--- a/packaging/windows/bootstrapper/build_bootstrapper.ps1
+++ b/packaging/windows/bootstrapper/build_bootstrapper.ps1
@@ -120,19 +120,99 @@ function Get-MsiProductVersion([string]$MsiPath) {
 }
 
 function Resolve-CscPath {
-    $candidates = @(
-        (Join-Path $env:WINDIR "Microsoft.NET\Framework64\v4.0.30319\csc.exe"),
-        (Join-Path $env:WINDIR "Microsoft.NET\Framework\v4.0.30319\csc.exe"),
-        "D:/Software/Visual Studio/MSBuild/Current/Bin/Roslyn/csc.exe"
-    )
+    <#
+        Locate a Roslyn-class csc.exe — i.e. one that supports C# 6 and
+        newer language features. We deliberately do NOT fall back to the
+        .NET Framework 4.x csc at
+            $env:WINDIR\Microsoft.NET\Framework64\v4.0.30319\csc.exe
+        because that compiler caps at C# 5 and silently rejects modern
+        syntax (read-only auto-properties, null-conditional `?.`, string
+        interpolation, nameof, expression-bodied members, etc.) that
+        LuminalShineInstaller.cs is allowed to use under the
+        `-langversion:7.3` flag passed to csc later in this script.
 
-    foreach ($candidate in $candidates) {
+        Resolution order:
+          1. $env:LUMINALSHINE_CSC_PATH — explicit override, escape
+             hatch for an unusual environment.
+          2. `vswhere.exe` — the Visual Studio installer's locator tool,
+             always present alongside the VS installer. Asks for the
+             latest VS instance with MSBuild and derives the Roslyn
+             csc.exe path relative to its installation root. Works for
+             VS Community / Professional / Enterprise / Build Tools at
+             any install path.
+          3. A short hardcoded list — GitHub Actions windows-2022
+             runners (VS 2022 Enterprise at the default path) and the
+             historical custom dev install at `D:\Software\Visual Studio\`
+             that an earlier maintainer used. Pure defence-in-depth in
+             case vswhere returns something unexpected.
+
+        If none of those produce a working compiler, throw with a clear
+        message rather than silently downgrading to the .NET 4 csc and
+        producing CS0840 / CS1525 errors at compile time.
+    #>
+
+    if (-not [string]::IsNullOrWhiteSpace($env:LUMINALSHINE_CSC_PATH) -and
+        (Test-Path -LiteralPath $env:LUMINALSHINE_CSC_PATH)) {
+        return (Resolve-PathStrict $env:LUMINALSHINE_CSC_PATH)
+    }
+
+    # vswhere.exe is shipped by the VS installer at a stable location
+    # under Program Files (x86) on every Windows host that has any
+    # edition of VS 2017+ installed.
+    $vswhereCandidates = @(
+        (Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"),
+        (Join-Path $env:ProgramFiles            "Microsoft Visual Studio\Installer\vswhere.exe")
+    )
+    foreach ($vswhereCandidate in $vswhereCandidates) {
+        if (-not (Test-Path -LiteralPath $vswhereCandidate)) {
+            continue
+        }
+        try {
+            $installRoot = (& $vswhereCandidate `
+                -latest `
+                -products * `
+                -requires Microsoft.Component.MSBuild `
+                -property installationPath 2>$null) | Select-Object -First 1
+        } catch {
+            $installRoot = $null
+        }
+        if (-not [string]::IsNullOrWhiteSpace($installRoot)) {
+            $candidate = Join-Path $installRoot "MSBuild\Current\Bin\Roslyn\csc.exe"
+            if (Test-Path -LiteralPath $candidate) {
+                return (Resolve-PathStrict $candidate)
+            }
+        }
+    }
+
+    $hardcodedCandidates = @(
+        # GitHub Actions windows-2022 runner default path
+        "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Roslyn\csc.exe",
+        # VS Build Tools 2022 (when Enterprise isn't installed)
+        "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\Roslyn\csc.exe",
+        # Historical custom dev install on D:
+        "D:\Software\Visual Studio\MSBuild\Current\Bin\Roslyn\csc.exe"
+    )
+    foreach ($candidate in $hardcodedCandidates) {
         if (Test-Path -LiteralPath $candidate) {
             return (Resolve-PathStrict $candidate)
         }
     }
 
-    throw "Could not locate a C# compiler (csc.exe)."
+    throw @"
+Could not locate a Roslyn-class csc.exe (C# 6+ compiler).
+
+The legacy .NET Framework 4.x csc at
+    $env:WINDIR\Microsoft.NET\Framework64\v4.0.30319\csc.exe
+is intentionally NOT used as a fallback because it caps at C# 5
+and rejects modern C# syntax we depend on
+(read-only auto-properties, null-conditional `?.`, etc.).
+
+To fix, do one of:
+  - Install Visual Studio 2022 Build Tools or Community (free), which
+    bundles Roslyn at <VS install root>\MSBuild\Current\Bin\Roslyn\csc.exe.
+  - Set the LUMINALSHINE_CSC_PATH environment variable to the absolute
+    path of a Roslyn csc.exe you already have.
+"@
 }
 
 $scriptDir = Split-Path -Parent $PSCommandPath
@@ -236,6 +316,15 @@ $args = @(
     "/target:winexe",
     "/optimize+",
     "/utf8output",
+    # Explicit language level so LuminalShineInstaller.cs can use C# 6 / 7 features
+    # (read-only auto-properties, null-conditional `?.`, string interpolation,
+    # nameof, expression-bodied members, etc.). Resolve-CscPath above guarantees
+    # the csc.exe we picked is Roslyn-class and supports this level. We pin to 7.3
+    # rather than `latest` for reproducibility — `latest` would silently drift as
+    # the runner's VS install gets newer compilers, and we don't need anything
+    # beyond C# 7.3 in this file. Bump deliberately if a later language feature
+    # becomes useful.
+    "/langversion:7.3",
     "/out:$outputPath",
     "/win32manifest:$manifestFile",
     "/win32icon:$iconPath",


### PR DESCRIPTION
## Summary

Replaces the .NET Framework 4.x `csc.exe` fallback in `build_bootstrapper.ps1` with a deliberate Roslyn-only resolver so the bootstrapper compiles with C# 6+ language support. Closes the two build failures from rc3.hfx1 (#15) and rc3.hfx2 (#16) at their root cause — the compiler — rather than chasing each new C# 6+ feature accidentally introduced into `LuminalShineInstaller.cs`.

## Why the legacy compiler keeps biting us

`Resolve-CscPath` previously tried these in order:

```
1. C:\Windows\Microsoft.NET\Framework64\v4.0.30319\csc.exe     (.NET 4 csc — C# 5 only)
2. C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe       (.NET 4 csc — C# 5 only)
3. D:/Software/Visual Studio/MSBuild/Current/Bin/Roslyn/csc.exe
```

Path 1 always exists on Windows, so the legacy compiler always won. It caps at C# 5 and rejects every modern syntax feature (read-only auto-properties, null-conditional `?.`, string interpolation, `nameof`, expression-bodied members, exception filters, ...). Two RC builds blew up on this in the last hour:

- **rc3.hfx1** — CS0840 on `public IntPtr Handle { get; }` (fix: #15)
- **rc3.hfx2** — CS1525 / CS1003 on `modernFailure?.Message` (fix: #16)

Both are language features that any C# developer today would reach for instinctively. Either we keep adding compat-fix PRs reactively, or we just use a modern compiler.

## What this PR does

### `Resolve-CscPath` in build_bootstrapper.ps1

New resolution order — Roslyn-only:

| Step | Source | Notes |
|---|---|---|
| 1 | `$env:LUMINALSHINE_CSC_PATH` | Explicit override / escape hatch |
| 2 | `vswhere.exe` | The VS installer's locator. Queries for the latest VS instance with MSBuild, then derives `<install>\MSBuild\Current\Bin\Roslyn\csc.exe`. Works for VS Community / Professional / Enterprise / Build Tools at any install path. |
| 3 | Hardcoded list | GitHub Actions `windows-2022` runner default (`C:\Program Files\Microsoft Visual Studio\2022\Enterprise\...`), VS Build Tools 2022 path, and the historical `D:\Software\Visual Studio\` custom dev path. |
| 4 | Throw | Clear error directing the user to either install VS Build Tools or set `LUMINALSHINE_CSC_PATH`. |

The legacy `.NET 4 csc.exe` is **removed** from the fallback chain. If it's the only thing on the machine, the build fails loudly with a clear error rather than silently downgrading the supported language level and producing CS0840 / CS1525 errors elsewhere.

### `/langversion:7.3` added to csc args

Pins the language level explicitly. C# 7.3 covers everything we'd reasonably want (`?.`, `?[ ]`, string interpolation, `nameof`, expression-bodied members, read-only auto-properties, tuples, pattern matching, ref returns). `latest` would silently drift as runner VS gets newer; 7.3 is reproducible.

### `LuminalShineInstaller.cs` restored to modern syntax

Reverts the compat workarounds from #15 and #16 back to idiomatic C#:

```csharp
public IntPtr Handle { get; }                                            // was: explicit backing field + get-only accessor
var detail = "Modern picker: " + (modernFailure?.Message ?? "(none)")    // was: explicit ternary
           + "\nLegacy picker: " + legacyEx.Message;
```

Same behaviour, fewer lines, and proves the compiler bump actually works.

## Risk analysis

The user explicitly asked whether the dev-machine vs test-machine split would cause issues. Verdict: **no**, because:

- **End-user runtime is unaffected.** The resulting `uninstall.exe` / `LuminalShineSetup.exe` still target .NET Framework 4.x (set by the `/reference:` lines pointing at `Framework64\v4.0.30319\System.dll`, `System.Xaml.dll`, `PresentationFramework.dll`, etc. — *not* by the compiler version). End users run them on whatever .NET 4.x ships with their Windows.
- **GHA `windows-2022` runner.** Has VS 2022 Enterprise preinstalled at `C:\Program Files\Microsoft Visual Studio\2022\Enterprise\` — both `vswhere` (path 2) and the hardcoded entry (path 3) point at this. Always available.
- **Dev machine.** Your existing fallback at `D:\Software\Visual Studio\MSBuild\Current\Bin\Roslyn\csc.exe` is preserved verbatim, and `vswhere` will find any normally-installed VS at any drive.
- **Anywhere else.** Either install VS Build Tools (free, ~1.5 GB), or set `LUMINALSHINE_CSC_PATH` to whatever Roslyn `csc.exe` is already present. Throwing is preferable to silently producing broken builds.

## Files changed

- `packaging/windows/bootstrapper/build_bootstrapper.ps1` — new `Resolve-CscPath` + `/langversion:7.3` arg (+100/−14)
- `packaging/windows/bootstrapper/LuminalShineInstaller.cs` — revert the two C# 5 workarounds to modern syntax (+2/−13)

## Test plan

- [ ] CI green on this PR (Vitest is the required check; full Windows build won't run here since it's only invoked from `ci.yml` workflow_dispatch)
- [ ] After merge, dispatch `CI` with `release_version: 26.05.0-rc3.hfx3` and confirm:
  - [ ] Resolve-CscPath picks up VS 2022 Enterprise's Roslyn (look for the resolved path in `[bootstrapper] Compiler:` log line)
  - [ ] csc compiles `LuminalShineInstaller.cs` cleanly — both the restored `{ get; }` read-only auto-property and the `?.` null-conditional should compile
  - [ ] `uninstall.exe` and `LuminalShineSetup.exe` artifacts emit normally
- [ ] Confirm `SIGN_ARTIFACTS` remains `'false'` in `.github/workflows/ci-windows.yml` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
