### PR TITLE
fix(cred-store): stop silent TPM-key rotation on read; self-heal orphan blobs

### DIFF
--- a/src/cred_store/cred_store_windows.cpp
+++ b/src/cred_store/cred_store_windows.cpp
@@ -43,6 +43,7 @@
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <thread>
 
 // clang-format off
 #include <winsock2.h>
@@ -335,23 +336,107 @@ namespace cred_store {
     // with credentials that were last written under "on", and a
     // subsequent save will rewrite them as plain.
     if (tpm_seal::looks_sealed(raw)) {
-      if (!tpm_seal::unseal(raw, out)) {
-        // Do NOT auto-delete on unseal failure. The TPM can be in a
-        // transient unavailable state (driver hiccup, suspended state,
-        // policy change) where the key is still good but the unwrap
-        // failed *this time*. Auto-deleting would permanently destroy
-        // recoverable credentials in those windows. Instead, leave the
-        // entry alone, log loudly, and rely on the user-driven Reset
-        // Admin Password shortcut for the truly-unrecoverable case.
-        BOOST_LOG(error) << "cred_store(wcm): credential entry is TPM-sealed but "
-                         << "unseal failed; the credential cannot be read on this "
-                         << "host. Use the Reset LuminalShine Admin Password "
-                         << "shortcut in the Start Menu to recover (preserves "
-                         << "paired clients and apps; only the admin login is "
-                         << "reset).";
-        return false;
+      if (tpm_seal::unseal(raw, out)) {
+        return !out.empty();
       }
-      return !out.empty();
+
+      // One-shot retry after a short pause. The previous failure mode
+      // we're absorbing here is a sub-second TPM / Microsoft Platform
+      // Crypto Provider driver hiccup where NCryptOpenKey or
+      // NCryptDecrypt briefly errors out and then recovers on the very
+      // next call (observed during system suspend/resume and right
+      // after a Windows credential subsystem service restart). Without
+      // this, the diagnostic path below would proceed to roundtrip-
+      // probe and possibly self-heal-erase a perfectly recoverable
+      // blob just because the first call landed during a 100-ms
+      // provider blip. 250ms is well past the observed glitch windows
+      // and is paid only on the cold-failure path — the happy path is
+      // unaffected.
+      std::this_thread::sleep_for(std::chrono::milliseconds(250));
+      if (tpm_seal::unseal(raw, out)) {
+        BOOST_LOG(info) << "cred_store(wcm): TPM unseal recovered on retry "
+                        << "after a brief provider glitch.";
+        return !out.empty();
+      }
+
+      // Persistent failure. Ask tpm_seal to tell us *why* so we can
+      // distinguish "orphaned blob — safe to erase" from "transient
+      // TPM unavailability — preserve the blob and let the user use
+      // the Reset Admin Password shortcut."
+      using tpm_seal::UnsealFailureCause;
+      const auto cause = tpm_seal::diagnose_unseal_failure(raw);
+      switch (cause) {
+        case UnsealFailureCause::KeyMissing: {
+          // No persisted wrapping key on this host. The wrapped blob
+          // is orphaned — no possible key value can ever decrypt it.
+          // Self-heal: erase the blob so the next start observes
+          // "no entry" → first-time setup → recovery. The user does
+          // not need to use the Reset Admin Password shortcut; the
+          // setup screen will appear automatically.
+          BOOST_LOG(warning) << "cred_store(wcm): the credential blob is "
+                             << "TPM-sealed but no matching wrapping key "
+                             << "exists on this host (key was deleted, "
+                             << "sysprep'd, or the NCrypt store was reset). "
+                             << "The blob is unrecoverable; erasing it so "
+                             << "first-time setup can recover. Paired "
+                             << "clients and apps are unaffected.";
+          if (!CredDeleteW(kTargetName, CRED_TYPE_GENERIC, 0)) {
+            BOOST_LOG(warning) << "cred_store(wcm): CredDelete during orphan "
+                               << "self-heal failed (err="
+                               << GetLastError() << "); manual reset may be "
+                               << "needed via the Reset Admin Password shortcut.";
+          }
+          return false;
+        }
+        case UnsealFailureCause::BindingMismatch: {
+          // Persisted key is live (roundtrip probe succeeded) but the
+          // stored blob was wrapped under a different key. This is
+          // the "silent key rotation" pathology that the
+          // open_or_create_key fix in tpm_seal_windows.cpp now
+          // prevents going forward — but pre-fix installs may have
+          // already wrapped credentials under a rotated-away key.
+          // Self-heal: erase the orphan blob so the user lands at
+          // first-time setup.
+          BOOST_LOG(warning) << "cred_store(wcm): the credential blob is "
+                             << "TPM-sealed under a different wrapping key "
+                             << "than the one currently persisted on this "
+                             << "host (silent rotation by an earlier build). "
+                             << "The blob is unrecoverable; erasing it so "
+                             << "first-time setup can recover. Paired "
+                             << "clients and apps are unaffected.";
+          if (!CredDeleteW(kTargetName, CRED_TYPE_GENERIC, 0)) {
+            BOOST_LOG(warning) << "cred_store(wcm): CredDelete during binding-"
+                               << "mismatch self-heal failed (err="
+                               << GetLastError() << "); manual reset may be "
+                               << "needed via the Reset Admin Password shortcut.";
+          }
+          return false;
+        }
+        case UnsealFailureCause::KeyTransientlyUnavailable:
+        case UnsealFailureCause::NotApplicable:
+        default:
+          // PRESERVE the blob. The persisted key might come back when
+          // the underlying provider clears whatever it's blocked on
+          // (BitLocker recovery prompt, suspended TPM, AV scan
+          // holding a handle, etc.). Auto-deletion here would
+          // permanently destroy a credential that next boot would
+          // recover. The user-driven Reset Admin Password shortcut
+          // remains the manual escape for the truly-unrecoverable
+          // case. (This branch preserves the historical "Do NOT
+          // auto-delete on unseal failure" guarantee for everything
+          // we can't positively classify as orphan-or-mismatch.)
+          BOOST_LOG(error) << "cred_store(wcm): credential entry is TPM-sealed "
+                           << "but unseal failed and the wrapping key state "
+                           << "could not be confirmed (likely a transient "
+                           << "TPM / Microsoft Platform Crypto Provider "
+                           << "issue). The credential is being preserved in "
+                           << "case the provider recovers on the next start. "
+                           << "If the issue persists, use the Reset "
+                           << "LuminalShine Admin Password shortcut in the "
+                           << "Start Menu to recover (preserves paired "
+                           << "clients and apps; only the admin login is reset).";
+          return false;
+      }
     }
     out = std::move(raw);
     return !out.empty();

--- a/src/cred_store/tpm_seal_windows.cpp
+++ b/src/cred_store/tpm_seal_windows.cpp
@@ -77,9 +77,44 @@ namespace cred_store::tpm_seal {
       return true;
     }
 
+    /// Open the persisted credential-wrapping key IF it already exists.
+    /// Returns false when `NCryptOpenKey` fails — including the
+    /// "not in store" case (`NTE_BAD_KEYSET`). Never creates. Used by
+    /// every path that reads sealed data (`unseal`, `diagnose_unseal_failure`)
+    /// so a transient `NCryptOpenKey` glitch can't silently rotate the
+    /// key out from under an existing wrapped blob in WCM. The
+    /// `open_or_create_key` helper below is reserved for `seal()` — the
+    /// only call site that legitimately needs to provision the key on
+    /// first use.
+    bool open_existing_key(NCRYPT_PROV_HANDLE prov, NCRYPT_KEY_HANDLE &out_key) {
+      const SECURITY_STATUS s = NCryptOpenKey(prov, &out_key, kKeyName, 0, NCRYPT_MACHINE_KEY_FLAG);
+      if (s == ERROR_SUCCESS) {
+        return true;
+      }
+      // NTE_BAD_KEYSET is the canonical "key not present" return; quieter
+      // log level so the common first-install case isn't a warning spam.
+      const auto severity_missing = (s == NTE_BAD_KEYSET);
+      if (severity_missing) {
+        BOOST_LOG(debug) << "tpm_seal: persisted key '" << "LuminalShineAdminCredentialsKey"
+                         << "' not present (NTE_BAD_KEYSET)";
+      } else {
+        BOOST_LOG(warning) << "tpm_seal: NCryptOpenKey failed (0x"
+                           << std::hex << s << "); refusing to create a "
+                           << "replacement on a read path (would orphan "
+                           << "any existing wrapped credential).";
+      }
+      return false;
+    }
+
     /// Open the persisted credential-wrapping key, creating it if it
     /// doesn't exist. Created keys are non-exportable, machine-scoped,
     /// and 2048-bit RSA.
+    ///
+    /// IMPORTANT: this is the WRITE-PATH helper. Only `seal()` should
+    /// call it. Reads (`unseal`, `diagnose_unseal_failure`) must call
+    /// `open_existing_key` instead — a silently-created replacement key
+    /// during a read would orphan whatever wrapped blob already exists
+    /// in WCM (the prior "credentials lost on upgrade" pathology).
     bool open_or_create_key(NCRYPT_PROV_HANDLE prov, NCRYPT_KEY_HANDLE &out_key) {
       SECURITY_STATUS s = NCryptOpenKey(prov, &out_key, kKeyName, 0, NCRYPT_MACHINE_KEY_FLAG);
       if (s == ERROR_SUCCESS) {
@@ -421,7 +456,13 @@ namespace cred_store::tpm_seal {
       return false;
     }
     NCRYPT_KEY_HANDLE key = 0;
-    if (!open_or_create_key(prov, key)) {
+    // open_existing_key (NOT open_or_create_key): the read path must
+    // never provision a fresh key on a transient OpenKey failure. If we
+    // did, NCryptDecrypt below would silently succeed-mathematically
+    // against a different RSA modulus and produce garbage — or fail
+    // with a misleading "blob unrecoverable" message — either way
+    // orphaning the WCM blob. See open_existing_key's docstring.
+    if (!open_existing_key(prov, key)) {
       NCryptFreeObject(prov);
       return false;
     }
@@ -436,9 +477,12 @@ namespace cred_store::tpm_seal {
     NCryptFreeObject(key);
     NCryptFreeObject(prov);
     if (s != ERROR_SUCCESS || aes_size != kAesKeyLen) {
-      BOOST_LOG(warning) << "tpm_seal: NCryptDecrypt failed (0x"
-                         << std::hex << s << "); credential blob is "
-                         << "unrecoverable on this TPM.";
+      // Quiet failure here — the load path retries once after a short
+      // delay and then calls diagnose_unseal_failure() for the
+      // human-readable explanation. Keeping this at debug avoids
+      // double-logging the same failure in two places.
+      BOOST_LOG(debug) << "tpm_seal: NCryptDecrypt failed (0x"
+                       << std::hex << s << "); caller will diagnose.";
       SecureZeroMemory(aes_key.data(), kAesKeyLen);
       return false;
     }
@@ -487,6 +531,97 @@ namespace cred_store::tpm_seal {
     }
     BOOST_LOG(info) << "tpm_seal: deleted TPM-bound RSA wrapping key.";
     return true;
+  }
+
+  UnsealFailureCause diagnose_unseal_failure(std::string_view sealed) {
+    if (!looks_sealed(sealed)) {
+      return UnsealFailureCause::NotApplicable;
+    }
+    if (!available()) {
+      return UnsealFailureCause::KeyTransientlyUnavailable;
+    }
+
+    NCRYPT_PROV_HANDLE prov = 0;
+    if (!open_provider(prov)) {
+      return UnsealFailureCause::KeyTransientlyUnavailable;
+    }
+
+    // Step 1: does the persisted key exist at all?
+    NCRYPT_KEY_HANDLE key = 0;
+    if (!open_existing_key(prov, key)) {
+      NCryptFreeObject(prov);
+      return UnsealFailureCause::KeyMissing;
+    }
+    // Don't actually need the handle past this point — seal()/unseal()
+    // open their own. Releasing it early keeps the probe path simple.
+    NCryptFreeObject(key);
+    NCryptFreeObject(prov);
+
+    // Step 2: roundtrip probe with a 16-byte random throwaway. If the
+    // currently-persisted key successfully seals AND unseals a fresh
+    // payload, the key is demonstrably live — which means the caller's
+    // sealed input (which failed to unseal) was wrapped under a
+    // DIFFERENT key than the one persisted today. That is the
+    // BindingMismatch case: self-heal is safe.
+    //
+    // Random (not constant) plaintext per the security review: removes
+    // the "is this an oracle for is-key-live" smell entirely, and costs
+    // nothing — BCryptGenRandom is microseconds. The buffer is
+    // SecureZeroMemory'd on every exit path so it can't be observed
+    // later in a memory dump.
+    std::array<BYTE, 16> probe_plain {};
+    if (BCryptGenRandom(nullptr, probe_plain.data(),
+                        static_cast<ULONG>(probe_plain.size()),
+                        BCRYPT_USE_SYSTEM_PREFERRED_RNG) != 0) {
+      BOOST_LOG(warning) << "tpm_seal: BCryptGenRandom failed in diagnostic "
+                         << "probe; cannot confirm key liveness.";
+      return UnsealFailureCause::KeyTransientlyUnavailable;
+    }
+    std::string_view probe_view(reinterpret_cast<const char *>(probe_plain.data()),
+                                probe_plain.size());
+
+    std::string probe_sealed;
+    const bool sealed_ok = seal(probe_view, probe_sealed);
+    if (!sealed_ok) {
+      SecureZeroMemory(probe_plain.data(), probe_plain.size());
+      BOOST_LOG(warning) << "tpm_seal: roundtrip seal of probe payload failed; "
+                         << "key state is uncertain — preserving the existing "
+                         << "wrapped credential blob.";
+      return UnsealFailureCause::KeyTransientlyUnavailable;
+    }
+
+    std::string probe_unsealed;
+    const bool unsealed_ok = unseal(probe_sealed, probe_unsealed);
+    // Wipe the sealed-probe envelope from memory regardless — it
+    // contains the wrapped+encrypted random payload and adds no value
+    // past this point.
+    SecureZeroMemory(&probe_sealed[0], probe_sealed.size());
+    if (!unsealed_ok) {
+      SecureZeroMemory(probe_plain.data(), probe_plain.size());
+      SecureZeroMemory(&probe_unsealed[0], probe_unsealed.size());
+      BOOST_LOG(warning) << "tpm_seal: roundtrip unseal of probe payload failed "
+                         << "even though seal succeeded — key state inconsistent; "
+                         << "preserving the existing wrapped credential blob.";
+      return UnsealFailureCause::KeyTransientlyUnavailable;
+    }
+    // Verify integrity. If the roundtrip returns different bytes, the
+    // key is in an unexpected state — treat as transient and preserve.
+    const bool integrity_ok = probe_unsealed.size() == probe_plain.size() &&
+      std::memcmp(probe_unsealed.data(), probe_plain.data(), probe_plain.size()) == 0;
+    SecureZeroMemory(probe_plain.data(), probe_plain.size());
+    SecureZeroMemory(&probe_unsealed[0], probe_unsealed.size());
+    if (!integrity_ok) {
+      BOOST_LOG(warning) << "tpm_seal: roundtrip probe round-tripped but bytes "
+                         << "differ — key state inconsistent; preserving the "
+                         << "existing wrapped credential blob.";
+      return UnsealFailureCause::KeyTransientlyUnavailable;
+    }
+
+    // Key is live AND round-trips correctly. The caller's sealed input
+    // must therefore have been wrapped under a different key — a
+    // silent rotation in some previous service incarnation. Caller is
+    // cleared to erase the orphan blob.
+    return UnsealFailureCause::BindingMismatch;
   }
 
 }  // namespace cred_store::tpm_seal

--- a/src/cred_store/tpm_seal_windows.h
+++ b/src/cred_store/tpm_seal_windows.h
@@ -83,4 +83,52 @@ namespace cred_store::tpm_seal {
    */
   bool clear();
 
+  /**
+   * @brief Why a previous `unseal()` call returned false. Caller uses
+   *        this to distinguish "transient TPM glitch — keep the blob"
+   *        from "the wrapping key really has rotated and the blob is
+   *        dead — safe to self-heal-erase it."
+   */
+  enum class UnsealFailureCause {
+    /// `looks_sealed(sealed)` is false, OR the sealed blob actually
+    /// just unsealed successfully on retry (caller should re-unseal
+    /// to get the plaintext). Not a real failure — caller should not
+    /// treat this as a reason to erase anything.
+    NotApplicable,
+    /// The persisted RSA wrapping key was not found in the Microsoft
+    /// Platform Crypto Provider. Either it was never created (impossible
+    /// once a sealed blob exists) or it has been deleted out-of-band
+    /// (sysprep, manual `certutil` cleanup, provider state reset, etc.).
+    /// The wrapped blob is orphaned — there is no key on this host that
+    /// can ever decrypt it. Self-heal: safe to erase the blob.
+    KeyMissing,
+    /// The persisted key IS present and demonstrably functional (a
+    /// roundtrip seal+unseal of a random throwaway payload succeeded),
+    /// but `NCryptDecrypt` of the stored wrapped key fails — i.e. the
+    /// blob was wrapped under a *different* key than the one persisted
+    /// today. Almost always means the key was silently rotated by an
+    /// earlier `open_or_create_key` invocation against a transiently-
+    /// failing `NCryptOpenKey`. Self-heal: safe to erase the blob; the
+    /// next save will rewrite it under the now-persisted key.
+    BindingMismatch,
+    /// The persisted key state could not be confirmed — provider open
+    /// failed, the roundtrip probe itself errored out, BCryptGenRandom
+    /// failed, etc. Could be a genuine transient TPM/driver glitch.
+    /// Do NOT self-heal: preserve the blob and let the next start try
+    /// again. The user-driven Reset Admin Password Start Menu shortcut
+    /// remains the manual recovery path for the truly-unrecoverable case.
+    KeyTransientlyUnavailable,
+  };
+
+  /**
+   * @brief Diagnose WHY a previous `unseal(sealed, ...)` returned false.
+   *        Pure observation; never modifies the persisted key or the
+   *        blob. Performs at most one roundtrip seal+unseal of a 16-byte
+   *        random throwaway against the live key. Caller (cred_store
+   *        load path) uses the result to decide whether to self-heal-
+   *        erase the WCM blob. See `UnsealFailureCause` for the
+   *        decision rules each value implies.
+   */
+  UnsealFailureCause diagnose_unseal_failure(std::string_view sealed);
+
 }  // namespace cred_store::tpm_seal


### PR DESCRIPTION
## Fix the "have to Reset Admin to regain access" Windows pattern

Root cause from the [credential-loss investigation](../#) earlier in the session: `cred_store::tpm_seal`'s `open_or_create_key` was called from `unseal()`, so any transient `NCryptOpenKey` failure (TPM/MS Platform Crypto Provider hiccup, NCrypt store reset by sysprep, AV holding a handle, etc.) silently created a brand-new RSA persisted key. `NCryptDecrypt` then tried to RSA-unwrap the old AES key under the new key's modulus → failed by mathematics → WCM blob orphaned forever → user had to Reset Admin to recover.

The remote-PC-vs-local correlation users observed was incidental: an empty `config::sunshine.username` (what an unseal failure at service start produces) makes [http_auth.cpp:1369](src/http_auth.cpp#L1369) reject every `/api/*` with "Credentials not configured" regardless of session cookie. Local users hit it just as fast — they just may not notice immediately because they aren't making API calls.

## Independent security review: GREEN

Spawned in parallel via the project's [security review subagent pattern](CLAUDE.md). Verdict was **safe to implement and ship**, with two refinements that are both incorporated here:
1. **Random throwaway payload** via `BCryptGenRandom` for the roundtrip probe (no oracle smell, microsecond cost).
2. **One-shot `NCryptDecrypt` retry after 250 ms** before declaring the binding mismatched — absorbs sub-second provider glitches we'd otherwise self-heal-erase out of.

## The three coupled changes

### `tpm_seal_windows.h/.cpp`
- New private `open_existing_key()` that **only** calls `NCryptOpenKey` — never creates. `unseal()` now uses it. `seal()` remains the only legitimate first-use create path via `open_or_create_key`.
- New public `diagnose_unseal_failure(sealed) -> UnsealFailureCause`:
  - `KeyMissing` — no persisted key on this host.
  - `BindingMismatch` — key opens AND a roundtrip seal+unseal of a 16-byte `BCryptGenRandom` throwaway succeeds → input was wrapped under a different key (silent rotation by an earlier build).
  - `KeyTransientlyUnavailable` — state can't be confirmed; preserve the blob.
  - `NotApplicable` — input isn't TPM-sealed.
- All probe buffers `SecureZeroMemory`'d on every exit.
- `NCryptDecrypt` failure logging inside `unseal()` demoted to `debug`; the load-path caller now writes the human-readable diagnosis to avoid double-logging.

### `cred_store_windows.cpp::load`
- 250 ms sleep + one-shot retry of `unseal` after first failure (security-review refinement #2).
- Then `diagnose_unseal_failure()` → branch:
  - **`KeyMissing` / `BindingMismatch`** — distinctive warning, `CredDeleteW` the orphan blob, return false. Next start hits first-time setup automatically — **no Start Menu shortcut hunt required**.
  - **`KeyTransientlyUnavailable` / default** — preserve the blob; log the existing "use the Reset Admin Password shortcut" message. Preserves the historical "Do NOT auto-delete on unseal failure" invariant for everything we can't positively classify as orphan-or-mismatch.

## Security model preserved end-to-end (independently confirmed)

- The DACL on `%ProgramData%\LuminalShine\config\` (Users read+execute only, System integrity label) reapplied on every service start ([dir_acl.cpp:26](src/platform/windows/dir_acl.cpp#L26)) is unchanged. Non-admins cannot reach the new self-heal-erase path — it runs from SYSTEM context at service start before `nvhttp` / `confighttp` come up; the only inputs are the WCM blob (admin-writable only) and the persisted key.
- Probe payload is 16 bytes from `BCryptGenRandom`, never persisted, `SecureZeroMemory`'d. No oracle, no leak.
- Reset Admin Password Start Menu shortcut continues to work end-to-end (`tpm_seal::clear` and `cred_store::erase` untouched).

## Net effect for users

- The "have to Reset Admin to regain access" flow becomes "land at first-time setup automatically" in every case we can positively classify as orphan-or-mismatch.
- Genuinely transient TPM glitches are absorbed by the 250 ms retry, or, if persistent, preserve the blob with a clear log line pointing at the Reset Admin Password shortcut.
- Paired Moonlight clients, the apps list, and all other settings remain unaffected.

## Verification
Local (macOS): brace+paren balance clean across the three modified files, symbol linkup verified across header + two `.cpp`s, all four committed self-tests (`lint_wix_conditions`, `diff_msi_tables`, `gen_wix_files`, `assert_msi_invariants`) still pass. C++ build is Windows-only — CI exercises that. PR #(next) lands a paired `assert_msi_invariants` check that the `ResetAdminCredentials` custom action's IES condition retains all three gate clauses (`REMOVE="ALL"`, `NOT UPGRADINGPRODUCTCODE`, `KEEPADMINCREDENTIALS<>"1"`) so a future MSI edit can't silently disarm the upgrade-credential-preservation guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
