### PR TITLE
feat(creds): three-layer admin-credential recovery for upgrades

### DIFF
--- a/packaging/windows/bootstrapper/LuminalShineInstaller.cs
+++ b/packaging/windows/bootstrapper/LuminalShineInstaller.cs
@@ -68,6 +68,17 @@ namespace LuminalShineInstaller {
         var exitCode = InstallerRunner.RelaunchSelfElevated(args);
         return exitCode;
       }
+      if (parsed.ResetAdminRequested
+          && !parsed.InternalElevatedInstall
+          && !parsed.InternalElevatedUninstall) {
+        // Reset-admin needs to drop a marker file under %ProgramData% and
+        // call sc.exe stop/start on LuminalShineService; both require admin.
+        // Same elevate-then-restart pattern as Reconfigure above.
+        if (!InstallerRunner.IsProcessElevated()) {
+          return InstallerRunner.RelaunchSelfElevated(args);
+        }
+        return InstallerRunner.RunAdminCredentialReset();
+      }
       if (parsed.UninstallUiRequested && !parsed.ShowUi && !parsed.InternalElevatedUninstall) {
         var uninstallResult = InstallerRunner.RunInteractiveUninstall(parsed, false, false);
         if (!string.IsNullOrWhiteSpace(uninstallResult.Message)) {
@@ -2421,6 +2432,14 @@ namespace LuminalShineInstaller {
     /// existing install is present, so this token mainly exists to
     /// document intent and avoid the arg leaking through to msiexec.
     private static readonly string[] ReconfigureTokens = { "--reconfigure" };
+    /// `--reset-admin` is the entry point used by the Start Menu
+    /// "Reset LuminalShine Admin Password" shortcut. The bootstrapper
+    /// elevates, confirms with the user, drops a marker file in the
+    /// service config dir, and bounces LuminalShineService. The
+    /// service-side handler in src/main.cpp picks up the marker on
+    /// the next startup and runs the same in-process erase the
+    /// `--reset-admin-credentials` CLI uses, then deletes the marker.
+    private static readonly string[] ResetAdminTokens = { "--reset-admin" };
     private static readonly string[] QuietTokens = { "/quiet", "/qn", "/qb", "/passive" };
     private const string InternalElevatedInstallToken = "--internal-elevated-install";
     private const string InternalElevatedUninstallToken = "--internal-elevated-uninstall";
@@ -2449,6 +2468,10 @@ namespace LuminalShineInstaller {
     /// install scripts directly instead of going through msiexec (which
     /// uninstall.exe couldn't do anyway because it has no embedded MSI).
     public bool ReconfigureRequested { get; set; }
+    /// True when `--reset-admin` was supplied on the command line. Triggers
+    /// the marker-file based admin credential reset; see ResetAdminTokens
+    /// above for the full handshake with the service-side handler.
+    public bool ResetAdminRequested { get; set; }
     public bool InternalElevatedInstall { get; set; }
     public bool InternalElevatedUninstall { get; set; }
     public string InternalInstallPath { get; set; }
@@ -2501,6 +2524,14 @@ namespace LuminalShineInstaller {
           // a quiet msiexec passthrough.
           showUiFlag = true;
           parsed.ReconfigureRequested = true;
+          continue;
+        }
+        if (ResetAdminTokens.Contains(arg, StringComparer.OrdinalIgnoreCase)) {
+          // Same rationale as ReconfigureRequested: the Start Menu shortcut
+          // launches us, we want UI for the confirmation dialog, never fall
+          // through to a silent msiexec pass.
+          showUiFlag = true;
+          parsed.ResetAdminRequested = true;
           continue;
         }
         if (string.Equals(arg, InternalElevatedInstallToken, StringComparison.OrdinalIgnoreCase)) {
@@ -4904,6 +4935,150 @@ namespace LuminalShineInstaller {
     /// the UAC prompt was declined.
     internal static int RelaunchSelfElevated(IReadOnlyList<string> arguments) {
       return RunElevatedBootstrapper(arguments ?? new string[0]);
+    }
+
+    /// User-facing admin credential reset flow, invoked by the Start Menu
+    /// "Reset LuminalShine Admin Password" shortcut (via `--reset-admin`).
+    ///
+    /// The actual credential erase happens in the LuminalShineService process
+    /// (which runs as LocalSystem, the only identity that can `CredDeleteW`
+    /// the SYSTEM-vault entry where the credential lives). The bootstrapper
+    /// is elevated-Administrator at this point but NOT SYSTEM, so it can't
+    /// touch the vault directly — instead it hands off via a marker file:
+    ///
+    ///   1. Confirm intent with the user via a MessageBox.
+    ///   2. Drop an empty sentinel at
+    ///        %ProgramData%\LuminalShine\config\.reset_admin_credentials_pending
+    ///      (the same path src/main.cpp checks on startup).
+    ///   3. Stop LuminalShineService, then start it again. The service-side
+    ///      handler in main.cpp sees the marker, calls the in-process
+    ///      args::reset_admin_credentials() helper (which is the same path
+    ///      `--reset-admin-credentials` uses), deletes the marker, and
+    ///      continues normal startup.
+    ///   4. Show a success/failure MessageBox with next steps.
+    ///
+    /// Returns 0 on success or user-cancel, non-zero on failure.
+    internal static int RunAdminCredentialReset() {
+      const string title = "Reset LuminalShine Admin Password";
+      var confirm = System.Windows.Forms.MessageBox.Show(
+        "This will clear the saved LuminalShine admin login. The next visit to" +
+        " https://localhost:47990 will prompt you to create a new admin" +
+        " username and password.\n\n" +
+        "Paired Moonlight clients, your apps list, and all other settings" +
+        " are NOT affected — only the Web UI admin login is reset.\n\n" +
+        "Continue?",
+        title,
+        System.Windows.Forms.MessageBoxButtons.YesNo,
+        System.Windows.Forms.MessageBoxIcon.Question,
+        System.Windows.Forms.MessageBoxDefaultButton.Button2);
+      if (confirm != System.Windows.Forms.DialogResult.Yes) {
+        return 0;
+      }
+
+      // Build the marker path. We do NOT shell out to the service for the
+      // appdata resolution — we hard-code the canonical layout because the
+      // bootstrapper can't easily ask the service binary "where is your
+      // appdata?" without spawning it, and the path has been stable since
+      // platf::appdata() was introduced. Keep this in sync with
+      // src/platform/windows/misc.cpp::appdata().
+      string markerPath;
+      try {
+        var commonAppData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+        var configDir = Path.Combine(commonAppData, "LuminalShine", "config");
+        Directory.CreateDirectory(configDir);
+        markerPath = Path.Combine(configDir, ".reset_admin_credentials_pending");
+        File.WriteAllText(markerPath, "marker written by uninstall.exe --reset-admin at "
+          + DateTime.UtcNow.ToString("o") + "\n");
+      } catch (Exception ex) {
+        System.Windows.Forms.MessageBox.Show(
+          "Could not write the reset marker file:\n\n" + ex.Message + "\n\n" +
+          "The admin password has NOT been reset. Try running this shortcut as" +
+          " Administrator if you weren't prompted to elevate.",
+          title,
+          System.Windows.Forms.MessageBoxButtons.OK,
+          System.Windows.Forms.MessageBoxIcon.Error);
+        return 1;
+      }
+
+      // Bounce the service. sc.exe stop is best-effort — the service may
+      // already be stopped, in which case sc.exe returns 1062 ("service has
+      // not been started") which we treat as success. Same for sc.exe start
+      // if the service is already running (1056).
+      string stopOutput, startOutput;
+      int stopExit = RunSc("stop", out stopOutput);
+      // Wait briefly for the service to actually settle into a stopped state;
+      // sc.exe stop returns immediately but the SCM may take a moment to
+      // process the stop request.
+      System.Threading.Thread.Sleep(2000);
+      int startExit = RunSc("start", out startOutput);
+
+      // 1062 = "service has not been started" (already stopped) — fine for stop
+      // 1056 = "an instance of the service is already running" — fine for start
+      bool stopOk = stopExit == 0 || stopExit == 1062;
+      bool startOk = startExit == 0 || startExit == 1056;
+
+      if (!stopOk || !startOk) {
+        // Try to clean up the marker so a future service restart doesn't
+        // un-expectedly reset credentials in the background — though the
+        // marker itself is harmless if it lingers (the next legit restart
+        // would process it). Best-effort.
+        try { File.Delete(markerPath); } catch { }
+
+        var detail = "";
+        if (!stopOk) detail += "sc.exe stop: exit " + stopExit + " — " + stopOutput.Trim() + "\n";
+        if (!startOk) detail += "sc.exe start: exit " + startExit + " — " + startOutput.Trim() + "\n";
+        System.Windows.Forms.MessageBox.Show(
+          "Could not bounce LuminalShineService cleanly. The reset has NOT" +
+          " completed.\n\n" + detail +
+          "\nTry restarting the LuminalShineService manually (Services.msc) " +
+          "or rebooting; the marker file will be processed on the next start.",
+          title,
+          System.Windows.Forms.MessageBoxButtons.OK,
+          System.Windows.Forms.MessageBoxIcon.Warning);
+        return startOk ? 0 : 1;
+      }
+
+      System.Windows.Forms.MessageBox.Show(
+        "Admin login reset.\n\n" +
+        "Open https://localhost:47990 in your browser to create a new admin" +
+        " username and password.",
+        title,
+        System.Windows.Forms.MessageBoxButtons.OK,
+        System.Windows.Forms.MessageBoxIcon.Information);
+      return 0;
+    }
+
+    /// Run sc.exe with a single verb against LuminalShineService and capture
+    /// stdout for diagnostic purposes. Returns the process exit code.
+    private static int RunSc(string verb, out string output) {
+      output = "";
+      try {
+        var psi = new System.Diagnostics.ProcessStartInfo {
+          FileName = Path.Combine(Environment.SystemDirectory, "sc.exe"),
+          Arguments = verb + " LuminalShineService",
+          UseShellExecute = false,
+          RedirectStandardOutput = true,
+          RedirectStandardError = true,
+          CreateNoWindow = true
+        };
+        using (var proc = System.Diagnostics.Process.Start(psi)) {
+          if (proc == null) {
+            return -1;
+          }
+          var stdout = proc.StandardOutput.ReadToEnd();
+          var stderr = proc.StandardError.ReadToEnd();
+          if (!proc.WaitForExit(30000)) {
+            try { proc.Kill(); } catch { }
+            output = "timeout";
+            return -1;
+          }
+          output = (stdout + stderr).Trim();
+          return proc.ExitCode;
+        }
+      } catch (Exception ex) {
+        output = ex.Message;
+        return -1;
+      }
     }
 
     private static string BuildResultMessage(string operationName, int exitCode, string logPath) {

--- a/packaging/windows/wix/custom_actions.wxs
+++ b/packaging/windows/wix/custom_actions.wxs
@@ -200,6 +200,30 @@
             </Shortcut>
             <RegistryValue Root="HKCU" Key="Software\LuminalShine\Shortcuts" Name="ReconfigureStartMenu" Type="integer" Value="1" KeyPath="yes" />
           </Component>
+          <!-- Reset Admin Password shortcut: launches uninstall.exe with
+               the `reset-admin` flag (double-dash prefix), which after a
+               confirmation prompt drops a sentinel file at
+               %ProgramData%\LuminalShine\config\.reset_admin_credentials_pending
+               and bounces LuminalShineService. The service-side handler in
+               src/main.cpp picks up the marker on its next startup and
+               runs the same in-process erase the CLI subcommand uses.
+               Lives in its own component for the same reason as the
+               Reconfigure shortcut above (MSI re-asserts independently
+               of the other shortcuts). XML-comment-syntax note: avoid
+               literal double-dash sequences inside this comment because
+               REXML and other strict XML parsers reject them. -->
+          <Component Id="ResetAdminStartMenuShortcut" Guid="{C9F1E2B0-3A8D-4F1C-95E2-7B6A0D5F4C8E}">
+            <Shortcut Id="LuminalShineResetAdminShortcut"
+                      Name="Reset LuminalShine Admin Password"
+                      Description="Clear the saved Web UI admin login so you can create a new one"
+                      Target="[INSTALL_ROOT]uninstall.exe"
+                      Icon="ProductIcon.ico"
+                      Arguments="--reset-admin"
+                      WorkingDirectory="INSTALL_ROOT">
+              <ShortcutProperty Key="System.AppUserModel.ID" Value="$(var.LuminalShineAppId)" />
+            </Shortcut>
+            <RegistryValue Root="HKCU" Key="Software\LuminalShine\Shortcuts" Name="ResetAdminStartMenu" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
         </Directory>
       </Directory>
     </DirectoryRef>
@@ -376,9 +400,24 @@
          and calls cred_store::erase + tpm_seal::clear) so it doesn't
          need the service to be running. Probes both the new and legacy
          exe names for the same reason as the NV prefs guard above. -->
+    <!-- The luminalshine.exe argv dispatcher in src/config.cpp around
+         line 1891 only recognizes subcommands prefixed with a double-dash.
+         Without it, the binary silently falls through to a full service
+         start instead of running the reset, which means this entire
+         ResetAdminCredentials custom action was a no-op in shipped releases
+         through 26.05.0-rc3 — tracked down during 26.05.0-rc3.hfx3
+         dogfooding when neither this action nor a bare invocation of
+         `luminalshine.exe reset-admin-credentials` (also missing the
+         double-dash) actually cleared a stuck admin credential. Both
+         invocations in the Value attribute below now correctly route to
+         src/main.cpp:81's dispatcher, which calls into
+         entry_handler::reset_admin_credentials, which in turn calls
+         cred_store::erase + tpm_seal::clear. XML-comment-syntax note:
+         this comment intentionally avoids literal double-dash sequences
+         because REXML and other strict XML parsers reject them. -->
     <CustomAction Id="SetResetAdminCredentials"
                  Property="ResetAdminCredentials"
-                 Value="&quot;[SystemFolder]cmd.exe&quot; /C (if exist &quot;[INSTALL_ROOT]luminalshine.exe&quot; (&quot;[INSTALL_ROOT]luminalshine.exe&quot; reset-admin-credentials) else if exist &quot;[INSTALL_ROOT]sunshine.exe&quot; (&quot;[INSTALL_ROOT]sunshine.exe&quot; reset-admin-credentials)) &amp; exit /b 0"/>
+                 Value="&quot;[SystemFolder]cmd.exe&quot; /C (if exist &quot;[INSTALL_ROOT]luminalshine.exe&quot; (&quot;[INSTALL_ROOT]luminalshine.exe&quot; --reset-admin-credentials) else if exist &quot;[INSTALL_ROOT]sunshine.exe&quot; (&quot;[INSTALL_ROOT]sunshine.exe&quot; --reset-admin-credentials)) &amp; exit /b 0"/>
 
 
     <CustomAction Id="SetUninstallMttVdd"

--- a/packaging/windows/wix/patch_custom_actions.wxs
+++ b/packaging/windows/wix/patch_custom_actions.wxs
@@ -29,6 +29,7 @@
       <ComponentRef Id="Fw_Exceptions"/>
       <ComponentRef Id="StartMenuShortcut"/>
       <ComponentRef Id="ReconfigureStartMenuShortcut"/>
+      <ComponentRef Id="ResetAdminStartMenuShortcut"/>
       <ComponentRef Id="SudoVdaRegistryDefaults"/>
       <ComponentRef Id="ArpCustomUninstallEntry"/>
     </Feature>

--- a/src/cred_store/cred_store_windows.cpp
+++ b/src/cred_store/cred_store_windows.cpp
@@ -254,6 +254,22 @@ namespace cred_store {
     // done (PR 6 lands that discipline on the verification paths).
     CredFree(cred);
     if (raw.empty()) {
+      // Self-heal: CredRead returned success with a zero-byte blob, which
+      // is broken state — the entry registered but holds nothing usable.
+      // Without cleaning up, the next start sees the same broken entry,
+      // the web UI shows a login form (because the entry "exists") that
+      // can never authenticate, and the user is locked out. Erase it so
+      // the next start observes "no entry" → first-time setup → recovery.
+      // The same self-heal pattern handles the matching reload_user_creds
+      // case in src/httpcommon.cpp where the blob loads non-empty but
+      // fails to parse.
+      BOOST_LOG(warning) << "cred_store(wcm): credential entry has empty blob; "
+                         << "erasing so first-time setup can recover.";
+      if (!CredDeleteW(kTargetName, CRED_TYPE_GENERIC, 0)) {
+        BOOST_LOG(warning) << "cred_store(wcm): CredDelete during self-heal failed "
+                           << "(err=" << GetLastError() << "); manual reset may be "
+                           << "needed via the Reset Admin Password shortcut.";
+      }
       return false;
     }
 
@@ -264,10 +280,19 @@ namespace cred_store {
     // subsequent save will rewrite them as plain.
     if (tpm_seal::looks_sealed(raw)) {
       if (!tpm_seal::unseal(raw, out)) {
+        // Do NOT auto-delete on unseal failure. The TPM can be in a
+        // transient unavailable state (driver hiccup, suspended state,
+        // policy change) where the key is still good but the unwrap
+        // failed *this time*. Auto-deleting would permanently destroy
+        // recoverable credentials in those windows. Instead, leave the
+        // entry alone, log loudly, and rely on the user-driven Reset
+        // Admin Password shortcut for the truly-unrecoverable case.
         BOOST_LOG(error) << "cred_store(wcm): credential entry is TPM-sealed but "
                          << "unseal failed; the credential cannot be read on this "
-                         << "host. Use Troubleshooting -> Reset Admin Credentials "
-                         << "to recover.";
+                         << "host. Use the Reset LuminalShine Admin Password "
+                         << "shortcut in the Start Menu to recover (preserves "
+                         << "paired clients and apps; only the admin login is "
+                         << "reset).";
         return false;
       }
       return !out.empty();

--- a/src/httpcommon.cpp
+++ b/src/httpcommon.cpp
@@ -588,15 +588,50 @@ namespace http {
       crypto::secure_wipe(blob);
     });
     pt::ptree inputTree;
+    bool parse_ok = false;
     try {
       std::istringstream in {blob};
       pt::read_json(in, inputTree);
+      parse_ok = true;
     } catch (const std::exception &) {
+      parse_ok = false;
+    }
+    // Self-heal: if cred_store::load returned a non-empty blob but we
+    // can't parse it as JSON (or the parsed object is missing the
+    // username/password/salt triplet required to verify a login),
+    // the stored credential is unusable for auth. Treat the entry as
+    // "doesn't exist" *and* erase it from the underlying store so the
+    // next user_creds_exist call observes a truly clean state and the
+    // web UI lands on first-time setup instead of presenting an
+    // un-authenticable login form.
+    //
+    // Common causes that put a credential into this state:
+    //   - Stored under an older serialization the current build no
+    //     longer understands (e.g. format drift on a major migration).
+    //   - On-disk corruption / partial write of the underlying
+    //     credentials file before the WCM import.
+    //   - WCM blob was written by a third-party tool with a different
+    //     structure.
+    //
+    // Erasure is best-effort; we still return false either way so the
+    // caller branches into setup-needed regardless of erase outcome.
+    const bool fields_present = parse_ok &&
+      inputTree.find("username") != inputTree.not_found() &&
+      inputTree.find("password") != inputTree.not_found() &&
+      inputTree.find("salt") != inputTree.not_found();
+    if (!fields_present) {
+      BOOST_LOG(warning) << "user_creds_exist: stored credential at "
+                         << file << " is unparseable or missing required fields; "
+                         << "erasing so first-time setup can recover.";
+      if (!cred_store::erase(file)) {
+        BOOST_LOG(warning) << "user_creds_exist: cred_store::erase failed during "
+                           << "self-heal; the next login attempt will fail again "
+                           << "until the Reset LuminalShine Admin Password "
+                           << "shortcut is used.";
+      }
       return false;
     }
-    return inputTree.find("username") != inputTree.not_found() &&
-           inputTree.find("password") != inputTree.not_found() &&
-           inputTree.find("salt") != inputTree.not_found();
+    return true;
   }
 
   // Caller must hold statefile::state_mutex() so the file we read isn't

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,7 @@
   #include <shobjidl.h>
 
   #include "src/display_helper_integration.h"
+  #include "src/platform/common.h"
   #include "src/platform/windows/frame_limiter_nvcp.h"
   #include "src/platform/windows/misc.h"
   #include "src/platform/windows/playnite_integration.h"
@@ -249,6 +250,59 @@ int main(int argc, char *argv[]) {
 
     return fn->second(argv[0], config::sunshine.cmd.argc, config::sunshine.cmd.argv);
   }
+
+#ifdef _WIN32
+  // Marker-file driven admin-credential reset.
+  //
+  // The "Reset LuminalShine Admin Password" Start Menu shortcut (added in
+  // packaging/windows/wix/custom_actions.wxs) routes through the lightweight
+  // uninstall.exe bootstrapper, which — after an "are you sure" prompt — drops
+  // an empty sentinel file at <appdata>/.reset_admin_credentials_pending and
+  // restarts LuminalShineService. The service comes back into this block on
+  // the next startup, sees the marker, runs the same in-process reset that
+  // the `--reset-admin-credentials` CLI subcommand uses, then deletes the
+  // marker so the reset doesn't repeat on subsequent restarts.
+  //
+  // The detour exists because the bootstrapper runs as the calling
+  // (elevated) user, while the credential store lives in the LocalSystem
+  // vault — only the service, running as SYSTEM, can `CredDeleteW` the
+  // entry. The marker hand-off is the cleanest way to bridge those two
+  // identities without resorting to PsExec / temporary services / scheduled
+  // tasks. Same mechanism is reused on every Windows host that ships this
+  // service+bootstrapper pair.
+  //
+  // We deliberately run this BEFORE any code path that loads credentials
+  // (web server start, etc.) so the reset is observed by the first auth
+  // check after restart and the user lands on first-time setup.
+  try {
+    const auto marker = platf::appdata() / ".reset_admin_credentials_pending";
+    std::error_code marker_ec;
+    if (std::filesystem::exists(marker, marker_ec)) {
+      BOOST_LOG(warning) << "Admin reset marker found at " << marker.string()
+                         << "; clearing the stored admin credential. The web UI "
+                         << "will show first-time setup on next login.";
+      const int rc = args::reset_admin_credentials();
+      if (rc != 0) {
+        BOOST_LOG(error) << "Marker-driven admin reset returned non-zero ("
+                         << rc << "); proceeding with normal startup anyway. "
+                         << "The marker will be removed regardless so this does "
+                         << "not loop on every restart.";
+      }
+      std::error_code remove_ec;
+      std::filesystem::remove(marker, remove_ec);
+      if (remove_ec) {
+        BOOST_LOG(warning) << "Could not delete admin reset marker at "
+                           << marker.string() << ": " << remove_ec.message()
+                           << ". Remove it manually to prevent reset loops.";
+      }
+    }
+  } catch (const std::exception &ex) {
+    // Don't let a marker-handling glitch block service startup. Log and
+    // continue; the user can retry the Reset shortcut.
+    BOOST_LOG(warning) << "Admin reset marker check failed: " << ex.what()
+                       << ". Continuing service startup.";
+  }
+#endif
 
   // Display configuration is managed by the external Windows helper; no in-process init.
 


### PR DESCRIPTION
## Summary

Addresses the issue we hit during 26.05.0-rc3.hfx3 dogfooding: an upgrade left the admin credential in a state where no password could authenticate, and the only recovery path was a manual PsExec sequence that no real user should ever have to perform. Three independent layers, all shippable together, so any future upgrade-time credential weirdness has a clear path back to working state.

## The three layers

### Layer 1 — Discoverable user-facing recovery

New Start Menu shortcut **"Reset LuminalShine Admin Password"** alongside the existing "LuminalShine" and "Reconfigure LuminalShine" entries. Clicking it:

1. Launches `uninstall.exe --reset-admin`
2. Bootstrapper elevates (UAC) if not already admin
3. Shows confirmation: *"This will clear the saved LuminalShine admin login... Paired Moonlight clients, your apps list, and all other settings are NOT affected"*
4. On confirm: drops a sentinel file at `%ProgramData%\LuminalShine\config\.reset_admin_credentials_pending` and bounces `LuminalShineService` via `sc.exe`
5. Service-side handler in `main.cpp` picks up the marker on its next startup, calls the same in-process `args::reset_admin_credentials()` the CLI uses, deletes the marker, continues normal startup
6. Shows success dialog directing user to `https://localhost:47990` for first-time setup

The marker hand-off bridges the identity gap: the bootstrapper is elevated-Administrator but **not** LocalSystem. The credential lives in the SYSTEM vault. Only the service, running as SYSTEM, can `CredDeleteW` the entry. Marker file is the cleanest bridge without resorting to PsExec / temporary services / scheduled tasks.

### Layer 2 — Fix the existing WiX uninstall reset action

The `SetResetAdminCredentials` custom action in `custom_actions.wxs:281` was invoking:

```
luminalshine.exe reset-admin-credentials
```

The argv dispatcher in `src/config.cpp:1891` only recognizes subcommands prefixed with `--`. Without it, the binary silently falls through to a full service start. **This action has been a no-op in every shipped release through 26.05.0-rc3** — part of why credential state kept persisting through manual reset attempts during debugging this afternoon. Adding the `--` prefix to both legs of the conditional fixes the uninstall-time reset path.

### Layer 3 — Service self-heal on unreadable credential

Two surgical adds to the credential load path:

- **`cred_store_windows.cpp::load`** — when `CredRead` returns success but the blob is empty (broken state), `CredDeleteW` the entry before returning false. Next call observes "no entry" → first-time setup.
- **`httpcommon.cpp::user_creds_exist`** — when the blob is non-empty but unparseable as JSON or missing the required `username`/`password`/`salt` triplet, `cred_store::erase` the entry and return false. Same first-time-setup recovery flow.

**TPM unseal failure is deliberately NOT auto-cleaned** — the TPM can be in transient unavailable states (driver hiccup, policy change, suspended) where the wrap key is still good but unwrap failed this time. Auto-deleting in that window would permanently destroy recoverable credentials. The Layer-1 Start Menu shortcut is the explicit-user-action recovery path for the truly-unrecoverable case; an error log entry now points users at that shortcut instead of the previous "Troubleshooting -> Reset Admin Credentials" generic placeholder.

## Files changed

| File | Layer | Purpose |
|---|---|---|
| `packaging/windows/wix/custom_actions.wxs` | 1, 2 | New `ResetAdminStartMenuShortcut` component + `--reset-admin-credentials` arg fix |
| `packaging/windows/wix/patch_custom_actions.wxs` | 1 | `<ComponentRef>` so the new shortcut is pulled into the feature |
| `packaging/windows/bootstrapper/LuminalShineInstaller.cs` | 1 | `--reset-admin` arg parsing + `RunAdminCredentialReset` flow |
| `src/main.cpp` | 1 | Marker file check at service startup |
| `src/cred_store/cred_store_windows.cpp` | 3 | Self-heal empty-blob case |
| `src/httpcommon.cpp` | 3 | Self-heal unparseable-JSON case |

## Why all three, not just Layer 1

- Layer 1 alone leaves the broken WiX action shipping for any user who manually uninstalls — they'd see an orphan vault entry survive uninstall.
- Layer 2 alone leaves an upgrade-time credential mismatch invisible to the user — they need a way to recover *without* uninstalling.
- Layer 3 alone catches the easy cases (empty blob, garbage JSON) but doesn't help when the credential is structurally valid but the password the user remembers doesn't match what's stored (the scenario we hit today).

Together: structural breakage → self-heals silently. Mysterious mismatch → user clicks the Start Menu shortcut. Manual uninstall → WiX cleanup actually runs.

## Test plan

- [ ] CI green on this PR (Vitest is the required check; full Windows build runs on `ci.yml` dispatch)
- [ ] After merge, build `26.05.0-rc3.hfx4` (or next RC) and verify on a fresh VM:
  - [ ] Install over an existing 26.05.0-rc3.hfx3 → Start Menu has three LuminalShine entries (LuminalShine, Reconfigure, Reset Admin Password)
  - [ ] Click "Reset LuminalShine Admin Password" → UAC prompt → confirmation dialog → success dialog → `https://localhost:47990` shows first-time setup
  - [ ] Paired Moonlight clients and apps list survive the reset
  - [ ] **Layer 3 smoke test**: manually corrupt the WCM entry (overwrite with garbage via PsExec/SYSTEM-context CredWrite) → restart service → service log shows the self-heal warning + entry is erased → web UI shows first-time setup
  - [ ] **Layer 2 smoke test**: uninstall with `KEEPADMINCREDENTIALS != "1"` → confirm the entry is actually deleted (verify via PsExec `cmdkey /list`)
- [ ] Confirm `SIGN_ARTIFACTS` remains `'false'` in `.github/workflows/ci-windows.yml` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
