### PR TITLE
feat(nvenc): bump encode-wait timeout to 250ms when DLSS-FG/DLAA detected (4/4)

### DIFF
--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -17,6 +17,7 @@
 #include "nvenc_api.h"
 
 // standard includes
+#include <algorithm>
 #include <atomic>
 #include <format>
 #include <optional>
@@ -164,6 +165,16 @@ namespace nvenc {
     encoder_params.height = client_config.height;
     encoder_params.buffer_format = buffer_format;
     encoder_params.rfi = true;
+
+    // Cache the per-session encode-wait timeout. Read once here; the
+    // per-frame wait below in encode_frame consults the cached value
+    // every frame instead of the global config so it cannot race a
+    // settings change mid-session, and so the timeout reflects whatever
+    // render-stack-aware tuning the caller applied at session start
+    // (e.g. 250 ms for DLSS-FG + AV1 + 4K HDR vs the 100 ms baseline).
+    // Clamp to >=10 ms so a misconfigured 0 doesn't busy-loop the
+    // encoder thread on every frame.
+    encoder_state.encode_wait_timeout_ms = std::max<uint32_t>(10, config.encode_wait_timeout_ms);
 
     selected_api_version = 0;
 
@@ -956,7 +967,7 @@ namespace nvenc {
     lock_bitstream.outputBitstream = output_bitstream;
     lock_bitstream.doNotWait = async_event_handle ? 1 : 0;
 
-    if (async_event_handle && !wait_for_async_event(100)) {
+    if (async_event_handle && !wait_for_async_event(encoder_state.encode_wait_timeout_ms)) {
       // Capture diagnostic context on the timeout. The previous one-line
       // log gave no signal about whether this was a transient bubble or
       // the start of a TDR — and the line printed two lines before the

--- a/src/nvenc/nvenc_base.h
+++ b/src/nvenc/nvenc_base.h
@@ -179,6 +179,12 @@ namespace nvenc {
       // the event signal, so there's no in-flight work to wait for and the
       // drain would just stall for the full timeout on every shutdown).
       bool has_pending_async = false;
+      // Cached at create_encoder time from nvenc_config.encode_wait_timeout_ms.
+      // Per-session immutable: deliberately NOT re-snapshotted mid-stream
+      // because the foreground render workload doesn't reclassify in <1s
+      // and re-evaluating each frame would just add jitter while paying
+      // ~10ms per snapshot for nothing.
+      uint32_t encode_wait_timeout_ms = 100;
     } encoder_state;
   };
 

--- a/src/nvenc/nvenc_config.h
+++ b/src/nvenc/nvenc_config.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 namespace nvenc {
 
   enum class nvenc_two_pass {
@@ -57,6 +59,19 @@ namespace nvenc {
 
     // Add filler data to encoded frames to stay at target bitrate, mainly for testing
     bool insert_filler_data = false;
+
+    // Per-frame ceiling for the encode-async-completion wait inside
+    // encode_frame's WaitForSingleObject. Default 100 ms is the
+    // historical tuning that's safe for RTX 20/30-era workloads.
+    // Render-stack-aware callers bump this to 250 ms when the
+    // foreground process has DLSS-FG or DLAA loaded (see
+    // src/platform/windows/display_vram.cpp::init_encoder), where the
+    // GPU's queued render + frame-gen work routinely exceeds the
+    // 100 ms budget at 4K HDR and would otherwise classify a
+    // legitimately-slow frame as a TDR-class event. See the team's
+    // own comment near evaluate_and_tip in src/video.cpp for the
+    // documented worst case (Frame-Gen + DLAA + AV1 NVENC at 4K).
+    uint32_t encode_wait_timeout_ms = 100;
   };
 
 }  // namespace nvenc

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -25,6 +25,7 @@ extern "C" {
 #include "src/nvenc/nvenc_d3d11_native.h"
 #include "src/nvenc/nvenc_d3d11_on_cuda.h"
 #include "src/nvenc/nvenc_utils.h"
+#include "src/platform/windows/render_stack_detect.h"
 #include "src/video.h"
 #include "utf_utils.h"
 
@@ -1108,7 +1109,40 @@ namespace platf::dxgi {
       }
 
       auto nvenc_colorspace = nvenc::nvenc_colorspace_from_sunshine_colorspace(colorspace);
-      if (!nvenc_d3d->create_encoder(config::video.nv, client_config, nvenc_colorspace, buffer_format)) {
+
+      // Render-stack-aware per-session timeout. Take ONE snapshot here
+      // (encoder init = session start), not per frame: snapshot() walks
+      // every accessible process for module matches and costs ~10ms,
+      // and the foreground render workload doesn't reclassify in the
+      // sub-second timescale the encode-wait gate cares about. If the
+      // detection reports DLSS Frame Generation or DLAA loaded in the
+      // foreground process, the GPU's queued render + frame-gen work
+      // regularly exceeds the 100ms default at 4K HDR — keeping the
+      // default would misclassify legitimately-slow frames as TDR-class
+      // and start tearing the encoder down (which prior PRs in the
+      // series harden, but is best avoided in the first place).
+      //
+      // Bump to 250ms when DLSS-FG or DLAA is detected. Plain DLSS
+      // (no FG) does not currently trigger the bump because its
+      // per-frame overhead stays well under 100ms even at 4K. If a
+      // future user-report indicates otherwise, add `has_dlss` to the
+      // condition below.
+      //
+      // The bump is one-way: don't downgrade mid-session if a later
+      // snapshot lost the flag (jitter > value).
+      auto encoder_cfg = config::video.nv;
+      const auto rs = platf::render_stack::snapshot();
+      if (rs.any_match && (rs.has_dlss_fg || rs.has_dlaa)) {
+        encoder_cfg.encode_wait_timeout_ms = 250;
+        BOOST_LOG(info) << "NvEnc: render-stack detection found "
+                        << (rs.has_dlss_fg ? "DLSS-FG " : "")
+                        << (rs.has_dlaa ? "DLAA " : "")
+                        << "in a foreground process; raising encode-wait timeout "
+                        << "from 100ms to " << encoder_cfg.encode_wait_timeout_ms
+                        << "ms for this session.";
+      }
+
+      if (!nvenc_d3d->create_encoder(encoder_cfg, client_config, nvenc_colorspace, buffer_format)) {
         return false;
       }
 


### PR DESCRIPTION
## Render-stack-aware encode-wait timeout (PR 4 of 4)

The 100 ms `wait_for_async_event` ceiling in [`encode_frame`](src/nvenc/nvenc_base.cpp#L891) is the RTX 20/30-era tuning. With DLSS Frame Generation or DLAA loaded in the foreground process, the GPU's combined render + frame-gen + encode work routinely **exceeds** 100 ms at 4K HDR — a legitimately-slow frame gets misclassified as a TDR-class event and starts the encoder teardown cascade (which prior PRs in this series harden, but is best avoided in the first place).

This PR raises the wait to **250 ms** specifically for the render-stack-detected case. The 100 ms baseline stays for everything else.

## Implementation

- `nvenc_config.h` — new `uint32_t encode_wait_timeout_ms = 100;`.
- `nvenc_base.h` — `encoder_state` gains a cached `encode_wait_timeout_ms`, populated by `create_encoder` with a `std::max<uint32_t>(10, …)` clamp so a misconfigured 0 cannot busy-loop the encoder thread.
- `nvenc_base.cpp::encode_frame` — replaces the literal `100` with `encoder_state.encode_wait_timeout_ms`.
- `display_vram.cpp::init_encoder` — takes **one** `platf::render_stack::snapshot()` at session start (~10 ms; paid once), builds a local `nvenc_config` copy with the bumped timeout when `has_dlss_fg` or `has_dlaa` is detected, and passes that copy to `create_encoder`. Logs an info line so the choice is visible in support transcripts.

## Honoring the correctness-review constraints

The independent review specifically called out three things; all three are honored:

1. **Sample at session start, not per frame.** A snapshot is ~10 ms; paying that per frame would be absurd, and the workload class doesn't flip in &lt;1 s anyway. The cached value lives on `encoder_state` and is immutable after `create_encoder`.
2. **Fallback when detection fails** (snapshot returns `any_match=false`): keep the 100 ms baseline. Never tighten further on detection failure.
3. **Don't downgrade mid-session** if a later snapshot loses the flag. The bump is one-way and never re-evaluated — we don't even re-snapshot.

`has_dlss` (plain DLSS without FG) does **not** trigger the bump because its per-frame overhead stays well under 100 ms even at 4K. One-line change in `init_encoder` if a future report indicates otherwise.

## Position in the series

| # | PR | Status |
|---|---|---|
| 1 | [#36](https://github.com/NortheBridge/luminalshine/pull/36) — drain in `destroy_encoder` | CI green ✅ |
| 2 | C2 — no-unmap-on-timeout (depends on #36 merging) | after #36 |
| 3 | [#37](https://github.com/NortheBridge/luminalshine/pull/37) — `ResetEvent` before encode | CI green ✅ |
| 4 | **this PR** — render-stack-aware timeout | here |

Independent of #36 / #37 / C2.

## Verification
Local: brace/paren balance clean across all four modified files; symbol references resolve; all four committed self-tests still pass. The C++ build is Windows-only — `Windows-AMD64 Coverage` is the build gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
