### PR TITLE
fix(crypto,nvhttp): reject unpaired peer certs in TLS verify (GHSA-ph75-mgxh-mv57)

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -63,8 +63,6 @@ namespace crypto {
       // Expired or not-yet-valid certificates are fine. Sometimes Moonlight is running on embedded devices
       // that don't have accurate clocks (or haven't yet synchronized by the time Moonlight first runs).
       // This behavior also matches what GeForce Experience does.
-      // TODO: Checking for X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY is a temporary workaround to get moonlight-embedded to work on the raspberry pi
-      case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY:
       case X509_V_ERR_CERT_NOT_YET_VALID:
       case X509_V_ERR_CERT_HAS_EXPIRED:
         return 1;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -2559,6 +2559,15 @@ namespace nvhttp {
         return verified;
       }
 
+      // Even if the chain verifier accepted this peer, require the leaf
+      // signature to match a paired client. A future regression in
+      // openssl_verify_cb cannot grant access to an unpaired peer.
+      if (get_client_uuid_from_peer_cert(x509_verify).empty()) {
+        BOOST_LOG(warning) << "SSL Verification error :: peer certificate not in paired client store"sv;
+
+        return verified;
+      }
+
       verified = 1;
 
       return verified;

--- a/tests/unit/test_cert_chain.cpp
+++ b/tests/unit/test_cert_chain.cpp
@@ -1,0 +1,37 @@
+/**
+ * @file tests/unit/test_cert_chain.cpp
+ * @brief Regression coverage for crypto::cert_chain_t::verify.
+ *
+ * Guards against re-introducing an error-code fast-path in
+ * openssl_verify_cb that would accept an unpaired self-signed leaf
+ * (GHSA-ph75-mgxh-mv57 / CVE-2026-32253).
+ */
+
+#include "../tests_common.h"
+
+#include <src/crypto.h>
+
+TEST(CertChainVerifyTest, RejectsUnpairedSelfSignedLeaf) {
+  auto paired = crypto::gen_creds("paired-client", 2048);
+  auto attacker = crypto::gen_creds("attacker", 2048);
+
+  crypto::cert_chain_t chain;
+  chain.add(crypto::x509(paired.x509));
+
+  auto attacker_x509 = crypto::x509(attacker.x509);
+  ASSERT_TRUE(attacker_x509);
+
+  EXPECT_NE(chain.verify(attacker_x509.get()), nullptr);
+}
+
+TEST(CertChainVerifyTest, AcceptsPairedSelfSignedLeaf) {
+  auto paired = crypto::gen_creds("paired-client", 2048);
+
+  crypto::cert_chain_t chain;
+  chain.add(crypto::x509(paired.x509));
+
+  auto presented = crypto::x509(paired.x509);
+  ASSERT_TRUE(presented);
+
+  EXPECT_EQ(chain.verify(presented.get()), nullptr);
+}


### PR DESCRIPTION
## Summary

Closes the upstream cert-chain auth bypass [GHSA-ph75-mgxh-mv57](https://github.com/LizardByte/Sunshine/security/advisories/GHSA-ph75-mgxh-mv57) (CVE-2026-32253, CVSS 9.8) with two layered changes:

- **Port upstream patch** — remove the `X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY` fast-path in `openssl_verify_cb` (`src/crypto.cpp`). Mirrors upstream Sunshine commit `888a6bb` shipped in `v2026.516.143833`.
- **Defense-in-depth pin** — after `cert_chain.verify` accepts a peer, require the leaf cert's exact signature to match a paired client by scanning `client_root.named_devices` (`src/nvhttp.cpp`). Reuses the existing `get_client_uuid_from_peer_cert` primitive — no new code paths, just an additional gate. Closes the class of bugs where any future regression in the verify callback could grant access to an unpaired peer.

## Why both

The upstream two-line patch closes the specific reported bypass. The leaf-pinning gate makes `cert_chain_t::verify` advisory rather than authoritative for client identity, so a future verify-cb error-code mishandling cannot be exploited the same way.

## Test plan

- [ ] CI passes on `ci-windows.yml`
- [ ] New regression test `tests/unit/test_cert_chain.cpp` passes:
  - `RejectsUnpairedSelfSignedLeaf` — attacker self-signed cert is rejected by `cert_chain_t::verify` (would have passed pre-patch via the deleted fast-path)
  - `AcceptsPairedSelfSignedLeaf` — paired cert continues to verify
- [ ] Existing `tests/unit/test_http_pairing.cpp` continues to pass — pairing flow unchanged
- [ ] Smoke test on Windows: pair a Moonlight client, disconnect, reconnect, confirm pairing persists and stream starts
- [ ] Smoke test on Windows: attempt to connect with an unpaired client cert; confirm rejection with `peer certificate not in paired client store` log line

## Compatibility

- Standard Moonlight clients (PC/Android/iOS/Apple TV) re-present the exact cert PEM that pairing stored, so the pinning gate is transparent.
- The deleted clock-skew tolerance (`X509_V_ERR_CERT_NOT_YET_VALID`, `X509_V_ERR_CERT_HAS_EXPIRED`) is retained for moonlight-embedded compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
