### PR TITLE
fix(sessionmon): redraw uPlot charts when a tab pane mounts (1/3)

### DIFF
--- a/src_assets/common/assets/web/components/SessionDetailsPanel.vue
+++ b/src_assets/common/assets/web/components/SessionDetailsPanel.vue
@@ -202,7 +202,33 @@ const charts: Map<string, uPlot> = new Map();
 const chartRefs: Record<string, HTMLDivElement | null> = {};
 
 function setChartRef(id: string, el: HTMLDivElement | null) {
+  // NaiveUI's <NTabs> lazy-mounts inactive panes, so the chart hosts
+  // for the Connection and Host tabs don't exist when loadSession()
+  // first runs redrawAllCharts() — those redraw calls bail because
+  // chartRefs[id] is null. When the user later switches tabs the
+  // host <div> mounts (this callback fires with a non-null el); the
+  // poll loop only re-fires for live sessions, so without this hook
+  // ended sessions would never paint anything on the freshly-mounted
+  // tab. Conversely on unmount (el == null) we tear down the uPlot
+  // instance so a subsequent re-mount creates a fresh one against
+  // the new DOM node instead of trying to size a chart whose canvas
+  // parent has been detached.
+  if (el == null) {
+    const existing = charts.get(id);
+    if (existing) {
+      existing.destroy();
+      charts.delete(id);
+    }
+    chartRefs[id] = null;
+    return;
+  }
   chartRefs[id] = el;
+  if (session.value) {
+    const spec = [...STREAM_CHARTS, ...CONNECTION_CHARTS, ...HOST_CHARTS].find((s) => s.id === id);
+    if (spec) {
+      void nextTick(() => redrawChart(spec));
+    }
+  }
 }
 
 function destroyAllCharts() {


### PR DESCRIPTION
## Redraw uPlot charts when a tab pane mounts (PR 1 of 3)

First of three independent fixes for the live session monitor (see #41 / #42 for the others).

### Bug
[`SessionDetailsPanel.vue`](https://github.com/NortheBridge/luminalshine/blob/main/src_assets/common/assets/web/components/SessionDetailsPanel.vue) groups its six per-session charts across three `<NTabPane>`s (**Stream** / **Connection** / **Host**). NaiveUI lazy-mounts inactive panes, so when the drawer opens on the default "Stream" tab the chart-host `<div>`s for the other two tabs don't exist yet. `loadSession()`'s `redrawAllCharts()` iterates every chart spec and silently bails for any spec whose `chartRefs[id]` is null — which is exactly the Connection + Host specs on first load. Switching tabs later mounts those `<div>`s but never re-runs the redraw, so the new panes stay permanently blank for **ended** sessions. Live sessions eventually paint when the 2-second poll fires the next `loadSession()`, masking the bug behind whichever recording the user happens to open.

### Fix
Piggyback the existing `:ref="(el) => setChartRef(...)"` callback:

| Transition | Behavior |
|---|---|
| `null → el` (pane mounts) | Schedule a single `nextTick`-deferred `redrawChart(spec)` for that one spec |
| `el → null` (pane unmounts) | Destroy the previous uPlot instance so the next mount creates a fresh chart against the new DOM node |

No lifecycle / data-flow changes. The fix is one function.

### Verification
- Local ESLint problem count unchanged (`73` against main; the 73 are pre-existing prettier wrap warnings on the `<template>` section).
- Manual smoke: open the drawer for an ended session → click Connection → chart paints; click Host → both host charts paint; click Stream → still paints (same code path as before).
- `vue-tsc` peer-dep noise pre-exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
