### PR TITLE
fix(sessionmon): stable per-process unique session IDs (2/3)

### DIFF
--- a/src/session_monitor_client.cpp
+++ b/src/session_monitor_client.cpp
@@ -24,6 +24,7 @@
 #include "logging.h"
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <deque>
 #include <mutex>
@@ -318,7 +319,34 @@ namespace session_mon {
   }
 
   std::string make_id(std::uint32_t launch_session_id) {
-    return std::to_string(launch_session_id);
+    // Stable per-process prefix: the unix-epoch milliseconds at the
+    // first call into this function. Captured once via the static
+    // local-init guarantee. Combined with the launch_session_id (a
+    // per-process counter starting at 1), this gives every session
+    // a string that is unique across luminalshine.exe restarts.
+    //
+    // Why this exists: launch_session_id alone resets to 1 on every
+    // restart, so the second run's first session would collide with
+    // the persisted "1.json" the monitor rehydrates at startup. The
+    // collision presented in the UI as "duplicate of the original
+    // session, no new sessions ever appearing" because each new
+    // stream silently overwrote the persisted record under the same
+    // id. The epoch prefix is opaque to the rest of the code — the
+    // service treats id as a free-form string key, the Web UI passes
+    // it through encodeURIComponent, and disk filenames are <id>.json
+    // which copes fine with the embedded hyphen.
+    //
+    // Legacy persisted sessions written with the pure-integer ID
+    // remain readable: their map key is "1" / "2" / ..., the new
+    // format's key always contains a hyphen, so the two namespaces
+    // can never collide as map keys.
+    static const std::string prefix = []() {
+      const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::system_clock::now().time_since_epoch()
+                      ).count();
+      return std::to_string(ms);
+    }();
+    return prefix + "-" + std::to_string(launch_session_id);
   }
 
   void session_started(const std::string &id, const SessionMetadata &md) {


### PR DESCRIPTION
## Stable per-process unique session IDs (PR 2 of 3)

Second of three independent fixes for the live session monitor (see #40 and the upcoming #42).

### Bug
`session_mon::make_id(launch_session_id)` in [`src/session_monitor_client.cpp`](https://github.com/NortheBridge/luminalshine/blob/main/src/session_monitor_client.cpp) returned the launch session id as a bare decimal string. `launch_session_id` is a counter inside `rtsp_stream::launch_session_t` that **resets to 1 on every `luminalshine.exe` restart**, so the second run's first stream produces `id="1"` — colliding with the persisted `1.json` the monitor sidecar rehydrates from `%ProgramData%\LuminalShine\sessions\` at startup.

In the UI this presented as:

- The "Live" row for the new stream replaced the previously-ended `1` record's metadata in place — looking like a duplicate of the original ended session.
- Every subsequent stream within the same restarted process used ids `2, 3, …` which collided with the persisted `2.json` / `3.json` chain, so the dashboard never grew past the original count; new streams kept silently overwriting rehydrated records under the same map key.

### Fix
Prefix the launch session id with the unix-epoch milliseconds captured **once** at process startup (static-local-init guarantees a single sample reused for every call). Format: `<epoch_ms>-<launch_id>`.

| Property | Behavior |
|---|---|
| Same call within one process | Same id (the prefix is cached in a `static const std::string`) |
| Across `luminalshine.exe` restarts | Different prefix → no possible collision |
| Vs. legacy pure-integer ids | Always disjoint (legacy ids never contain `-`) → no migration needed |
| Vs. encodings | Web UI passes `id` through `encodeURIComponent`; on-disk filenames are `<id>.json` — both cope with the embedded hyphen |

### Verification
- Compiles clean locally; brace/paren balance unchanged.
- `make_id()`'s signature and return-type contract are unchanged — every call site (`session_started`, `sample`, `session_ended`) continues to work without modification.
- The C++ build runs in `Windows-AMD64 Coverage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
