### PR TITLE
ci(coverage): make web Codecov upload non-blocking

### DIFF
--- a/.github/workflows/coverage-web.yml
+++ b/.github/workflows/coverage-web.yml
@@ -70,10 +70,14 @@ jobs:
           files: ../../../../coverage/web/lcov.info
           flags: web
           name: web-vitest
-          # Blocking check: if the upload itself fails, fail the job too. This
-          # is the only knob that decides whether codecov-action's exit code
-          # propagates.
-          fail_ci_if_error: true
+          # Non-blocking: a Codecov upload failure must not gate the PR.
+          # The codecov CLI self-verifies its downloaded binary via GPG, and
+          # Codecov's keyserver intermittently fails to serve the public key
+          # ("gpg: Can't check signature: No public key" -> the wrapper exits
+          # 1), which would otherwise block every merge on a Codecov-side
+          # outage rather than any real coverage problem. This matches the
+          # already-non-blocking Codecov upload in coverage-windows.yml.
+          fail_ci_if_error: false
           verbose: true
 
       - name: Upload test results to Codecov Test Analytics


### PR DESCRIPTION
## Problem
The `Vitest Coverage` check is a required gate, and its **Upload to Codecov** step (`coverage-web.yml`) sets `fail_ci_if_error: true`. The codecov CLI GPG-verifies its own downloaded binary, but Codecov's keyserver is intermittently failing to serve the public key:

```
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
    Exiting...
##[error]Process completed with exit code 1.
```

The vitest **tests pass** — only the upload's binary-integrity check fails — yet the whole job fails, hard-blocking every merge during a Codecov-side outage. (Reran the job; fails identically.)

## Fix
Set `fail_ci_if_error: false` on the web coverage upload, making it observability rather than a merge gate. This **matches the already-non-blocking** Codecov upload in `coverage-windows.yml` (line 263) — which is exactly why `Windows-AMD64 Coverage` stays green through the same outage. GPG verification itself is unchanged; when Codecov's keyserver recovers, uploads resume normally.

## Test plan
- [ ] This PR's own `Vitest Coverage` check passes (the fix applies to its own run)
- [ ] Build / CodeQL remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)