### PR TITLE
fix: stop leaking across display-wedge cycles + survive OOM gracefully (rc8)

### DIFF
--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -133,7 +133,26 @@ namespace audio {
     }
   }
 
+  static void capture_impl(safe::mail_t mail, config_t config, void *channel_data);
+
+  // Thread-top exception barrier. The audio capture loop allocates every
+  // iteration (PCM buffers, packets) on its own thread with no outer catch;
+  // under system-wide memory exhaustion a std::bad_alloc here would escape the
+  // thread and std::terminate the whole SYSTEM service (0xC0000409). Contain
+  // it: audio stops for this session, but the host stays up.
   void capture(safe::mail_t mail, config_t config, void *channel_data) {
+    try {
+      capture_impl(std::move(mail), std::move(config), channel_data);
+    } catch (const std::exception &e) {
+      BOOST_LOG(error) << "Audio capture thread terminated by exception: "sv << e.what()
+                       << " — audio stops for this session; the host stays up."sv;
+    } catch (...) {
+      BOOST_LOG(error) << "Audio capture thread terminated by an unknown exception — "
+                          "audio stops for this session; the host stays up."sv;
+    }
+  }
+
+  void capture_impl(safe::mail_t mail, config_t config, void *channel_data) {
     auto shutdown_event = mail->event<bool>(mail::shutdown);
     if (!config::audio.stream) {
       shutdown_event->view();

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -4360,6 +4360,22 @@ namespace confighttp {
         BOOST_LOG(fatal) << "Couldn't start Configuration HTTPS server on port ["sv << port_https << "]: "sv << err.what();
         shutdown_event->raise(true);
         return;
+      } catch (const std::exception &err) {
+        // Don't let std::bad_alloc (system-wide memory pressure) or any other
+        // exception escape this thread and std::terminate the host.
+        if (shutdown_event->peek()) {
+          return;
+        }
+        BOOST_LOG(fatal) << "Configuration HTTPS server thread terminated by exception: "sv << err.what();
+        shutdown_event->raise(true);
+        return;
+      } catch (...) {
+        if (shutdown_event->peek()) {
+          return;
+        }
+        BOOST_LOG(fatal) << "Configuration HTTPS server thread terminated by an unknown exception."sv;
+        shutdown_event->raise(true);
+        return;
       }
     };
     api_token_manager.load_api_tokens();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,8 @@
 #include <chrono>
 #include <codecvt>
 #include <csignal>
+#include <cstdlib>
+#include <exception>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -139,6 +141,28 @@ WINAPI BOOL ConsoleCtrlHandler(DWORD type) {
 
 int main(int argc, char *argv[]) {
   lifetime::argv = argv;
+
+  // Last-resort diagnostics: if any thread lets an exception escape (e.g.
+  // std::bad_alloc under system-wide memory exhaustion), log what it was
+  // before the runtime aborts, so a crash bundle explains the 0xC0000409
+  // instead of pointing only at ucrtbase. This cannot resume execution —
+  // per-thread catch barriers (audio capture, the HTTP run loops, the encoder
+  // probe) handle graceful degradation; this only makes the hard-abort case
+  // diagnosable.
+  std::set_terminate([]() {
+    if (auto active = std::current_exception()) {
+      try {
+        std::rethrow_exception(active);
+      } catch (const std::exception &e) {
+        BOOST_LOG(fatal) << "std::terminate: unhandled exception escaped a thread: " << e.what();
+      } catch (...) {
+        BOOST_LOG(fatal) << "std::terminate: unhandled non-standard exception escaped a thread.";
+      }
+    } else {
+      BOOST_LOG(fatal) << "std::terminate called with no active exception.";
+    }
+    std::abort();
+  });
 
   task_pool_util::TaskPool::task_id_t force_shutdown = nullptr;
 

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -2631,6 +2631,22 @@ namespace nvhttp {
         BOOST_LOG(fatal) << "Couldn't start http server on ports ["sv << port_https << ", "sv << port_https << "]: "sv << err.what();
         shutdown_event->raise(true);
         return;
+      } catch (const std::exception &err) {
+        // Any other exception (e.g. std::bad_alloc under system-wide memory
+        // pressure) must not escape this thread and std::terminate the host.
+        if (shutdown_event->peek()) {
+          return;
+        }
+        BOOST_LOG(fatal) << "nvhttp server thread terminated by exception: "sv << err.what();
+        shutdown_event->raise(true);
+        return;
+      } catch (...) {
+        if (shutdown_event->peek()) {
+          return;
+        }
+        BOOST_LOG(fatal) << "nvhttp server thread terminated by an unknown exception."sv;
+        shutdown_event->raise(true);
+        return;
       }
     };
     std::thread ssl {accept_and_run, &https_server};

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -472,10 +472,22 @@ namespace platf::dxgi {
       // previous attempt so we never accidentally release a half-built
       // device. D3D11CreateDevice itself zero-fills on entry, but only on
       // the happy path.
+      // Release (not merely null) anything a previous failed attempt left
+      // behind. On a mid-creation device-loss, D3D11CreateDevice can populate
+      // an out-param before returning failure, and these out-params write into
+      // util::safe_ptr raw slots — so overwriting with nullptr without
+      // releasing would orphan a full D3D11 device/context on every retry,
+      // an unbounded leak across a sustained TDR/device-removed wedge.
       if (device) {
+        if (*device) {
+          (*device)->Release();
+        }
         *device = nullptr;
       }
       if (context) {
+        if (*context) {
+          (*context)->Release();
+        }
         *context = nullptr;
       }
       if (feature_level) {

--- a/src/platform/windows/virtual_display.cpp
+++ b/src/platform/windows/virtual_display.cpp
@@ -2910,6 +2910,19 @@ namespace VDISPLAY {
     if (active_backend() == BackendType::MTT) {
       return mtt::initialize();
     }
+    // Idempotency: a prior driver handle may still be open — the recovery
+    // monitor and the several proc::initVDisplayDriver() call sites can
+    // re-enter while a handle is live. Overwriting SUDOVDA_DRIVER_HANDLE below
+    // would leak the old kernel handle on every call; across a multi-minute
+    // display wedge (repeated recovery attempts) that is an unbounded handle
+    // leak. Reuse a still-responsive handle; otherwise close it before
+    // re-opening.
+    if (SUDOVDA_DRIVER_HANDLE != INVALID_HANDLE_VALUE) {
+      if (driver_handle_responsive(SUDOVDA_DRIVER_HANDLE)) {
+        return DRIVER_STATUS::OK;
+      }
+      closeVDisplayDevice();
+    }
     uint32_t retryInterval = 20;
     bool attempted_recovery = false;
     while (true) {

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2407,6 +2407,23 @@ namespace video {
       }
       std::lock_guard lg {mutex};
       pending.push_back(std::move(session));
+      // Bound the backlog. During a sustained streaming reinit storm against a
+      // wedged GPU, each teardown can stall on its device-drain, so sessions
+      // can enqueue faster than the single worker drains them — each one
+      // pinning a D3D11 device + NVENC resources, feeding the process toward
+      // OOM. Cap the backlog and intentionally LEAK the oldest overflow:
+      // release ownership without destroying it, so we never run a concurrent
+      // destroy (the race this serializer exists to prevent) and never block
+      // the encode thread. A bounded per-storm leak is strictly preferable to
+      // unbounded growth.
+      constexpr std::size_t kMaxPendingTeardowns = 8;
+      while (pending.size() > kMaxPendingTeardowns) {
+        pending.front().release();  // intentional leak — must NOT destroy here
+        pending.pop_front();
+        BOOST_LOG(warning) << "Encoder teardown backlog exceeded "sv << kMaxPendingTeardowns
+                           << " (GPU teardown stalled); leaking oldest queued session to bound memory. "
+                              "Total teardown-overflow leaks this process: "sv << ++overflow_leaks << '.';
+      }
       if (!worker_active) {
         // enqueue() runs from a fail_guard destructor, so it must never throw
         // (that would std::terminate during stack unwinding). Set worker_active
@@ -2447,6 +2464,7 @@ namespace video {
     std::mutex mutex;
     std::deque<std::unique_ptr<encode_session_t>> pending;
     bool worker_active = false;
+    uint64_t overflow_leaks = 0;  // count of sessions leaked on backlog overflow
   };
 
   /**


### PR DESCRIPTION
**Target: rc8.**

## Background
A crash bundle captured a **system-wide out-of-memory event**: Explorer died with `STATUS_FATAL_MEMORY_EXHAUSTION`, two .NET apps with `OutOfMemoryException`, the game aborted, and `luminalshine.exe` fast-failed with `0xC0000409` (an uncaught `std::bad_alloc` → `std::terminate`). An audit of the GPU-display-wedge cycle found **two genuine unbounded leaks** LuminalShine accrues while the display stack stays wedged for minutes, plus **no thread-level exception barrier** anywhere. LuminalShine was a *secondary aggravator* of the OOM (the dominant consumer was almost certainly another process), but these are real and worth fixing.

## Leaks fixed (unbounded across wedge cycles)
- **`virtual_display.cpp` `openVDisplayDevice()`** re-opened the SudoVDA driver handle without closing the previous one → **one leaked kernel handle per recovery / `initVDisplayDriver` call**. Now idempotent: reuse a responsive handle, else close before re-opening.
- **`display_base.cpp` `D3D11CreateDeviceWithRecovery()`** nulled the `device`/`context` out-params at the top of each retry **without releasing** them → a partially-created D3D11 device/context (mid-creation device-loss) leaked **per retry**. Now released before nulling.

## Resilience (turn hard aborts into logged, survivable failures)
- **`main.cpp`**: install `std::set_terminate` to log the escaping exception before abort, so a `0xC0000409` is diagnosable instead of pointing only at `ucrtbase`.
- **`audio.cpp` / `nvhttp.cpp` / `confighttp.cpp`**: wrap the audio capture thread and the two HTTP run loops (which previously only caught `boost::system::system_error`) so `std::bad_alloc` and any other exception is caught + logged instead of terminating the SYSTEM service.

## Backlog bound (authorized change to the protected serialized-teardown patch)
- **`video.cpp` `encoder_teardown_queue_t`**: cap the `pending` deque and **intentionally leak the oldest overflow** (release without destroying) so a wedged-GPU reinit storm can't grow it without bound. This **preserves the no-concurrent-destroy invariant** the serializer exists to protect (we never destroy concurrently — we leak, bounded).

## Verification
Full **build + link succeeds** (`luminalshine.exe`, `test_sunshine`, web UI).

## Scope / caveats
- Touches the previously-protected teardown serializer **with explicit owner authorization**; the NVENC `destroy_encoder` drain/leak is **not** touched.
- This reduces *LuminalShine's own* footprint and stops it from being the process that hard-aborts under external memory pressure. It does **not** fix the system-wide OOM root cause (identify the dominant memory consumer; ensure an adequate pagefile/commit limit) or the underlying display-stack/SudoVDA wedge (SudoVDA→MTT VDD, off Insider 29613, driver, reboot).
- Under *true* system OOM, a `bad_alloc` catch handler may itself fail to allocate — these barriers are best-effort but strictly better than an unguarded terminate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)