### PR TITLE
fix(video): survive a wedged display stack instead of aborting the host (rc7)

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -3567,7 +3567,10 @@ namespace video {
 #endif
   }
 
-  int probe_encoders() {
+  // Internal probe body — never call directly; go through probe_encoders(),
+  // which converts any thrown C++ exception into a probe failure so a wedged
+  // display stack can't fast-fail the SYSTEM service. See probe_encoders().
+  static int probe_encoders_impl() {
     std::lock_guard<std::mutex> lock(encoder_probe_mutex);
     const auto cache_key = build_probe_cache_key();
     const bool hevc_mode_auto = config::video.hevc_mode == 0;
@@ -3804,6 +3807,40 @@ namespace video {
 
     restore_previous_probe_state.disable();
     return 0;
+  }
+
+  /**
+   * @brief Probe available encoders; treat any thrown exception as a probe
+   *        failure rather than letting it abort the process.
+   *
+   * probe_encoders_impl() drives D3D11 device creation, NVENC init and
+   * virtual-display acquisition. On Windows those paths can throw C++
+   * exceptions (e.g. std::bad_alloc / std::system_error from the display,
+   * threading or STL code) when the display stack is wedged — no enumerable
+   * monitors, a SudoVDA enumerate timeout, or a sustained
+   * DXGI_ERROR_DEVICE_REMOVED loop. The per-encoder probe shield is SEH-only
+   * on Windows, so such a C++ exception would unwind out of whichever thread
+   * ran the probe (startup, the nvhttp/RTSP control thread, or the WebRTC
+   * signaling thread) and fast-fail the entire SYSTEM service via
+   * std::terminate (STATUS_STACK_BUFFER_OVERRUN, 0xC0000409) — seen in the
+   * field as "LuminalShine crashed and never came back, screen left blank".
+   *
+   * Returning the existing failure sentinel (-1) instead lets every caller
+   * take its graceful no-display path (log, wait for display activation,
+   * retry) and keeps the daemon alive.
+   */
+  int probe_encoders() {
+    try {
+      return probe_encoders_impl();
+    } catch (const std::exception &e) {
+      BOOST_LOG(error) << "Encoder probe aborted by an exception: "sv << e.what()
+                       << " — treating as probe failure so the host stays up."sv;
+      return -1;
+    } catch (...) {
+      BOOST_LOG(error) << "Encoder probe aborted by an unknown exception — "
+                          "treating as probe failure so the host stays up."sv;
+      return -1;
+    }
   }
 
   // Linux only declaration

--- a/src/webrtc_stream.cpp
+++ b/src/webrtc_stream.cpp
@@ -2542,18 +2542,35 @@ namespace webrtc_stream {
         }
 #endif
 
-        if (video::probe_encoders()) {
+        // Capture/encoder acquisition runs on the WebRTC signaling thread.
+        // VDISPLAY::ensure_display() / cleanup_ensure_display() can throw
+        // (std::system_error on the lock, std::bad_alloc) when the display
+        // stack is wedged, and probe_encoders() can fail for the same reason.
+        // An escape here would unwind the signaling thread and fast-fail the
+        // SYSTEM service (0xC0000409). Refuse the session instead — keep the
+        // host alive so the client can retry once the display recovers.
+        try {
+          if (video::probe_encoders()) {
 #ifdef _WIN32
-          // If probe failed, try ensuring a display is available for headless systems
-          auto ensure_result = VDISPLAY::ensure_display();
-          bool retry_failed = ensure_result.success ? video::probe_encoders() : true;
-          VDISPLAY::cleanup_ensure_display(ensure_result, !retry_failed);
-          if (retry_failed) {
-            return std::string {"Failed to initialize video capture/encoding. Is a display connected and turned on?"};
-          }
+            // If probe failed, try ensuring a display is available for headless systems
+            auto ensure_result = VDISPLAY::ensure_display();
+            bool retry_failed = ensure_result.success ? video::probe_encoders() : true;
+            VDISPLAY::cleanup_ensure_display(ensure_result, !retry_failed);
+            if (retry_failed) {
+              return std::string {"Failed to initialize video capture/encoding. Is a display connected and turned on?"};
+            }
 #else
-          return std::string {"Failed to initialize video capture/encoding. Is a display connected and turned on?"};
+            return std::string {"Failed to initialize video capture/encoding. Is a display connected and turned on?"};
 #endif
+          }
+        } catch (const std::exception &e) {
+          BOOST_LOG(error) << "WebRTC capture start: display/encoder acquisition threw (" << e.what()
+                           << "); refusing the session instead of aborting the host.";
+          return std::string {"Failed to initialize video capture/encoding. Is a display connected and turned on?"};
+        } catch (...) {
+          BOOST_LOG(error) << "WebRTC capture start: display/encoder acquisition threw an unknown "
+                              "exception; refusing the session instead of aborting the host.";
+          return std::string {"Failed to initialize video capture/encoding. Is a display connected and turned on?"};
         }
       }
 


### PR DESCRIPTION
**Target: 26.05.0-rc7.**

## Problem
A `luminalshine.exe` process died with **`0xC0000409` (fast-fail / `std::terminate`)** in `ucrtbase.dll`, and **did not recover** — monitors went blank and the stream dropped (the client's "TLS error" was just the control connection being torn when the host died; there are **no** TLS/cert errors in the host logs).

Crash-bundle logs show this was **not a GPU hardware TDR** (no `nvlddmkm` 4101 / Kernel-Power events). At startup the Windows display stack was wedged: `QueryDisplayConfig` → `ERROR_NOT_SUPPORTED`, **no enumerable monitors**, the **SudoVDA virtual display failed to enumerate** ("Timed out waiting for Windows to enumerate virtual display"), then `D3D11CreateDevice` looped on `0x887A0004` for ~5 min before the abort. Insider build 29613.

## Root cause
`probe_encoders()` is not `noexcept`, and its per-encoder shield is **SEH-only on Windows** — so a C++ exception (`std::bad_alloc` / `std::system_error` from the display/threading/STL paths) thrown when the display stack is wedged escapes the thread that ran the probe → `std::terminate` → fast-fail. The nvhttp paths already degrade gracefully ("no active display → wait for activation, retry"); the **WebRTC client-connect path** and the bare process exit on a thrown probe did not.

## Fix (probe/start side only)
- **video.cpp** — wrap `probe_encoders()` in a catch-all that returns the existing failure sentinel (`-1`); internal body moved to `probe_encoders_impl()`. This uniformly protects **all four** probe call sites (startup, nvhttp ×2, WebRTC) so a wedged display can never abort the daemon — every caller takes its graceful no-display path.
- **webrtc_stream.cpp** — wrap the WebRTC `ensure_display()`/`cleanup_ensure_display()` block (called directly, outside `probe_encoders`) in a barrier that refuses the session instead of aborting.

## Scope / boundary
Deliberately **minimal, not sweeping** — fresh-eyes localization (see analysis) pinned the gap, and broad edits to SYSTEM-privileged GPU/display code pre-Gold would risk regressions. **Does not touch** the serialized encoder teardown (`encoder_teardown_queue`/`encode_run`) or the NVENC drain/leak logic (`nvenc_base.cpp::destroy_encoder`) from the prior GPU PRs — both are on the teardown/drain path; this is on the probe/start path.

## Verification
Full **build + link succeeds** (`luminalshine.exe`, `test_sunshine`, web UI).

## What it does / doesn't do
- ✅ Host no longer **aborts / fails to recover** when the display stack or SudoVDA is wedged — it stays up, returns a clean error, and recovers when displays return.
- ❌ Does **not** fix the *trigger* (wedged display stack + SudoVDA enumerate failure on the Insider build). Environmental mitigation: switch **SudoVDA → MTT VDD**, and reboot to clear the wedged display API.

## Caveat
The exact terminate mechanism (non-`std::exception` throw vs. throw-during-unwind) couldn't be pinned without the Event Viewer faulting-module entry, but the `catch(...)` barriers close it regardless of which fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)