### PR TITLE
fix(installer): revert Start Menu shortcut keypath change (HKCU is ICE-required)

### DIFF
--- a/packaging/windows/wix/custom_actions.wxs
+++ b/packaging/windows/wix/custom_actions.wxs
@@ -169,36 +169,17 @@
     <DirectoryRef Id="TARGETDIR">
       <Directory Id="ProgramMenuFolder">
         <Directory Id="LUMINALSHINE_PROGRAM_MENU_FOLDER" Name="LuminalShine">
-          <!-- All three shortcut Components below use the Shortcut element
-               itself as the KeyPath. This is the WiX 3 recommended pattern
-               for non-advertised shortcuts in per-machine (ALLUSERS=1)
-               installs. The HKCU registry values are kept as non-keypath
-               siblings for backward observability (existing tooling can
-               still detect "did MSI place this shortcut?" via the registry
-               value), but Windows Installer tracks the component identity
-               by the .lnk file on disk — not by an HKCU value that under
-               ALLUSERS=1 lands in the elevated-installing-user's hive and
-               becomes unreliable across upgrades. The previous HKCU-keypath
-               authoring shipped through 26.05.0-rc4 left
-               `Reset LuminalShine Admin Password.lnk` missing from
-               %ProgramData%\Microsoft\Windows\Start Menu\Programs\LuminalShine
-               on installs that upgraded into a version that introduced it.
-               Component GUIDs are rotated alongside the keypath change —
-               MSI Component Rules require a new GUID whenever the KeyPath
-               identity moves, so upgrades cleanly replace the old
-               registry-keypath authoring with the new file-keypath one. -->
-          <Component Id="StartMenuShortcut" Guid="{6229CF91-41B2-4BE5-9A4A-83DE9760E8B8}">
+          <Component Id="StartMenuShortcut" Guid="{A3B4C5D6-E7F8-4A5B-9C2D-3E4F5A6B7C8D}">
             <Shortcut Id="LuminalShineStartMenuShortcut"
                       Name="LuminalShine"
                       Description="Launch LuminalShine Web UI"
                       Target="[INSTALL_ROOT]luminalshine.exe"
                       Icon="ProductIcon.ico"
                       Arguments="--shortcut"
-                      WorkingDirectory="INSTALL_ROOT"
-                      KeyPath="yes">
+                      WorkingDirectory="INSTALL_ROOT">
               <ShortcutProperty Key="System.AppUserModel.ID" Value="$(var.LuminalShineAppId)" />
             </Shortcut>
-            <RegistryValue Root="HKCU" Key="Software\LuminalShine\Shortcuts" Name="StartMenu" Type="integer" Value="1" />
+            <RegistryValue Root="HKCU" Key="Software\LuminalShine\Shortcuts" Name="StartMenu" Type="integer" Value="1" KeyPath="yes" />
             <RemoveFolder Id="RemoveLuminalShineMenuFolder" Directory="LUMINALSHINE_PROGRAM_MENU_FOLDER" On="uninstall" />
           </Component>
           <!-- Reconfigure shortcut: opens the bootstrapper installer, which
@@ -207,18 +188,17 @@
                re-downloading. Lives in its own component so MSI always
                recreates it, even when the parent product is being upgraded
                from a build that didn't ship this shortcut. -->
-          <Component Id="ReconfigureStartMenuShortcut" Guid="{212C7B7A-0537-4865-A7A9-B19E52FD5AFD}">
+          <Component Id="ReconfigureStartMenuShortcut" Guid="{F8E9D7C6-B5A4-4938-8271-6C5D4E3F2A1B}">
             <Shortcut Id="LuminalShineReconfigureShortcut"
                       Name="Reconfigure LuminalShine"
                       Description="Switch the virtual display driver or reinstall LuminalShine"
                       Target="[INSTALL_ROOT]uninstall.exe"
                       Icon="ProductIcon.ico"
                       Arguments="--reconfigure"
-                      WorkingDirectory="INSTALL_ROOT"
-                      KeyPath="yes">
+                      WorkingDirectory="INSTALL_ROOT">
               <ShortcutProperty Key="System.AppUserModel.ID" Value="$(var.LuminalShineAppId)" />
             </Shortcut>
-            <RegistryValue Root="HKCU" Key="Software\LuminalShine\Shortcuts" Name="ReconfigureStartMenu" Type="integer" Value="1" />
+            <RegistryValue Root="HKCU" Key="Software\LuminalShine\Shortcuts" Name="ReconfigureStartMenu" Type="integer" Value="1" KeyPath="yes" />
           </Component>
           <!-- Reset Admin Password shortcut: launches uninstall.exe with
                the `reset-admin` flag (double-dash prefix), which after a
@@ -227,29 +207,22 @@
                and bounces LuminalShineService. The service-side handler in
                src/main.cpp picks up the marker on its next startup and
                runs the same in-process erase the CLI subcommand uses.
-               Authorization gate is uninstall.exe's requireAdministrator
-               manifest plus the System-integrity / Administrators-only DACL
-               that platf::harden_config_directory reapplies on every service
-               start — a non-admin local user cannot launch the bootstrapper
-               and cannot write the marker file, so the trigger is
-               admin-only end to end.
                Lives in its own component for the same reason as the
                Reconfigure shortcut above (MSI re-asserts independently
                of the other shortcuts). XML-comment-syntax note: avoid
                literal double-dash sequences inside this comment because
                REXML and other strict XML parsers reject them. -->
-          <Component Id="ResetAdminStartMenuShortcut" Guid="{C21698E1-50ED-4C98-885A-0F95D2396207}">
+          <Component Id="ResetAdminStartMenuShortcut" Guid="{C9F1E2B0-3A8D-4F1C-95E2-7B6A0D5F4C8E}">
             <Shortcut Id="LuminalShineResetAdminShortcut"
                       Name="Reset LuminalShine Admin Password"
                       Description="Clear the saved Web UI admin login so you can create a new one"
                       Target="[INSTALL_ROOT]uninstall.exe"
                       Icon="ProductIcon.ico"
                       Arguments="--reset-admin"
-                      WorkingDirectory="INSTALL_ROOT"
-                      KeyPath="yes">
+                      WorkingDirectory="INSTALL_ROOT">
               <ShortcutProperty Key="System.AppUserModel.ID" Value="$(var.LuminalShineAppId)" />
             </Shortcut>
-            <RegistryValue Root="HKCU" Key="Software\LuminalShine\Shortcuts" Name="ResetAdminStartMenu" Type="integer" Value="1" />
+            <RegistryValue Root="HKCU" Key="Software\LuminalShine\Shortcuts" Name="ResetAdminStartMenu" Type="integer" Value="1" KeyPath="yes" />
           </Component>
         </Directory>
       </Directory>

--- a/scripts/lint_wix_conditions.py
+++ b/scripts/lint_wix_conditions.py
@@ -14,17 +14,6 @@
 # the proactive PowerShell stop list, so upgrades hit file-in-use on
 # the binary that service held mapped.
 #
-# Plus asserts that every Component placed under ProgramMenuFolder uses
-# a non-HKCU KeyPath. HKCU registry keypaths in per-machine
-# (ALLUSERS=1) installs are the documented Windows Installer
-# anti-pattern that caused the "Reset LuminalShine Admin Password"
-# shortcut to be silently dropped from upgrades in 26.05.0-rc3.hfx4
-# through rc4. The fix is to either KeyPath the Shortcut element
-# itself (recommended for non-advertised shortcuts) or to use an HKLM
-# registry value as the keypath. Catching this in the lint means a
-# future contributor adding a new Start Menu shortcut can't reintroduce
-# the same trap.
-#
 # Run standalone for debugging:
 #   python3 scripts/lint_wix_conditions.py
 #
@@ -173,81 +162,6 @@ def check_service_list_coverage(action_id: str, value: str) -> list[str]:
     return failures
 
 
-def start_menu_component_keypath_failures(tree: ET.ElementTree, ns: str) -> list[str]:
-    # Walk every Component whose parent <Directory> chain includes
-    # ProgramMenuFolder. For each, verify that the KeyPath is either the
-    # Shortcut element itself or an HKLM/HKMU registry value — anything
-    # under HKCU is the per-machine anti-pattern that drops shortcuts on
-    # upgrade.
-    prefix = f"{{{ns}}}" if ns else ""
-
-    # Build a map of parent -> [children] so we can walk up from each
-    # Component to confirm it lives under ProgramMenuFolder.
-    parent_map: dict[ET.Element, ET.Element] = {}
-    for parent in tree.iter():
-        for child in parent:
-            parent_map[child] = parent
-
-    def ancestors(elem: ET.Element):
-        node = parent_map.get(elem)
-        while node is not None:
-            yield node
-            node = parent_map.get(node)
-
-    def under_program_menu_folder(comp: ET.Element) -> bool:
-        for anc in ancestors(comp):
-            tag = anc.tag.split("}")[-1]
-            if tag == "Directory" and anc.get("Id") == "ProgramMenuFolder":
-                return True
-        return False
-
-    failures: list[str] = []
-    for comp in tree.iter(f"{prefix}Component"):
-        if not under_program_menu_folder(comp):
-            continue
-
-        comp_id = comp.get("Id", "<no Id>")
-
-        # Find which child is the keypath. The element with
-        # KeyPath="yes" wins; if none, the Component's File child is
-        # implicit keypath (we don't allow File-based shortcut
-        # components, but tolerate the absence here).
-        keypath_elements = [
-            (child.tag.split("}")[-1], child)
-            for child in comp
-            if child.get("KeyPath") == "yes"
-        ]
-
-        if not keypath_elements:
-            failures.append(
-                f"Component {comp_id!r} under ProgramMenuFolder has no "
-                "explicit KeyPath. Add KeyPath=\"yes\" to the Shortcut "
-                "element (recommended for non-advertised shortcuts) or "
-                "to an HKLM/HKMU RegistryValue."
-            )
-            continue
-
-        if len(keypath_elements) > 1:
-            failures.append(
-                f"Component {comp_id!r} has multiple KeyPath=\"yes\" "
-                "children; MSI requires exactly one."
-            )
-
-        for tag, elem in keypath_elements:
-            if tag == "RegistryValue" and elem.get("Root") == "HKCU":
-                failures.append(
-                    f"Component {comp_id!r} under ProgramMenuFolder uses "
-                    "an HKCU registry value as its KeyPath. Under "
-                    "ALLUSERS=1, this lands in the elevated-installing "
-                    "user's hive and is unreliable on upgrade — the "
-                    "shortcut may not be created. Move KeyPath=\"yes\" "
-                    "onto the Shortcut element (preferred) or change the "
-                    "registry Root to HKLM/HKMU."
-                )
-
-    return failures
-
-
 def main() -> int:
     if not PATCH_FILE.exists():
         print(f"missing: {PATCH_FILE}", file=sys.stderr)
@@ -284,8 +198,6 @@ def main() -> int:
             continue
         failures.extend(check_service_list_coverage(action_id, setter_values[action_id]))
 
-    failures.extend(start_menu_component_keypath_failures(ca_tree, ca_ns))
-
     if failures:
         print(
             f"WiX condition lint failed ({len(failures)} issue"
@@ -300,8 +212,7 @@ def main() -> int:
         f"WiX condition lint: OK "
         f"({len(STOP_KILL_ACTION_IDS)} actions, "
         f"{len(REQUIRED_SERVICE_NAMES)} services, "
-        f"{len(SERVICE_LIST_SETTER_IDS)} setters checked, "
-        "ProgramMenuFolder keypaths audited)"
+        f"{len(SERVICE_LIST_SETTER_IDS)} setters checked)"
     )
     return 0
 


### PR DESCRIPTION
## Revert the Start Menu shortcut keypath change — `main`'s MSI build is broken

This supersedes the earlier title. After two failed packaging builds, the correct fix is a **clean revert of `3b6293a3`**.

### What went wrong

`3b6293a3` ("keypath Start Menu shortcuts on the .lnk") was based on a wrong hypothesis — that an HKCU keypath on a per-machine install was dropping the Reset Admin shortcut. Two packaging builds disproved it:

1. `KeyPath="yes"` on `<Shortcut>` → **`CNDL0004`** — that attribute is WiX 4+ only; WiX 3.14 candle rejects it. (This is what broke `main`.)
2. Falling back to an HKLM registry keypath → **`ICE38` / `ICE43` / `ICE57`**:
   ```
   ICE38: Component installs to user profile. Its KeyPath registry key must fall under HKCU.
   ICE43: Component has non-advertised shortcuts. Its KeyPath registry key should fall under HKCU.
   ICE57: Component has both per-user and per-machine data with a per-machine KeyPath.
   ```

**MSI's own validation requires the keypath of a non-advertised Start Menu shortcut to be HKCU.** The original authoring was correct and ICE-compliant — it is how rc4 actually built and shipped. My "fix" was wrong in both directions.

### This PR

Reverts `3b6293a3` wholesale:
- `custom_actions.wxs`: the three shortcut Components return to their original **HKCU keypath + original Component GUIDs** (`{A3B4…}`, `{F8E9…}`, `{C9F1…}`). Byte-identical to rc4's authoring → builds and is ICE-clean.
- `lint_wix_conditions.py`: removes the backwards `ProgramMenuFolder`-keypath check (it forbade exactly what ICE38/43 require). The valid stop/kill-condition + service-list lint from the service-stop fix stays.

### Still open (separately)

We **never verified** the Reset Admin shortcut is actually missing — the original report came with an inconclusive `dir` command (PowerShell didn't expand `%ProgramData%`). Since HKCU is required and rc4 authored the component correctly, the real cause (if any) is something else — most likely an upgrade-from-pre-`bf6becb6` Component-Rules interaction, or a Start Menu refresh lag. That needs proper on-Windows verification (check whether `…\Start Menu\Programs\LuminalShine\Reset LuminalShine Admin Password.lnk` exists after a clean install vs. an upgrade) **before** any further change. No keypath change is warranted.

### Verification
Local: XML parses, all three components HKCU + original GUIDs, no `<Shortcut>` carries `KeyPath`, lint passes. The real gate is the packaging build — triggered on this branch; **this is rc4's exact authoring, so it should build clean.** Merging this unblocks the WiX-7-migration golden baseline (PR #26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
