### PR TITLE
fix(nvenc): ResetEvent before each encode submission to discard stale signals (3/4)

### DIFF
--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -879,6 +879,14 @@ namespace nvenc {
     pic_params.outputBitstream = output_bitstream;
     pic_params.completionEvent = async_event_handle;
 
+    // Discard any stale signal latched on the auto-reset completion event
+    // by a previously-timed-out wait. Without this, the WaitForSingleObject
+    // below would return WAIT_OBJECT_0 immediately on the stale signal and
+    // we'd proceed to nvEncLockBitstream against an uncommitted bitstream.
+    // See reset_async_event documentation in nvenc_base.h for the failure
+    // mode this defends against. No-op on sync-mode encoders.
+    reset_async_event();
+
     if (nvenc_failed(nvenc->nvEncEncodePicture(encoder, &pic_params))) {
       BOOST_LOG(error) << "NvEnc: NvEncEncodePicture() failed: " << last_nvenc_error_string;
       return {};

--- a/src/nvenc/nvenc_base.h
+++ b/src/nvenc/nvenc_base.h
@@ -105,6 +105,27 @@ namespace nvenc {
       return false;
     }
 
+    /**
+     * @brief Optional. Override to put `async_event_handle` back into the
+     *        unsignaled state before issuing the next nvEncEncodePicture.
+     *
+     *        Why this exists: the async completion event is created
+     *        auto-reset. A successful wait on it clears the signal, but a
+     *        TIMED-OUT wait does not — the signal latches. If NVENC then
+     *        completes the picture after our timeout window elapsed, the
+     *        event becomes signaled with no consumer. The very next
+     *        encode_frame's wait would return WAIT_OBJECT_0 immediately on
+     *        that stale signal, before NVENC has actually finished the new
+     *        picture, and the subsequent nvEncLockBitstream would read an
+     *        uncommitted bitstream — undefined behavior, observed as
+     *        bitstream corruption that subsequently trips the heap
+     *        validator on RTX 40/50 with split-frame AV1.
+     *
+     *        Default is a no-op (sync-mode encoders don't need it).
+     */
+    virtual void reset_async_event() {
+    }
+
     bool nvenc_failed(NVENCSTATUS status);
 
     const NV_ENC_DEVICE_TYPE device_type;

--- a/src/nvenc/nvenc_d3d11.cpp
+++ b/src/nvenc/nvenc_d3d11.cpp
@@ -108,5 +108,16 @@ namespace nvenc {
     return WaitForSingleObject(async_event_handle, timeout_ms) == WAIT_OBJECT_0;
   }
 
+  void nvenc_d3d11::reset_async_event() {
+    if (async_event_handle) {
+      // ResetEvent is a no-op when the event is already unsignaled (the
+      // happy-path case after a successful WaitForSingleObject consumed
+      // the signal). Costs ~one syscall and forecloses the stale-signal
+      // pathway entirely. See nvenc_base.h::reset_async_event for the
+      // failure mode this defends against.
+      ResetEvent(async_event_handle);
+    }
+  }
+
 }  // namespace nvenc
 #endif

--- a/src/nvenc/nvenc_d3d11.h
+++ b/src/nvenc/nvenc_d3d11.h
@@ -37,6 +37,7 @@ namespace nvenc {
   protected:
     bool init_library(uint32_t api_version) override;
     bool wait_for_async_event(uint32_t timeout_ms) override;
+    void reset_async_event() override;
 
   private:
     HMODULE dll = nullptr;


### PR DESCRIPTION
## ResetEvent before each NVENC submission (PR 3 of 4)

The async completion event is created **auto-reset** ([`nvenc_d3d11.cpp:26`](src/nvenc/nvenc_d3d11.cpp#L26): `CreateEvent(nullptr, FALSE, FALSE, nullptr)`). Auto-reset semantics: a *successful* `WaitForSingleObject` consumes the signal, but a *timed-out* wait does not — the signal stays latched if NVENC ever completes that picture afterward.

## The bug

1. Frame N: `nvEncEncodePicture` → GPU starts → 100 ms wait times out → `encode_frame` returns `{}`.
2. NVENC completes frame N seconds later → **event becomes signaled with no consumer**.
3. Frame N+1: `nvEncEncodePicture` → `WaitForSingleObject(handle, 100)` → **returns `WAIT_OBJECT_0` immediately on the stale signal from N**, before NVENC has actually finished N+1.
4. `nvEncLockBitstream` reads an uncommitted bitstream → undefined behavior. On RTX 40/50 + split-frame AV1 loads where wait-timeouts are reachable, this manifests as bitstream corruption that subsequently trips the heap validator.

## The fix

Call `ResetEvent(async_event_handle)` immediately before every `nvEncEncodePicture`. `ResetEvent` is a no-op when the event is already unsignaled (the happy path after a successful wait consumed the signal), so the cost is ~one syscall per frame on async-mode encoders and zero on sync-mode.

Implementation:
- New virtual `nvenc_base::reset_async_event()` (default no-op).
- `nvenc_d3d11::reset_async_event()` calls `ResetEvent(async_event_handle)`.
- `encode_frame` calls it just before `nvEncEncodePicture`.

Mirrors the existing `wait_for_async_event` virtual pattern.

## Land order

| # | PR | Status |
|---|---|---|
| 1 | [#36](https://github.com/NortheBridge/luminalshine/pull/36) — drain in destroy_encoder | in flight |
| 2 | C2 — no-unmap-on-timeout (depends on #36) | after #36 |
| 3 | **this PR** — ResetEvent before encode (independent) | here |
| 4 | C4 — DLSS-FG / path-trace aware timeout bump (independent) | next |

PR-C1 is independent of #36 and C2/C4 — can ship in any order relative to them.

## Verification
Local: brace/paren balance clean across all four modified files; new virtual is properly overridden in the d3d11 subclass; all four committed self-tests still pass. The C++ build is Windows-only — `Windows-AMD64 Coverage` is the build gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
