### PR TITLE
docs: light Microsoft Learn redesign of the Furo site (Aurora Blue)

### DIFF
--- a/docs/_static/breadcrumbs.js
+++ b/docs/_static/breadcrumbs.js
@@ -1,0 +1,147 @@
+/*
+ * LuminalShine docs — Microsoft Learn-style breadcrumb trail.
+ *
+ * Furo has no breadcrumb, so we synthesize one client-side from the
+ * rendered DOM: Home / <section caption> / <page title>. This is
+ * deliberately defensive — every lookup is guarded and any failure
+ * leaves the page untouched rather than throwing, so a Furo markup
+ * change can never break the docs render.
+ */
+(function () {
+  "use strict";
+
+  function ready(fn) {
+    if (document.readyState !== "loading") {
+      fn();
+    } else {
+      document.addEventListener("DOMContentLoaded", fn);
+    }
+  }
+
+  // The top-level <ul> that holds the current page lives directly under
+  // .sidebar-tree, immediately preceded by its <p class="caption">.
+  function sectionCaptionFor(currentLink) {
+    var el = currentLink;
+    while (
+      el &&
+      !(
+        el.tagName === "UL" &&
+        el.parentElement &&
+        el.parentElement.classList.contains("sidebar-tree")
+      )
+    ) {
+      el = el.parentElement;
+    }
+    if (!el) {
+      return null;
+    }
+    var prev = el.previousElementSibling;
+    if (prev && prev.classList && prev.classList.contains("caption")) {
+      var text = prev.querySelector(".caption-text") || prev;
+      var value = (text.textContent || "").trim();
+      return value || null;
+    }
+    return null;
+  }
+
+  function pageTitle(article) {
+    var h1 = article.querySelector("h1");
+    if (!h1) {
+      return null;
+    }
+    // Clone so we can drop Furo's "¶" headerlink before reading text.
+    var clone = h1.cloneNode(true);
+    clone.querySelectorAll(".headerlink").forEach(function (n) {
+      n.remove();
+    });
+    return (clone.textContent || "").trim() || null;
+  }
+
+  function makeSep() {
+    var sep = document.createElement("span");
+    sep.className = "ls-breadcrumb-sep";
+    sep.setAttribute("aria-hidden", "true");
+    sep.textContent = "/";
+    return sep;
+  }
+
+  function build() {
+    try {
+      var article =
+        document.querySelector("article[role='main']") ||
+        document.querySelector(".content article") ||
+        document.querySelector("article");
+      if (!article || article.querySelector(".ls-breadcrumb")) {
+        return;
+      }
+
+      var items = [];
+
+      // Home — reuse the sidebar brand link so the relative href is
+      // always correct regardless of page depth.
+      var brand = document.querySelector("a.sidebar-brand");
+      var homeText = "LuminalShine";
+      if (brand) {
+        var brandText = brand.querySelector(".sidebar-brand-text");
+        if (brandText && brandText.textContent.trim()) {
+          homeText = brandText.textContent.trim();
+        }
+        items.push({ text: homeText, href: brand.getAttribute("href") });
+      } else {
+        items.push({ text: homeText, href: null });
+      }
+
+      // Section caption (from the current item in the sidebar tree).
+      var currentLink =
+        document.querySelector(".sidebar-tree .current-page > a.reference") ||
+        document.querySelector(".sidebar-tree a.reference.current") ||
+        document.querySelector(".sidebar-tree .current > a.reference");
+      if (currentLink) {
+        var caption = sectionCaptionFor(currentLink);
+        if (caption) {
+          items.push({ text: caption, href: null });
+        }
+      }
+
+      // Current page title (non-link).
+      var title = pageTitle(article);
+      if (title) {
+        items.push({ text: title, href: null, current: true });
+      }
+
+      // Nothing meaningful beyond Home (e.g. the landing page) — skip.
+      if (items.length <= 1) {
+        return;
+      }
+
+      var nav = document.createElement("nav");
+      nav.className = "ls-breadcrumb";
+      nav.setAttribute("aria-label", "Breadcrumb");
+
+      items.forEach(function (item, i) {
+        if (i > 0) {
+          nav.appendChild(makeSep());
+        }
+        var node;
+        if (item.href && !item.current) {
+          node = document.createElement("a");
+          node.setAttribute("href", item.href);
+        } else {
+          node = document.createElement("span");
+          if (item.current) {
+            node.className = "ls-breadcrumb-current";
+            node.setAttribute("aria-current", "page");
+          }
+        }
+        node.textContent = item.text;
+        nav.appendChild(node);
+      });
+
+      article.insertBefore(nav, article.firstChild);
+    } catch (e) {
+      /* never break the page over a breadcrumb */
+    }
+  }
+
+  ready(build);
+})();

--- a/docs/_static/luminalshine.css
+++ b/docs/_static/luminalshine.css
@@ -1,160 +1,418 @@
 /*
- * LuminalShine Sphinx (Furo) overrides — NortheBridge aurora palette.
- * Matches https://gitdocs.northebridge.com/luminalshine.
+ * LuminalShine Sphinx (Furo) overrides — light, Microsoft Learn-style.
  *
- * Most colors are wired through Furo's CSS variables in conf.py; this
- * file adds the radial aurora backdrop, Inter webfont, and a few
- * accent-on-black niceties that Furo doesn't expose as variables.
+ * Models the learn.microsoft.com reading experience: white surfaces,
+ * Segoe UI typography, generous whitespace, a breadcrumb trail, an
+ * "In this article" rail, and clean cards/tables/admonitions.
+ *
+ * NortheBridge branding is preserved through "Aurora Blue": the royal
+ * blue (--ls-blue-2, #4a7dff) carries links and accents, and the
+ * cyan->blue duo (--ls-blue-1 -> --ls-blue-2) carries brand elements
+ * such as the site title. The old aurora-3 violet is retired — every
+ * spot that used purple now uses Aurora Blue.
+ *
+ * Most colors flow through Furo's CSS variables set in conf.py; this
+ * file adds the typographic polish and structural pieces Furo doesn't
+ * expose as variables.
  */
-
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
 
 :root,
 body,
 body[data-theme="light"],
 body[data-theme="dark"] {
-  --ls-bg-base: #04060f;
-  --ls-bg-deep: #070b1f;
-  --ls-blue-1: #1ec8ff;
-  --ls-blue-2: #4a7dff;
-  --ls-violet: #8a5cff;
-  --ls-teal:   #00e0c6;
-  --ls-text:   #f3f6ff;
-  --ls-border: rgba(255, 255, 255, 0.12);
+  --ls-page:        #ffffff;
+  --ls-surface:     #f7f9fc;
+  --ls-surface-alt: #eef2f8;
+  --ls-text:        #1b1f24;
+  --ls-text-2:      #4a5563;
+  --ls-muted:       #6b7280;
+  --ls-border:      #e3e8ef;
+  --ls-border-2:    #d4dae3;
+  --ls-blue-1:      #1ec8ff; /* aurora-1, cyan — brand duo start */
+  --ls-blue-2:      #4a7dff; /* aurora-2, "Aurora Blue" — links/accents */
+  --ls-blue-hover:  #2f5fe0;
+  --ls-accent-soft: #eef3ff;
+
+  --ls-green:  #2e7d32;
+  --ls-amber:  #b86e00;
+  --ls-red:    #d13438;
+
+  --ls-radius: 8px;
+  --ls-shadow-sm: 0 1px 2px rgba(16, 24, 40, 0.06);
+  --ls-shadow-md: 0 4px 14px rgba(16, 24, 40, 0.10);
 }
 
-/* Aurora gradient backdrop — same recipe as the gh-pages site */
+/* ----------------------------------------------------------------------
+ * Base surface + typography
+ * -------------------------------------------------------------------- */
+
 body {
-  background-color: var(--ls-bg-base);
-  position: relative;
+  background-color: var(--ls-page);
+  color: var(--ls-text);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  line-height: 1.6;
 }
 
+/* The old dark aurora gradient backdrop is gone — Learn is flat white. */
 body::before {
-  content: "";
-  position: fixed;
-  inset: -20%;
-  z-index: -2;
-  pointer-events: none;
-  background:
-    radial-gradient(ellipse 60% 50% at 15% 20%, rgba(30, 200, 255, 0.28), transparent 60%),
-    radial-gradient(ellipse 50% 45% at 85% 15%, rgba(138, 92, 255, 0.22), transparent 60%),
-    radial-gradient(ellipse 70% 55% at 50% 95%, rgba(0, 224, 198, 0.16), transparent 65%),
-    radial-gradient(ellipse 45% 40% at 90% 80%, rgba(74, 125, 255, 0.22), transparent 60%),
-    linear-gradient(180deg, var(--ls-bg-deep) 0%, var(--ls-bg-base) 100%);
-  filter: blur(40px) saturate(125%);
+  content: none !important;
 }
 
-/* Keep content surfaces readable on top of the aurora */
+/* This is a light-only site; hide Furo's light/dark toggle. */
+.theme-toggle-container,
+.theme-toggle {
+  display: none !important;
+}
+
+/* Keep content surfaces flat (drop the dark glassmorphism). */
 .sidebar-drawer,
-.content,
 .toc-drawer {
-  background-color: rgba(7, 11, 31, 0.72);
-  backdrop-filter: blur(18px) saturate(160%);
-  -webkit-backdrop-filter: blur(18px) saturate(160%);
+  background-color: var(--ls-page);
 }
 
-/* Brand mark / site title */
-.sidebar-brand-text {
-  background: linear-gradient(135deg, var(--ls-blue-1), var(--ls-violet));
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
+.content {
+  background-color: var(--ls-page);
+}
+
+article {
+  font-size: 1rem;
+}
+
+/* ----------------------------------------------------------------------
+ * Headings — clean and solid, Learn-style hierarchy (no gradient H1)
+ * -------------------------------------------------------------------- */
+
+h1, h2, h3, h4, h5, h6 {
+  color: var(--ls-text);
   font-weight: 600;
   letter-spacing: -0.01em;
 }
 
-/* Headings get a subtle cyan tint, links the brand blue */
-h1, h2, h3, h4, h5, h6 {
-  color: var(--ls-text);
-  letter-spacing: -0.015em;
+h1 {
+  font-size: 2.1rem;
+  line-height: 1.2;
+  margin-bottom: 0.6em;
 }
 
-h1 {
-  background: linear-gradient(135deg, var(--ls-text) 0%, var(--ls-blue-1) 100%);
+h2 {
+  font-size: 1.5rem;
+  margin-top: 1.8em;
+  padding-top: 0.6em;
+  border-top: 1px solid var(--ls-border);
+}
+
+h3 { font-size: 1.2rem; }
+
+/* ----------------------------------------------------------------------
+ * Links
+ * -------------------------------------------------------------------- */
+
+a {
+  color: var(--ls-blue-2);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--ls-blue-hover);
+  text-decoration: underline;
+  text-decoration-color: rgba(74, 125, 255, 0.5);
+}
+
+/* ----------------------------------------------------------------------
+ * Sidebar — brand duo title + Learn-style nav
+ * -------------------------------------------------------------------- */
+
+.sidebar-brand-text {
+  /* Brand duo: cyan -> Aurora Blue (deepened cyan keeps it legible on
+     white). This is the only place the cyan end of the duo appears. */
+  background: linear-gradient(135deg, #109fe0 0%, var(--ls-blue-2) 100%);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
+  font-weight: 700;
+  letter-spacing: -0.02em;
 }
 
-a, .toctree-l1 > a:hover {
-  text-decoration-color: rgba(30, 200, 255, 0.4);
+.sidebar-drawer {
+  border-right: 1px solid var(--ls-border);
 }
 
-/* Inline + block code blocks */
-code.literal {
-  background: rgba(30, 200, 255, 0.10);
-  border: 1px solid rgba(30, 200, 255, 0.22);
-  border-radius: 4px;
-  padding: 0.05em 0.35em;
-  color: var(--ls-blue-1);
+.sidebar-tree .caption {
+  color: var(--ls-muted);
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
 }
 
-.highlight, pre {
-  background: rgba(7, 11, 31, 0.85) !important;
-  border: 1px solid var(--ls-border);
-  border-radius: 8px;
-}
-
-/* Buttons / admonitions / search */
-.sidebar-search,
-.sidebar-search:focus,
-.sidebar-search-container input[type="search"] {
-  background-color: rgba(7, 11, 31, 0.6);
-  border: 1px solid var(--ls-border);
-  color: var(--ls-text);
-}
-
-.admonition {
-  border-left: 3px solid var(--ls-blue-1);
-  background-color: rgba(7, 11, 31, 0.7);
+.sidebar-tree .reference {
   border-radius: 6px;
 }
 
+/* Selected page gets an Aurora-Blue rail, Learn-style. */
+.sidebar-tree .current-page > .reference {
+  font-weight: 600;
+  color: var(--ls-blue-2);
+  box-shadow: inset 3px 0 0 var(--ls-blue-2);
+}
+
+/* ----------------------------------------------------------------------
+ * Breadcrumb (injected by breadcrumbs.js)
+ * -------------------------------------------------------------------- */
+
+.ls-breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0 0 1.4rem;
+  font-size: 0.82rem;
+  color: var(--ls-muted);
+}
+
+.ls-breadcrumb a {
+  color: var(--ls-text-2);
+}
+
+.ls-breadcrumb a:hover {
+  color: var(--ls-blue-2);
+  text-decoration: none;
+}
+
+.ls-breadcrumb .ls-breadcrumb-sep {
+  color: var(--ls-border-2);
+  user-select: none;
+}
+
+.ls-breadcrumb .ls-breadcrumb-current {
+  color: var(--ls-text);
+  font-weight: 500;
+}
+
+/* ----------------------------------------------------------------------
+ * "In this article" right-hand rail
+ * -------------------------------------------------------------------- */
+
+.toc-drawer {
+  border-left: 1px solid var(--ls-border);
+}
+
+.toc-title {
+  /* Relabel Furo's "Contents" to Microsoft Learn's "In this article". */
+  color: var(--ls-text);
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: 0;
+  visibility: hidden;
+  position: relative;
+}
+
+.toc-title::after {
+  content: "In this article";
+  visibility: visible;
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+.toc-tree {
+  font-size: 0.85rem;
+  border-left: 1px solid var(--ls-border);
+}
+
+.toc-tree li.scroll-current > .reference {
+  color: var(--ls-blue-2);
+  font-weight: 600;
+  box-shadow: inset 2px 0 0 var(--ls-blue-2);
+}
+
+/* ----------------------------------------------------------------------
+ * Inline + block code
+ * -------------------------------------------------------------------- */
+
+code.literal {
+  background: var(--ls-surface-alt);
+  border: 1px solid var(--ls-border);
+  border-radius: 4px;
+  padding: 0.1em 0.38em;
+  font-size: 0.88em;
+  color: #1b1f24;
+}
+
+.highlight,
+pre {
+  background: var(--ls-surface) !important;
+  border: 1px solid var(--ls-border);
+  border-radius: var(--ls-radius);
+}
+
+.highlight {
+  box-shadow: var(--ls-shadow-sm);
+}
+
+/* ----------------------------------------------------------------------
+ * Search box
+ * -------------------------------------------------------------------- */
+
+.sidebar-search,
+.sidebar-search:focus,
+.sidebar-search-container input[type="search"] {
+  background-color: var(--ls-page);
+  border: 1px solid var(--ls-border-2);
+  border-radius: 6px;
+  color: var(--ls-text);
+}
+
+.sidebar-search:focus {
+  border-color: var(--ls-blue-2);
+  box-shadow: 0 0 0 2px rgba(74, 125, 255, 0.2);
+}
+
+/* ----------------------------------------------------------------------
+ * Admonitions — Microsoft Learn note/tip/important/warning boxes
+ * -------------------------------------------------------------------- */
+
+.admonition,
+div.admonition {
+  border: 1px solid var(--ls-border);
+  border-left: 4px solid var(--ls-blue-2);
+  background-color: var(--ls-accent-soft);
+  border-radius: var(--ls-radius);
+  box-shadow: none;
+}
+
+.admonition > .admonition-title {
+  font-weight: 600;
+  background: transparent;
+}
+
 .admonition.note,
-.admonition.tip,
-.admonition.hint {
-  border-left-color: var(--ls-blue-1);
+.admonition.hint,
+.admonition.seealso,
+.admonition.important {
+  border-left-color: var(--ls-blue-2);
+  background-color: var(--ls-accent-soft);
+}
+
+.admonition.tip {
+  border-left-color: var(--ls-green);
+  background-color: #eef7ee;
 }
 
 .admonition.warning,
-.admonition.caution {
-  border-left-color: #ffb454;
+.admonition.caution,
+.admonition.attention {
+  border-left-color: var(--ls-amber);
+  background-color: #fff6e9;
 }
 
 .admonition.danger,
 .admonition.error {
-  border-left-color: #ff6b6b;
+  border-left-color: var(--ls-red);
+  background-color: #fdeded;
 }
 
-/* Tables */
+/* ----------------------------------------------------------------------
+ * Tables — Learn-style: light header, row separators, no heavy chrome
+ * -------------------------------------------------------------------- */
+
 table.docutils {
   border: 1px solid var(--ls-border);
-  border-radius: 6px;
+  border-radius: var(--ls-radius);
+  border-collapse: separate;
+  border-spacing: 0;
   overflow: hidden;
+  box-shadow: var(--ls-shadow-sm);
 }
 
 table.docutils thead {
-  background: rgba(30, 200, 255, 0.08);
+  background: var(--ls-surface);
 }
 
 table.docutils th {
-  color: var(--ls-blue-1);
+  color: var(--ls-text);
   font-weight: 600;
   letter-spacing: 0.01em;
+  border-bottom: 1px solid var(--ls-border-2);
 }
 
-/* Selection */
-::selection {
-  background: rgba(30, 200, 255, 0.35);
+table.docutils td,
+table.docutils th {
+  border-color: var(--ls-border);
+}
+
+table.docutils tbody tr:hover {
+  background: var(--ls-surface);
+}
+
+/* ----------------------------------------------------------------------
+ * Cards (sphinx-design) — Microsoft Learn landing tiles
+ * -------------------------------------------------------------------- */
+
+.sd-card {
+  border: 1px solid var(--ls-border) !important;
+  border-radius: var(--ls-radius) !important;
+  background: var(--ls-page) !important;
+  box-shadow: var(--ls-shadow-sm);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease,
+    transform 0.15s ease;
+}
+
+.sd-card:hover {
+  border-color: var(--ls-blue-2) !important;
+  box-shadow: var(--ls-shadow-md);
+  transform: translateY(-2px);
+}
+
+.sd-card .sd-card-title {
+  font-weight: 600;
   color: var(--ls-text);
 }
 
-/* Scrollbar polish */
-::-webkit-scrollbar { width: 10px; height: 10px; }
-::-webkit-scrollbar-track { background: var(--ls-bg-base); }
+.sd-card .sd-card-body {
+  color: var(--ls-text-2);
+}
+
+/* Card-as-link: keep the whole tile neutral, accent on hover. */
+.sd-card a.sd-stretched-link,
+.sd-card a.sd-stretched-link:hover {
+  text-decoration: none;
+}
+
+/* ----------------------------------------------------------------------
+ * Buttons (sphinx-design) — Aurora Blue primary
+ * -------------------------------------------------------------------- */
+
+.sd-btn-primary,
+.sd-btn-outline-primary:hover {
+  background-color: var(--ls-blue-2) !important;
+  border-color: var(--ls-blue-2) !important;
+  color: #fff !important;
+}
+
+.sd-btn-primary:hover {
+  background-color: var(--ls-blue-hover) !important;
+  border-color: var(--ls-blue-hover) !important;
+}
+
+/* ----------------------------------------------------------------------
+ * Selection + scrollbar (Aurora Blue, no purple)
+ * -------------------------------------------------------------------- */
+
+::selection {
+  background: rgba(74, 125, 255, 0.22);
+  color: var(--ls-text);
+}
+
+::-webkit-scrollbar { width: 12px; height: 12px; }
+::-webkit-scrollbar-track { background: var(--ls-surface); }
 ::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, var(--ls-blue-2), var(--ls-violet));
-  border-radius: 5px;
+  background: var(--ls-border-2);
+  border: 3px solid var(--ls-surface);
+  border-radius: 7px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--ls-blue-2);
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,11 @@
 """Sphinx configuration for LuminalShine.
 
-Tunes the Furo theme to the NortheBridge "aurora" palette so the rendered
-docs match https://gitdocs.northebridge.com/luminalshine: a near-black
-background with cyan (#1ec8ff) and royal-blue (#4a7dff) accents on Inter.
+Tunes the Furo theme to a light, content-first layout modelled on
+Microsoft Learn (learn.microsoft.com): white surfaces, Segoe UI
+typography, generous whitespace, breadcrumbs and an "In this article"
+rail. NortheBridge branding is preserved through "Aurora Blue" — the
+royal-blue #4a7dff link/accent and the cyan->blue brand duo — used
+wherever the old dark theme leaned on purple/violet.
 """
 
 from __future__ import annotations
@@ -85,63 +88,78 @@ html_theme = "furo"
 html_title = "LuminalShine"
 html_static_path = ["_static"]
 html_css_files = ["luminalshine.css"]
+html_js_files = ["breadcrumbs.js"]
 
-# Aurora palette from gitdocs.northebridge.com/luminalshine/assets/css/site.css
-_AURORA = {
-    "bg_base": "#04060f",
-    "bg_deep": "#070b1f",
-    "blue_primary": "#1ec8ff",   # --aurora-1, cyan-blue
-    "blue_secondary": "#4a7dff", # --aurora-2, royal blue
-    "violet": "#8a5cff",         # --aurora-3
-    "teal": "#00e0c6",           # --aurora-4
-    "text_primary": "#f3f6ff",
-    "text_secondary": "rgba(225, 232, 255, 0.78)",
-    "text_muted": "rgba(180, 195, 230, 0.65)",
-    "border": "rgba(255, 255, 255, 0.12)",
-    "glass": "rgba(20, 30, 60, 0.55)",
+# Microsoft Learn-style light palette with NortheBridge "Aurora Blue"
+# branding. The cyan/blue values are the aurora-1/aurora-2 brand colors;
+# aurora-3 (violet/#8a5cff) is intentionally retired — every spot that
+# used purple now uses Aurora Blue.
+_PALETTE = {
+    "page_bg": "#ffffff",
+    "surface": "#f7f9fc",          # sidebar / toc rail surface
+    "surface_alt": "#eef2f8",      # hover, code-block chrome
+    "text": "#1b1f24",
+    "text_secondary": "#4a5563",
+    "text_muted": "#6b7280",
+    "border": "#e3e8ef",
+    "aurora_cyan": "#1ec8ff",      # aurora-1 — brand duo start
+    "aurora_blue": "#4a7dff",      # aurora-2 — "Aurora Blue", links/accents
+    "aurora_blue_hover": "#2f5fe0",
+    "accent_soft": "#eef3ff",      # selected nav item / note tint
 }
 
+# Segoe UI first to match the Microsoft Learn reading experience; system
+# fallbacks keep it native on non-Windows visitors.
 _FONT_STACK = (
-    '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI Variable", '
-    '"Segoe UI", system-ui, sans-serif'
+    '"Segoe UI Variable Text", "Segoe UI", -apple-system, '
+    'BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", Arial, '
+    "sans-serif"
 )
 _MONO_STACK = (
-    '"JetBrains Mono", "Fira Code", SFMono-Regular, Menlo, '
-    "Consolas, monospace"
+    '"Cascadia Code", "Cascadia Mono", SFMono-Regular, Menlo, '
+    'Consolas, "Liberation Mono", monospace'
 )
 
+# Light syntax highlighting in BOTH modes. Combined with identical
+# light/dark CSS variables below, this pins the site to the light
+# Microsoft Learn look regardless of the visitor's OS dark-mode
+# preference (Furo would otherwise swap in a dark Pygments sheet).
+pygments_style = "friendly"
+pygments_dark_style = "friendly"
+
 _furo_vars = {
-    "color-brand-primary": _AURORA["blue_primary"],
-    "color-brand-content": _AURORA["blue_primary"],
-    "color-background-primary": _AURORA["bg_base"],
-    "color-background-secondary": _AURORA["bg_deep"],
-    "color-background-hover": _AURORA["glass"],
-    "color-background-border": _AURORA["border"],
-    "color-foreground-primary": _AURORA["text_primary"],
-    "color-foreground-secondary": _AURORA["text_secondary"],
-    "color-foreground-muted": _AURORA["text_muted"],
-    "color-foreground-border": _AURORA["border"],
-    "color-link": _AURORA["blue_primary"],
-    "color-link--hover": _AURORA["blue_secondary"],
+    "color-brand-primary": _PALETTE["aurora_blue"],
+    "color-brand-content": _PALETTE["aurora_blue"],
+    "color-background-primary": _PALETTE["page_bg"],
+    "color-background-secondary": _PALETTE["surface"],
+    "color-background-hover": _PALETTE["surface_alt"],
+    "color-background-border": _PALETTE["border"],
+    "color-foreground-primary": _PALETTE["text"],
+    "color-foreground-secondary": _PALETTE["text_secondary"],
+    "color-foreground-muted": _PALETTE["text_muted"],
+    "color-foreground-border": _PALETTE["border"],
+    "color-link": _PALETTE["aurora_blue"],
+    "color-link--hover": _PALETTE["aurora_blue_hover"],
     "color-link-underline": "transparent",
-    "color-link-underline--hover": _AURORA["blue_secondary"],
-    "color-highlight-on-target": "rgba(30, 200, 255, 0.18)",
-    "color-api-background": _AURORA["bg_deep"],
-    "color-api-background-hover": _AURORA["glass"],
-    "color-admonition-background": _AURORA["bg_deep"],
-    "color-sidebar-background": _AURORA["bg_deep"],
-    "color-sidebar-background-border": _AURORA["border"],
-    "color-sidebar-link-text": _AURORA["text_secondary"],
-    "color-sidebar-link-text--top-level": _AURORA["text_primary"],
-    "color-sidebar-item-background--current": _AURORA["glass"],
-    "color-sidebar-item-background--hover": _AURORA["glass"],
+    "color-link-underline--hover": _PALETTE["aurora_blue_hover"],
+    "color-highlight-on-target": "rgba(74, 125, 255, 0.12)",
+    "color-api-background": _PALETTE["surface"],
+    "color-api-background-hover": _PALETTE["surface_alt"],
+    "color-admonition-background": _PALETTE["page_bg"],
+    "color-sidebar-background": _PALETTE["page_bg"],
+    "color-sidebar-background-border": _PALETTE["border"],
+    "color-sidebar-link-text": _PALETTE["text_secondary"],
+    "color-sidebar-link-text--top-level": _PALETTE["text"],
+    "color-sidebar-item-background--current": _PALETTE["accent_soft"],
+    "color-sidebar-item-background--hover": _PALETTE["surface_alt"],
     "font-stack": _FONT_STACK,
     "font-stack--monospace": _MONO_STACK,
 }
 
 html_theme_options = {
-    # Force the dark aurora look in both modes — the upstream site is
-    # dark-only and the cyan accents are tuned for a black background.
+    # Force the light Microsoft Learn look in both modes — Aurora Blue
+    # accents are tuned for a white background and the theme toggle is
+    # hidden in luminalshine.css.
     "light_css_variables": _furo_vars,
     "dark_css_variables": _furo_vars,
     "sidebar_hide_name": False,


### PR DESCRIPTION
Restyles the Read the Docs (Furo) site from the dark "aurora" theme to a light, content-first layout modelled on [learn.microsoft.com](https://learn.microsoft.com/en-us/azure/app-service/overview), keeping NortheBridge branding via **Aurora Blue**.

## Changes
- **conf.py** — light Furo palette (white surfaces, `#1b1f24` text), **Segoe UI** font stack, royal-blue `#4a7dff` (aurora-2 / "Aurora Blue") links & accents. Forces light in both OS modes and pins Pygments to a light style so code never renders dark.
- **luminalshine.css** — full rewrite for the light look: drops the dark backdrop/glassmorphism, hides the theme toggle, and adds MS-Learn styling for nav, the **"In this article"** rail, **breadcrumbs**, code, admonitions (note/tip/important/warning/danger), tables, **landing card tiles**, buttons, selection, scrollbar. Brand cyan→Aurora-Blue duo kept only on the site title; H1s solid. **aurora-3 violet retired** — every former purple accent is now Aurora Blue.
- **breadcrumbs.js** — defensive client-side breadcrumb trail (Home / Section / Page) from the DOM; fully guarded so it can never break the render.

## Verification
Clean `sphinx -b html` build; both static assets are emitted and wired into pages, Pygments resolves to the light style, no `#8a5cff` remains. Pixel-level rendering not screenshotted in CI — preview via `python -m sphinx -b html docs docs/_build`.

## Notes
- Scope is the Furo (RTD) site; the separate Doxygen `/api/` browser (`docs/doc-styles.css`) is unchanged.
- Judgment calls: light-only (toggle hidden), solid H1s, JS-injected breadcrumb (no-JS → no breadcrumb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)