### PR TITLE
fix(installer): catch pre-MSI Vibeshine installs in conflict removal

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -266,7 +266,11 @@
       "WebFetch(domain:wixtoolset.org)",
       "WebFetch(domain:docs.firegiant.com)",
       "Bash(gh search *)",
-      "Bash(git rebase *)"
+      "Bash(git rebase *)",
+      "Bash(chmod +x /Users/Avalon/Git/luminalshine/scripts/assert_msi_invariants.py)",
+      "Bash(python3 /Users/Avalon/Git/luminalshine/scripts/assert_msi_invariants.py --selftest)",
+      "Bash(python3 scripts/assert_msi_invariants.py --selftest)",
+      "Bash(python3 scripts/assert_msi_invariants.py /Users/Avalon/Git/luminalshine/tests/fixtures/msi_golden/msi_baseline.txt)"
     ],
     "deny": [],
     "ask": [],

--- a/packaging/windows/wix/remove_conflicting_products.vbs
+++ b/packaging/windows/wix/remove_conflicting_products.vbs
@@ -105,11 +105,23 @@ Private Function UninstallConflict(reg, shell, hive, fullPath, subKeyName, displ
 End Function
 
 Private Function IsTargetProduct(displayName)
+    ' Conflict-removal targets the upstream forks LuminalShine descends from
+    ' or that have been observed running side-by-side with it. Each prefix
+    ' is matched against the uppercased registry DisplayName.
+    '
+    ' VIBESHINE intentionally appears here even though LuminalShine inherits
+    ' Vibeshine's MSI UpgradeCode (C2C36624...) and post-Sep-2025 Vibeshine
+    ' MSIs are therefore picked up by MajorUpgrade directly. The prefix
+    ' catches pre-MSI Vibeshine installs (the project shipped NSIS-based
+    ' installers before swapping to WiX), which leave no MSI Upgrade-table
+    ' row for MajorUpgrade to act on but DO leave an Uninstall registry
+    ' entry whose DisplayName begins with "Vibeshine".
     Dim nameUpper
     nameUpper = UCase(Trim(displayName))
     IsTargetProduct = (Left(nameUpper, 8) = "SUNSHINE") _
         Or (Left(nameUpper, 6) = "APOLLO") _
-        Or (Left(nameUpper, 9) = "VIBEPOLLO")
+        Or (Left(nameUpper, 9) = "VIBEPOLLO") _
+        Or (Left(nameUpper, 9) = "VIBESHINE")
 End Function
 
 Private Function BuildMsiUninstallCommand(shell, productCode)


### PR DESCRIPTION
## Summary

`remove_conflicting_products.vbs` only matched DisplayName prefixes `SUNSHINE` / `APOLLO` / `VIBEPOLLO`. Post-Sep-2025 Vibeshine MSIs are already handled by `<MajorUpgrade>` because they share LuminalShine's `UpgradeCode={C2C36624...}` (inherited through the Vibeshine → LuminalShine rename), but the pre-Sep-2025 Vibeshine releases that shipped as **NSIS installers** don't appear in the MSI Upgrade table at all. Those installs would have ended up side-by-side with a fresh LuminalShine install.

Adding the `VIBESHINE` prefix to `IsTargetProduct` picks them up via their Uninstall-registry DisplayName instead, closing the gap.

## Test plan

- [x] No table-diff impact: `Binary` table contents aren't part of `dump_msi_tables.ps1`'s `\$TablesToDump`, so the candidate dump is unchanged.
- [x] `assert_msi_invariants` unaffected (no new pinned values).
- [ ] Windows CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)