### PR TITLE
fix: stop LuminalShine interfering with games (ghost VDD, RTSS scope/lifetime, GPU priority, native frame-gen fix)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -790,6 +790,14 @@ int main(int argc, char *argv[]) {
     if (encoder_probe_failed) {
       BOOST_LOG(error) << "Failed to probe encoders during startup.";
     }
+
+#ifdef _WIN32
+    // The probe's display/encoder init raises this process to REALTIME/HIGH
+    // GPU scheduling priority; revert it — nothing is capturing yet. Stream
+    // capture init re-raises it for the session and streaming_will_stop()
+    // reverts it again.
+    platf::reset_gpu_scheduling_priority();
+#endif
   };
 
   startup_probe();

--- a/src/platform/windows/frame_limiter.cpp
+++ b/src/platform/windows/frame_limiter.cpp
@@ -11,10 +11,12 @@
   #include "src/logging.h"
   #include "src/platform/windows/frame_limiter_nvcp.h"
   #include "src/platform/windows/misc.h"
+  #include "src/process.h"
 
   #include <algorithm>
   #include <array>
   #include <cctype>
+  #include <mutex>
   #include <optional>
   #include <string>
   #include <vector>
@@ -25,6 +27,16 @@ namespace platf {
 
     frame_limiter_provider g_active_provider = frame_limiter_provider::none;
     unsigned int g_stream_owner_count = 0;
+    // Serializes limiter lifecycle across the stream-control threads and the
+    // encoder thread (frame_limiter_notify_frame_generation).
+    std::recursive_mutex g_lifecycle_mutex;
+    // Parameters from the session's original start, so the native frame-gen
+    // fix can re-apply the overrides with the capture fix engaged.
+    int g_last_start_fps = 0;
+    std::optional<int> g_last_lossless_rtss_limit;
+    std::string g_last_frame_generation_provider;
+    bool g_last_smooth_motion = false;
+    bool g_framegen_auto_fix_applied = false;
     bool g_nvcp_started = false;
     bool g_gen1_framegen_fix_active = false;
     bool g_gen2_framegen_fix_active = false;
@@ -116,13 +128,32 @@ namespace platf {
     }
   }
 
+  namespace {
+    // Resolve the streamed app's exe name so the RTSS cap can be scoped to an
+    // application profile instead of the Global profile. Empty when the app is
+    // unknown (desktop stream) or launched via a URI/launcher indirection —
+    // those fall back to the Global profile as before.
+    std::string resolve_streamed_app_rtss_profile() {
+      if (proc::proc.running() <= 0) {
+        return {};
+      }
+      return proc::proc.get_running_app_exe_name();
+    }
+  }  // namespace
+
   void frame_limiter_streaming_start(int fps, bool gen1_framegen_fix, bool gen2_framegen_fix, std::optional<int> lossless_rtss_limit, const std::string &frame_generation_provider, bool smooth_motion) {
+    std::lock_guard<std::recursive_mutex> lk(g_lifecycle_mutex);
     if (g_stream_owner_count > 0) {
       ++g_stream_owner_count;
       BOOST_LOG(debug) << "Frame limiter start requested while already active; reusing existing overrides (owners=" << g_stream_owner_count << ")";
       return;
     }
     g_stream_owner_count = 1;
+    g_last_start_fps = fps;
+    g_last_lossless_rtss_limit = lossless_rtss_limit;
+    g_last_frame_generation_provider = frame_generation_provider;
+    g_last_smooth_motion = smooth_motion;
+    g_framegen_auto_fix_applied = false;
 
     g_active_provider = frame_limiter_provider::none;
     g_nvcp_started = false;
@@ -219,7 +250,7 @@ namespace platf {
             break;
           }
         } else if (provider == frame_limiter_provider::rtss) {
-          bool ok = rtss_streaming_start(effective_limit);
+          bool ok = rtss_streaming_start(effective_limit, resolve_streamed_app_rtss_profile());
           if (ok) {
             g_active_provider = frame_limiter_provider::rtss;
             applied = true;
@@ -310,7 +341,8 @@ namespace platf {
     return rtss_warmup_process();
   }
 
-  void frame_limiter_streaming_stop(bool keep_rtss_running) {
+  void frame_limiter_streaming_stop() {
+    std::lock_guard<std::recursive_mutex> lk(g_lifecycle_mutex);
     if (g_stream_owner_count == 0) {
       return;
     }
@@ -335,7 +367,7 @@ namespace platf {
     }
 
     if (g_active_provider == frame_limiter_provider::rtss) {
-      rtss_streaming_stop(keep_rtss_running);
+      rtss_streaming_stop();
     }
 
     if (g_nvcp_started || g_active_provider == frame_limiter_provider::nvidia_control_panel) {
@@ -348,6 +380,7 @@ namespace platf {
   }
 
   void frame_limiter_streaming_refresh() {
+    std::lock_guard<std::recursive_mutex> lk(g_lifecycle_mutex);
     if (g_active_provider != frame_limiter_provider::rtss || g_last_effective_limit <= 0) {
       return;
     }
@@ -355,6 +388,42 @@ namespace platf {
     if (rtss_streaming_refresh(g_last_effective_limit)) {
       BOOST_LOG(info) << "Frame limiter provider 'rtss' refreshed";
     }
+  }
+
+  void frame_limiter_notify_frame_generation(bool dlss_fg_detected) {
+    if (!dlss_fg_detected) {
+      return;
+    }
+
+    std::lock_guard<std::recursive_mutex> lk(g_lifecycle_mutex);
+    if (g_stream_owner_count == 0) {
+      // No limiter session; nothing to upgrade.
+      return;
+    }
+    if (g_gen1_framegen_fix_active || g_gen2_framegen_fix_active) {
+      // A per-app capture fix is already engaged (manual override).
+      return;
+    }
+    if (g_framegen_auto_fix_applied) {
+      return;
+    }
+
+    BOOST_LOG(info) << "Frame generation detected in the streamed game; engaging the capture fix natively";
+
+    // Re-apply the overrides with the gen2 capture fix engaged, reusing the
+    // session's original start parameters. Temporarily collapse the owner
+    // count so stop() performs a full restore before the restart.
+    const unsigned int owners = g_stream_owner_count;
+    const int fps = g_last_start_fps;
+    const auto lossless = g_last_lossless_rtss_limit;
+    const bool smooth = g_last_smooth_motion;
+    std::string provider = g_last_frame_generation_provider.empty() ? std::string {"game-provided"} : g_last_frame_generation_provider;
+
+    g_stream_owner_count = 1;
+    frame_limiter_streaming_stop();
+    frame_limiter_streaming_start(fps, false, true, lossless, provider, smooth);
+    g_stream_owner_count = owners;
+    g_framegen_auto_fix_applied = true;
   }
 
   frame_limiter_provider frame_limiter_active_provider() {

--- a/src/platform/windows/frame_limiter.cpp
+++ b/src/platform/windows/frame_limiter.cpp
@@ -8,6 +8,7 @@
   #include "frame_limiter.h"
 
   #include "src/config.h"
+  #include "src/globals.h"
   #include "src/logging.h"
   #include "src/platform/windows/frame_limiter_nvcp.h"
   #include "src/platform/windows/misc.h"
@@ -137,7 +138,42 @@ namespace platf {
       if (proc::proc.running() <= 0) {
         return {};
       }
-      return proc::proc.get_running_app_exe_name();
+      auto exe = proc::proc.get_running_app_exe_name();
+      if (exe.empty()) {
+        return {};
+      }
+
+      // Launchers/bootstrappers spawn the real game under a different exe; a
+      // per-app profile named after them would leave the game uncapped, so
+      // fall back to the Global profile for those.
+      static constexpr std::array k_launcher_exes = {
+        "steam.exe",
+        "steamwebhelper.exe",
+        "epicgameslauncher.exe",
+        "eaapp.exe",
+        "origin.exe",
+        "battle.net.exe",
+        "galaxyclient.exe",
+        "ubisoftconnect.exe",
+        "upc.exe",
+        "playnite.desktopapp.exe",
+        "playnite.fullscreenapp.exe",
+        "launcher.exe",
+        "cmd.exe",
+        "powershell.exe",
+        "pwsh.exe",
+        "explorer.exe",
+      };
+      std::string lowered = exe;
+      std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+      });
+      for (auto launcher : k_launcher_exes) {
+        if (lowered == launcher) {
+          return {};
+        }
+      }
+      return exe;
     }
   }  // namespace
 
@@ -395,35 +431,56 @@ namespace platf {
       return;
     }
 
-    std::lock_guard<std::recursive_mutex> lk(g_lifecycle_mutex);
-    if (g_stream_owner_count == 0) {
-      // No limiter session; nothing to upgrade.
-      return;
-    }
-    if (g_gen1_framegen_fix_active || g_gen2_framegen_fix_active) {
-      // A per-app capture fix is already engaged (manual override).
-      return;
-    }
-    if (g_framegen_auto_fix_applied) {
-      return;
+    {
+      std::lock_guard<std::recursive_mutex> lk(g_lifecycle_mutex);
+      if (g_stream_owner_count == 0) {
+        // No limiter session; nothing to upgrade.
+        return;
+      }
+      if (g_gen1_framegen_fix_active || g_gen2_framegen_fix_active) {
+        // A per-app capture fix is already engaged (manual override).
+        return;
+      }
+      if (g_framegen_auto_fix_applied) {
+        return;
+      }
+      // The capture fix is RTSS-based. Without RTSS there is nothing better to
+      // apply, and restarting the limiter would drop an NVCP cap without a
+      // replacement — leave the session alone.
+      if (!rtss_is_configured()) {
+        BOOST_LOG(info) << "Frame generation detected in the streamed game, but RTSS is unavailable; leaving the frame limiter unchanged";
+        g_framegen_auto_fix_applied = true;
+        return;
+      }
+      g_framegen_auto_fix_applied = true;
     }
 
     BOOST_LOG(info) << "Frame generation detected in the streamed game; engaging the capture fix natively";
 
-    // Re-apply the overrides with the gen2 capture fix engaged, reusing the
-    // session's original start parameters. Temporarily collapse the owner
-    // count so stop() performs a full restore before the restart.
-    const unsigned int owners = g_stream_owner_count;
-    const int fps = g_last_start_fps;
-    const auto lossless = g_last_lossless_rtss_limit;
-    const bool smooth = g_last_smooth_motion;
-    std::string provider = g_last_frame_generation_provider.empty() ? std::string {"game-provided"} : g_last_frame_generation_provider;
+    // The RTSS stop/relaunch cycle can block for seconds; run it off the
+    // encoder thread so the session's first frames aren't stalled.
+    task_pool.push([]() {
+      std::lock_guard<std::recursive_mutex> lk(g_lifecycle_mutex);
+      if (g_stream_owner_count == 0 || g_gen1_framegen_fix_active || g_gen2_framegen_fix_active) {
+        return;
+      }
 
-    g_stream_owner_count = 1;
-    frame_limiter_streaming_stop();
-    frame_limiter_streaming_start(fps, false, true, lossless, provider, smooth);
-    g_stream_owner_count = owners;
-    g_framegen_auto_fix_applied = true;
+      // Re-apply the overrides with the gen2 capture fix engaged, reusing the
+      // session's original start parameters. Temporarily collapse the owner
+      // count so stop() performs a full restore before the restart.
+      const unsigned int owners = g_stream_owner_count;
+      const int fps = g_last_start_fps;
+      const auto lossless = g_last_lossless_rtss_limit;
+      const bool smooth = g_last_smooth_motion;
+      std::string provider = g_last_frame_generation_provider.empty() ? std::string {"game-provided"} : g_last_frame_generation_provider;
+
+      g_stream_owner_count = 1;
+      frame_limiter_streaming_stop();
+      frame_limiter_streaming_start(fps, false, true, lossless, provider, smooth);
+      g_stream_owner_count = owners;
+      // streaming_start() reset the flag; re-mark so this runs once per session.
+      g_framegen_auto_fix_applied = true;
+    });
   }
 
   frame_limiter_provider frame_limiter_active_provider() {

--- a/src/platform/windows/frame_limiter.h
+++ b/src/platform/windows/frame_limiter.h
@@ -35,8 +35,15 @@ namespace platf {
   };
 
   void frame_limiter_streaming_start(int fps, bool gen1_framegen_fix, bool gen2_framegen_fix, std::optional<int> lossless_rtss_limit, const std::string &frame_generation_provider, bool smooth_motion);
-  void frame_limiter_streaming_stop(bool keep_rtss_running = false);
+  void frame_limiter_streaming_stop();
   void frame_limiter_streaming_refresh();
+
+  // Native frame-generation capture fix: called by the encoder path when the
+  // streamed game is detected running frame generation (e.g. DLSS FG). If no
+  // per-app capture fix is already engaged, re-applies the limiter overrides
+  // with the gen2 capture fix so capture pacing matches generated frames.
+  // Safe to call from any thread; no-ops when nothing needs to change.
+  void frame_limiter_notify_frame_generation(bool dlss_fg_detected);
 
   bool frame_limiter_prepare_launch(bool gen1_framegen_fix, bool gen2_framegen_fix, std::optional<int> lossless_rtss_limit);
 

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -1635,6 +1635,27 @@ namespace platf {
     }
   }
 
+  void reset_gpu_scheduling_priority() {
+    // Mirrors display_base.cpp's D3DKMT declarations; NORMAL is 2 in
+    // D3DKMT_SCHEDULINGPRIORITYCLASS (idle, below_normal, normal, ...).
+    typedef NTSTATUS(WINAPI *set_process_priority_fn)(HANDLE, int);
+    constexpr int k_d3dkmt_priority_normal = 2;
+
+    auto gdi32 = GetModuleHandleA("GDI32");
+    if (!gdi32) {
+      return;
+    }
+    auto fn = (set_process_priority_fn) GetProcAddress(gdi32, "D3DKMTSetProcessSchedulingPriorityClass");
+    if (!fn) {
+      return;
+    }
+    if (FAILED(fn(GetCurrentProcess(), k_d3dkmt_priority_normal))) {
+      BOOST_LOG(warning) << "Failed to restore GPU scheduling priority to normal"sv;
+    } else {
+      BOOST_LOG(info) << "GPU scheduling priority restored to normal"sv;
+    }
+  }
+
   void streaming_will_stop() {
     // If the client disconnected without /cancel, Sunshine can leave the app running to allow /resume.
     // In that "paused" state, we must keep feeding the display helper heartbeat to prevent it from
@@ -1647,6 +1668,10 @@ namespace platf {
     }
     // Demote ourselves back to normal priority class
     SetPriorityClass(GetCurrentProcess(), NORMAL_PRIORITY_CLASS);
+
+    // Capture raised our GPU scheduling priority to REALTIME/HIGH; drop back
+    // to NORMAL so an idle host never preempts a foreground game's GPU work.
+    reset_gpu_scheduling_priority();
 
     // End our 0.5ms timer request
     if (used_nt_set_timer_resolution) {

--- a/src/platform/windows/misc.h
+++ b/src/platform/windows/misc.h
@@ -26,6 +26,16 @@ namespace platf {
   void print_status(const std::string_view &prefix, HRESULT status);
   HDESK syncThreadDesktop();
 
+  /**
+   * @brief Restore this process's GPU scheduling priority to NORMAL.
+   *
+   * Capture init raises the process to REALTIME/HIGH GPU scheduling priority
+   * (display_base.cpp) and there is no automatic revert; call this when no
+   * capture is active (stream stop, after the startup encoder probe) so an
+   * idle LuminalShine never outranks a foreground game at the GPU scheduler.
+   */
+  void reset_gpu_scheduling_priority();
+
   int64_t qpc_counter();
 
   std::chrono::nanoseconds qpc_time_difference(int64_t performance_counter1, int64_t performance_counter2);

--- a/src/platform/windows/rtss_integration.cpp
+++ b/src/platform/windows/rtss_integration.cpp
@@ -77,6 +77,14 @@ namespace platf {
     std::optional<int> g_original_denominator;
     std::optional<DWORD> g_original_flags;
 
+    // Profile the overrides target: "" is the Global profile; otherwise an
+    // application profile name such as "game.exe". Scoping the cap to the
+    // streamed app keeps every other application on the host uncapped.
+    std::string g_active_profile;
+    // True when we created the per-app profile file ourselves; restore then
+    // deletes the file instead of writing values back into it.
+    bool g_profile_created_by_us = false;
+
     // Install path resolved from config (root RTSS folder)
     fs::path g_rtss_root;
 
@@ -89,14 +97,19 @@ namespace platf {
     const std::array<const wchar_t *, 2> k_rtss_process_names = {L"RTSS.exe", L"RTSS64.exe"};
     const std::array<const wchar_t *, 2> k_rtss_executable_names = {L"RTSS.exe", L"RTSS64.exe"};
 
-    const fs::path profile_path(const fs::path &root) {
-      return root / "Profiles" / "Global";
+    // "" selects the Global profile; an application profile "game.exe" is
+    // stored by RTSS as "Profiles/game.exe.cfg".
+    const fs::path profile_path(const fs::path &root, const std::string &profile) {
+      if (profile.empty()) {
+        return root / "Profiles" / "Global";
+      }
+      return root / "Profiles" / (profile + ".cfg");
     }
 
     bool load_hooks(const fs::path &root);
-    std::optional<int> set_limit_denominator(const fs::path &root, int new_denominator);
-    std::optional<int> set_profile_property_int(const char *name, int new_value);
-    bool write_profile_value_int(const fs::path &root, const char *key, int new_value);
+    std::optional<int> set_limit_denominator(const fs::path &root, const std::string &profile, int new_denominator);
+    std::optional<int> set_profile_property_int(const std::string &profile, const char *name, int new_value);
+    bool write_profile_value_int(const fs::path &root, const std::string &profile, const char *key, int new_value);
     fs::path resolve_rtss_root();
 
     struct recovery_snapshot_t {
@@ -108,6 +121,8 @@ namespace platf {
       std::optional<int> original_limit;
       bool sync_limiter_modified = false;
       std::optional<int> original_sync_limiter;
+      std::string profile;
+      bool profile_created = false;
     };
 
     bool snapshot_has_changes(const recovery_snapshot_t &snapshot) {
@@ -145,7 +160,7 @@ namespace platf {
     }
 
     bool write_overrides_file(const recovery_snapshot_t &snapshot) {
-      if (!snapshot_has_changes(snapshot)) {
+      if (!snapshot_has_changes(snapshot) && !snapshot.profile_created) {
         return true;
       }
 
@@ -184,6 +199,8 @@ namespace platf {
       encode("denominator", snapshot.denominator_modified, snapshot.original_denominator);
       encode("limit", snapshot.limit_modified, snapshot.original_limit);
       encode("sync_limiter", snapshot.sync_limiter_modified, snapshot.original_sync_limiter);
+      j["profile"] = snapshot.profile;
+      j["profile_created"] = snapshot.profile_created;
 
       std::ofstream out(file_path, std::ios::binary | std::ios::trunc);
       if (!out.is_open()) {
@@ -257,8 +274,12 @@ namespace platf {
       decode("denominator", snapshot.denominator_modified, snapshot.original_denominator);
       decode("limit", snapshot.limit_modified, snapshot.original_limit);
       decode("sync_limiter", snapshot.sync_limiter_modified, snapshot.original_sync_limiter);
+      if (j.contains("profile") && j["profile"].is_string()) {
+        snapshot.profile = j["profile"].get<std::string>();
+      }
+      snapshot.profile_created = j.value("profile_created", false);
 
-      if (!snapshot_has_changes(snapshot)) {
+      if (!snapshot_has_changes(snapshot) && !snapshot.profile_created) {
         return std::nullopt;
       }
 
@@ -305,36 +326,49 @@ namespace platf {
 
       bool success = true;
 
-      if (snapshot.denominator_modified && snapshot.original_denominator.has_value()) {
-        if (!set_limit_denominator(root, *snapshot.original_denominator).has_value()) {
+      if (snapshot.profile_created && !snapshot.profile.empty()) {
+        // We created the per-app profile ourselves; deleting it restores the
+        // pre-stream state exactly, so skip the per-value restores below.
+        std::error_code ec;
+        fs::remove(profile_path(root, snapshot.profile), ec);
+        if (ec) {
+          BOOST_LOG(warning) << "RTSS overrides: failed to delete created profile '" << snapshot.profile << "': " << ec.message();
           success = false;
+        } else if (ensure_hooks_loaded()) {
+          g_hooks.UpdateProfiles();
         }
-      }
+      } else {
+        if (snapshot.denominator_modified && snapshot.original_denominator.has_value()) {
+          if (!set_limit_denominator(root, snapshot.profile, *snapshot.original_denominator).has_value()) {
+            success = false;
+          }
+        }
 
-      if (snapshot.limit_modified) {
-        int value = snapshot.original_limit.value_or(0);
-        bool applied = false;
-        if (ensure_hooks_loaded()) {
-          set_profile_property_int("FramerateLimit", value);
-          applied = true;
-        } else if (write_profile_value_int(root, "FramerateLimit", value)) {
-          applied = true;
+        if (snapshot.limit_modified) {
+          int value = snapshot.original_limit.value_or(0);
+          bool applied = false;
+          if (ensure_hooks_loaded()) {
+            set_profile_property_int(snapshot.profile, "FramerateLimit", value);
+            applied = true;
+          } else if (write_profile_value_int(root, snapshot.profile, "FramerateLimit", value)) {
+            applied = true;
+          }
+          if (!applied) {
+            success = false;
+          }
         }
-        if (!applied) {
-          success = false;
-        }
-      }
 
-      if (snapshot.sync_limiter_modified && snapshot.original_sync_limiter.has_value()) {
-        bool applied = false;
-        if (ensure_hooks_loaded()) {
-          set_profile_property_int("SyncLimiter", *snapshot.original_sync_limiter);
-          applied = true;
-        } else if (write_profile_value_int(root, "SyncLimiter", *snapshot.original_sync_limiter)) {
-          applied = true;
-        }
-        if (!applied) {
-          success = false;
+        if (snapshot.sync_limiter_modified && snapshot.original_sync_limiter.has_value()) {
+          bool applied = false;
+          if (ensure_hooks_loaded()) {
+            set_profile_property_int(snapshot.profile, "SyncLimiter", *snapshot.original_sync_limiter);
+            applied = true;
+          } else if (write_profile_value_int(root, snapshot.profile, "SyncLimiter", *snapshot.original_sync_limiter)) {
+            applied = true;
+          }
+          if (!applied) {
+            success = false;
+          }
         }
       }
 
@@ -372,8 +406,8 @@ namespace platf {
       }
     }
 
-    bool ensure_profile_exists(const fs::path &root) {
-      auto path = profile_path(root);
+    bool ensure_profile_exists(const fs::path &root, const std::string &profile) {
+      auto path = profile_path(root, profile);
       if (fs::exists(path)) {
         return true;
       }
@@ -382,21 +416,21 @@ namespace platf {
         static constexpr char k_default_profile[] = "[Framerate]\nLimit=0\nLimitDenominator=1\nSyncLimiter=0\n";
         std::ofstream init_out(path, std::ios::out | std::ios::binary | std::ios::trunc);
         if (!init_out) {
-          BOOST_LOG(warning) << "Unable to create RTSS Global profile at: "sv << path.string();
+          BOOST_LOG(warning) << "Unable to create RTSS profile at: "sv << path.string();
           return false;
         }
         init_out.write(k_default_profile, sizeof(k_default_profile) - 1);
         init_out.flush();
-        BOOST_LOG(info) << "Created default RTSS Global profile"sv;
+        BOOST_LOG(info) << "Created default RTSS profile: "sv << (profile.empty() ? "Global" : profile.c_str());
         return true;
       } catch (const std::exception &e) {
-        BOOST_LOG(warning) << "Failed to ensure RTSS Global profile exists: "sv << e.what();
+        BOOST_LOG(warning) << "Failed to ensure RTSS profile exists: "sv << e.what();
         return false;
       }
     }
 
-    std::optional<int> read_profile_value_int(const fs::path &root, const char *key) {
-      auto path = profile_path(root);
+    std::optional<int> read_profile_value_int(const fs::path &root, const std::string &profile, const char *key) {
+      auto path = profile_path(root, profile);
       if (!fs::exists(path)) {
         return std::nullopt;
       }
@@ -428,12 +462,12 @@ namespace platf {
       }
     }
 
-    bool write_profile_value_int(const fs::path &root, const char *key, int new_value) {
+    bool write_profile_value_int(const fs::path &root, const std::string &profile, const char *key, int new_value) {
       try {
-        if (!ensure_profile_exists(root)) {
+        if (!ensure_profile_exists(root, profile)) {
           return false;
         }
-        auto path = profile_path(root);
+        auto path = profile_path(root, profile);
         std::string content;
         {
           std::ifstream in(path, std::ios::in | std::ios::binary);
@@ -687,13 +721,13 @@ namespace platf {
       return true;
     }
 
-    // Read and replace LimitDenominator in the RTSS Global profile. Returns previous value (or 1 if missing).
-    std::optional<int> set_limit_denominator(const fs::path &root, int new_denominator) {
+    // Read and replace LimitDenominator in the targeted RTSS profile. Returns previous value (or 1 if missing).
+    std::optional<int> set_limit_denominator(const fs::path &root, const std::string &profile, int new_denominator) {
       try {
-        if (!ensure_profile_exists(root)) {
+        if (!ensure_profile_exists(root, profile)) {
           return std::nullopt;
         }
-        auto global_path = profile_path(root);
+        auto global_path = profile_path(root, profile);
         std::string content;
         {
           std::ifstream in(global_path, std::ios::in | std::ios::binary);
@@ -735,18 +769,18 @@ namespace platf {
         BOOST_LOG(info) << "RTSS LimitDenominator set to "sv << new_denominator << ", original "sv << old_den;
         return old_den;
       } catch (const std::exception &e) {
-        BOOST_LOG(warning) << "Failed updating RTSS Global profile: "sv << e.what();
+        BOOST_LOG(warning) << "Failed updating RTSS profile: "sv << e.what();
         return std::nullopt;
       }
     }
 
     // Helper: read integer profile property, returns value if present
-    std::optional<int> get_profile_property_int(const char *name) {
+    std::optional<int> get_profile_property_int(const std::string &profile, const char *name) {
       if (!g_hooks) {
         return std::nullopt;
       }
       int value = 0;
-      g_hooks.LoadProfile("");
+      g_hooks.LoadProfile(profile.c_str());
       if (g_hooks.GetProfileProperty(name, &value, sizeof(value))) {
         return value;
       }
@@ -754,7 +788,7 @@ namespace platf {
     }
 
     // Helper: set integer profile property and return previous value if present
-    std::optional<int> set_profile_property_int(const char *name, int new_value) {
+    std::optional<int> set_profile_property_int(const std::string &profile, const char *name, int new_value) {
       if (!g_hooks) {
         return std::nullopt;
       }
@@ -762,15 +796,16 @@ namespace platf {
       int old_value = 0;
       BOOL had_old = FALSE;
 
-      // Empty string selects global profile as in RTSS UI
-      g_hooks.LoadProfile("");
+      // Empty string selects the global profile as in the RTSS UI; otherwise
+      // an application profile such as "game.exe".
+      g_hooks.LoadProfile(profile.c_str());
 
       if (g_hooks.GetProfileProperty(name, &old_value, sizeof(old_value))) {
         had_old = TRUE;
       }
 
       g_hooks.SetProfileProperty(name, &new_value, sizeof(new_value));
-      g_hooks.SaveProfile("");
+      g_hooks.SaveProfile(profile.c_str());
       g_hooks.UpdateProfiles();
 
       if (had_old) {
@@ -846,13 +881,15 @@ namespace platf {
     return ensure_rtss_running(g_rtss_root);
   }
 
-  bool rtss_streaming_start(int fps) {
+  bool rtss_streaming_start(int fps, const std::string &app_profile) {
     g_limit_active = false;
     g_settings_dirty = false;
     g_flags_modified = false;
     g_denominator_modified = false;
     g_limit_modified = false;
     g_sync_limiter_modified = false;
+    g_active_profile.clear();
+    g_profile_created_by_us = false;
     maybe_restore_from_overrides_file();
 
     if (!config::frame_limiter.enable) {
@@ -863,6 +900,15 @@ namespace platf {
     if (!fs::exists(g_rtss_root)) {
       BOOST_LOG(warning) << "RTSS install path not found: "sv << g_rtss_root.string();
       return false;
+    }
+
+    if (!app_profile.empty()) {
+      g_active_profile = app_profile;
+      g_profile_created_by_us = !fs::exists(profile_path(g_rtss_root, g_active_profile));
+      BOOST_LOG(info) << "RTSS frame limit scoped to application profile '" << g_active_profile
+                      << (g_profile_created_by_us ? "' (creating profile)" : "' (existing profile)");
+    } else {
+      BOOST_LOG(info) << "RTSS frame limit falling back to the Global profile (streamed app exe unknown)"sv;
     }
 
     ensure_rtss_running(g_rtss_root);
@@ -895,7 +941,7 @@ namespace platf {
     int scaled_limit = fps;
 
     // Update LimitDenominator in Global profile and remember previous value
-    g_original_denominator = set_limit_denominator(g_rtss_root, current_denominator);
+    g_original_denominator = set_limit_denominator(g_rtss_root, g_active_profile, current_denominator);
     if (g_original_denominator.has_value() && *g_original_denominator != current_denominator) {
       g_denominator_modified = true;
       g_settings_dirty = true;
@@ -907,15 +953,15 @@ namespace platf {
 
     // If hooks are available, capture original values BEFORE making further changes
     if (g_hooks) {
-      g_original_limit = get_profile_property_int("FramerateLimit");
-      g_original_sync_limiter = get_profile_property_int("SyncLimiter");
+      g_original_limit = get_profile_property_int(g_active_profile, "FramerateLimit");
+      g_original_sync_limiter = get_profile_property_int(g_active_profile, "SyncLimiter");
       BOOST_LOG(info) << "RTSS original values: limit="
                       << (g_original_limit.has_value() ? std::to_string(*g_original_limit) : std::string("<unset>"))
                       << ", syncLimiter="
                       << (g_original_sync_limiter.has_value() ? std::to_string(*g_original_sync_limiter) : std::string("<unset>"));
     } else {
-      g_original_limit = read_profile_value_int(g_rtss_root, "FramerateLimit");
-      g_original_sync_limiter = read_profile_value_int(g_rtss_root, "SyncLimiter");
+      g_original_limit = read_profile_value_int(g_rtss_root, g_active_profile, "FramerateLimit");
+      g_original_sync_limiter = read_profile_value_int(g_rtss_root, g_active_profile, "SyncLimiter");
       BOOST_LOG(info) << "RTSS profile snapshot: limit="
                       << (g_original_limit.has_value() ? std::to_string(*g_original_limit) : std::string("<unset>"))
                       << ", syncLimiter="
@@ -945,9 +991,9 @@ namespace platf {
       bool applied = false;
       if (!already_set) {
         if (g_hooks) {
-          set_profile_property_int("SyncLimiter", *sync_limiter_value);
+          set_profile_property_int(g_active_profile, "SyncLimiter", *sync_limiter_value);
           applied = true;
-        } else if (write_profile_value_int(g_rtss_root, "SyncLimiter", *sync_limiter_value)) {
+        } else if (write_profile_value_int(g_rtss_root, g_active_profile, "SyncLimiter", *sync_limiter_value)) {
           applied = true;
         }
         if (applied) {
@@ -974,7 +1020,7 @@ namespace platf {
         BOOST_LOG(info) << "RTSS framerate limit already at " << scaled_limit << " (denominator=" << current_denominator << ")";
         g_limit_active = true;
       } else {
-        set_profile_property_int("FramerateLimit", scaled_limit);
+        set_profile_property_int(g_active_profile, "FramerateLimit", scaled_limit);
         BOOST_LOG(info) << "RTSS applied framerate limit=" << scaled_limit << " (denominator=" << current_denominator << ")";
         g_limit_active = true;
         g_limit_modified = true;
@@ -984,7 +1030,7 @@ namespace platf {
       if (limit_already_set) {
         BOOST_LOG(info) << "RTSS profile framerate limit already "sv << scaled_limit;
         g_limit_active = true;
-      } else if (write_profile_value_int(g_rtss_root, "FramerateLimit", scaled_limit)) {
+      } else if (write_profile_value_int(g_rtss_root, g_active_profile, "FramerateLimit", scaled_limit)) {
         BOOST_LOG(info) << "RTSS profile framerate limit set to "sv << scaled_limit;
         g_limit_active = true;
         g_limit_modified = true;
@@ -1001,6 +1047,8 @@ namespace platf {
       snapshot.original_limit = g_original_limit;
       snapshot.sync_limiter_modified = g_sync_limiter_modified;
       snapshot.original_sync_limiter = g_original_sync_limiter;
+      snapshot.profile = g_active_profile;
+      snapshot.profile_created = g_profile_created_by_us;
       g_recovery_file_owned = write_overrides_file(snapshot);
     } else {
       g_recovery_file_owned = false;
@@ -1014,7 +1062,7 @@ namespace platf {
     }
 
     if (!g_limit_active && !g_settings_dirty) {
-      return rtss_streaming_start(fps);
+      return rtss_streaming_start(fps, g_active_profile);
     }
 
     g_rtss_root = resolve_rtss_root();
@@ -1047,7 +1095,7 @@ namespace platf {
     }
 
     int current_denominator = 1;
-    auto old_den = set_limit_denominator(g_rtss_root, current_denominator);
+    auto old_den = set_limit_denominator(g_rtss_root, g_active_profile, current_denominator);
     if (old_den.has_value() && *old_den != current_denominator) {
       if (!g_original_denominator.has_value()) {
         g_original_denominator = *old_den;
@@ -1078,9 +1126,9 @@ namespace platf {
     if (sync_limiter_value) {
       bool applied = false;
       if (g_hooks) {
-        set_profile_property_int("SyncLimiter", *sync_limiter_value);
+        set_profile_property_int(g_active_profile, "SyncLimiter", *sync_limiter_value);
         applied = true;
-      } else if (write_profile_value_int(g_rtss_root, "SyncLimiter", *sync_limiter_value)) {
+      } else if (write_profile_value_int(g_rtss_root, g_active_profile, "SyncLimiter", *sync_limiter_value)) {
         applied = true;
       }
       if (applied) {
@@ -1097,9 +1145,9 @@ namespace platf {
     int scaled_limit = fps;
     bool applied_limit = false;
     if (g_hooks) {
-      set_profile_property_int("FramerateLimit", scaled_limit);
+      set_profile_property_int(g_active_profile, "FramerateLimit", scaled_limit);
       applied_limit = true;
-    } else if (write_profile_value_int(g_rtss_root, "FramerateLimit", scaled_limit)) {
+    } else if (write_profile_value_int(g_rtss_root, g_active_profile, "FramerateLimit", scaled_limit)) {
       applied_limit = true;
     }
     if (applied_limit) {
@@ -1120,13 +1168,15 @@ namespace platf {
       snapshot.original_limit = g_original_limit;
       snapshot.sync_limiter_modified = g_sync_limiter_modified;
       snapshot.original_sync_limiter = g_original_sync_limiter;
+      snapshot.profile = g_active_profile;
+      snapshot.profile_created = g_profile_created_by_us;
       g_recovery_file_owned = write_overrides_file(snapshot);
     }
 
     return applied_limit;
   }
 
-  void rtss_streaming_stop(bool keep_process_running) {
+  void rtss_streaming_stop() {
     g_sync_limiter_override.reset();
     auto cleanup = [&]() {
       g_original_limit.reset();
@@ -1139,16 +1189,19 @@ namespace platf {
       g_denominator_modified = false;
       g_limit_modified = false;
       g_sync_limiter_modified = false;
+      g_active_profile.clear();
+      g_profile_created_by_us = false;
       if (g_hooks.module) {
         FreeLibrary(g_hooks.module);
         g_hooks = {};
       }
-      if (!keep_process_running) {
-        stop_rtss_process();
-      }
+      // RTSS injects its hooks into every process that starts while it runs.
+      // Never leave a LuminalShine-launched RTSS behind (paused sessions
+      // included) — anti-tamper titles refuse to start under those hooks.
+      stop_rtss_process();
     };
 
-    if (!g_settings_dirty) {
+    if (!g_settings_dirty && !g_profile_created_by_us) {
       if (g_recovery_file_owned) {
         delete_overrides_file();
         g_recovery_file_owned = false;
@@ -1158,6 +1211,26 @@ namespace platf {
     }
 
     bool restore_success = true;
+
+    if (g_profile_created_by_us && !g_active_profile.empty()) {
+      // We created the per-app profile; deleting it restores pre-stream state
+      // exactly. Flags are still restored below; the per-value restores are
+      // skipped by clearing the modified markers.
+      std::error_code ec;
+      fs::remove(profile_path(g_rtss_root, g_active_profile), ec);
+      if (ec) {
+        BOOST_LOG(warning) << "Failed to delete created RTSS profile '" << g_active_profile << "': " << ec.message();
+        restore_success = false;
+      } else {
+        BOOST_LOG(info) << "Removed created RTSS profile '" << g_active_profile << '\'';
+        if (g_hooks) {
+          g_hooks.UpdateProfiles();
+        }
+      }
+      g_denominator_modified = false;
+      g_limit_modified = false;
+      g_sync_limiter_modified = false;
+    }
 
     if (g_hooks && g_flags_modified && g_original_flags.has_value()) {
       constexpr DWORD limiter_mask = k_rtss_flag_limiter_disabled;
@@ -1173,28 +1246,28 @@ namespace platf {
     }
 
     if (g_denominator_modified && g_original_denominator.has_value()) {
-      if (!set_limit_denominator(g_rtss_root, *g_original_denominator).has_value()) {
+      if (!set_limit_denominator(g_rtss_root, g_active_profile, *g_original_denominator).has_value()) {
         restore_success = false;
       }
     }
 
     if (g_hooks) {
       if (g_sync_limiter_modified && g_original_sync_limiter.has_value()) {
-        set_profile_property_int("SyncLimiter", *g_original_sync_limiter);
+        set_profile_property_int(g_active_profile, "SyncLimiter", *g_original_sync_limiter);
       }
 
       if (g_limit_modified) {
         if (g_original_limit.has_value()) {
-          set_profile_property_int("FramerateLimit", *g_original_limit);
+          set_profile_property_int(g_active_profile, "FramerateLimit", *g_original_limit);
           BOOST_LOG(info) << "RTSS restored framerate limit=" << *g_original_limit;
         } else {
-          set_profile_property_int("FramerateLimit", 0);
+          set_profile_property_int(g_active_profile, "FramerateLimit", 0);
           BOOST_LOG(info) << "RTSS restored framerate limit=<unset> (set 0)";
         }
       }
     } else {
       if (g_sync_limiter_modified && g_original_sync_limiter.has_value()) {
-        if (write_profile_value_int(g_rtss_root, "SyncLimiter", *g_original_sync_limiter)) {
+        if (write_profile_value_int(g_rtss_root, g_active_profile, "SyncLimiter", *g_original_sync_limiter)) {
           BOOST_LOG(info) << "RTSS profile SyncLimiter restored to "sv << *g_original_sync_limiter;
         } else {
           restore_success = false;
@@ -1203,12 +1276,12 @@ namespace platf {
 
       if (g_limit_modified) {
         if (g_original_limit.has_value()) {
-          if (write_profile_value_int(g_rtss_root, "FramerateLimit", *g_original_limit)) {
+          if (write_profile_value_int(g_rtss_root, g_active_profile, "FramerateLimit", *g_original_limit)) {
             BOOST_LOG(info) << "RTSS profile framerate limit restored to "sv << *g_original_limit;
           } else {
             restore_success = false;
           }
-        } else if (write_profile_value_int(g_rtss_root, "FramerateLimit", 0)) {
+        } else if (write_profile_value_int(g_rtss_root, g_active_profile, "FramerateLimit", 0)) {
           BOOST_LOG(info) << "RTSS profile framerate limit restored to 0"sv;
         } else {
           restore_success = false;

--- a/src/platform/windows/rtss_integration.cpp
+++ b/src/platform/windows/rtss_integration.cpp
@@ -277,7 +277,9 @@ namespace platf {
       if (j.contains("profile") && j["profile"].is_string()) {
         snapshot.profile = j["profile"].get<std::string>();
       }
-      snapshot.profile_created = j.value("profile_created", false);
+      if (j.contains("profile_created") && j["profile_created"].is_boolean()) {
+        snapshot.profile_created = j["profile_created"].get<bool>();
+      }
 
       if (!snapshot_has_changes(snapshot) && !snapshot.profile_created) {
         return std::nullopt;
@@ -1037,7 +1039,7 @@ namespace platf {
         g_settings_dirty = true;
       }
     }
-    if (g_settings_dirty) {
+    if (g_settings_dirty || g_profile_created_by_us) {
       recovery_snapshot_t snapshot;
       snapshot.flags_modified = g_flags_modified && g_original_flags.has_value();
       snapshot.original_flags = g_original_flags;
@@ -1062,7 +1064,8 @@ namespace platf {
     }
 
     if (!g_limit_active && !g_settings_dirty) {
-      return rtss_streaming_start(fps, g_active_profile);
+      // Copy: rtss_streaming_start clears g_active_profile before reading its argument.
+      return rtss_streaming_start(fps, std::string {g_active_profile});
     }
 
     g_rtss_root = resolve_rtss_root();

--- a/src/platform/windows/rtss_integration.h
+++ b/src/platform/windows/rtss_integration.h
@@ -23,15 +23,19 @@ namespace platf {
   };
 
   // Apply RTSS frame limit and related settings at stream start.
-  // fps is the integer client framerate.
-  bool rtss_streaming_start(int fps);
+  // fps is the integer client framerate. app_profile is the streamed app's
+  // exe name ("game.exe") to scope the cap to an RTSS application profile;
+  // empty falls back to the Global profile.
+  bool rtss_streaming_start(int fps, const std::string &app_profile = std::string());
 
   // Re-apply RTSS frame limit and related settings without resetting originals.
   bool rtss_streaming_refresh(int fps);
 
-  // Restore any RTSS settings modified at stream start.
-  // If keep_process_running is true, Sunshine leaves RTSS running for pause/resume scenarios.
-  void rtss_streaming_stop(bool keep_process_running = false);
+  // Restore any RTSS settings modified at stream start and stop the RTSS
+  // process if we started it. RTSS is never left running across paused
+  // sessions: its hooks inject into every new process and can prevent
+  // anti-tamper titles from launching.
+  void rtss_streaming_stop();
 
   void rtss_restore_pending_overrides();
 

--- a/src/platform/windows/virtual_display.cpp
+++ b/src/platform/windows/virtual_display.cpp
@@ -4772,6 +4772,12 @@ namespace VDISPLAY {
         if (!g_ensure_display_retained || !guid_equal(g_ensure_display_guid, guid)) {
           return;
         }
+        // Re-check staleness: ensure_display() reuse/create refreshes the
+        // timestamp under this mutex and the persistent GUID is shared, so
+        // reaping past this point would delete a display a launch just claimed.
+        if (std::chrono::steady_clock::now() - g_ensure_display_retained_at < ENSURE_DISPLAY_RETENTION_TIMEOUT) {
+          return;
+        }
         g_ensure_display_retained = false;
         g_ensure_display_failure_count = 0;
         std::memset(&g_ensure_display_guid, 0, sizeof(g_ensure_display_guid));

--- a/src/platform/windows/virtual_display.cpp
+++ b/src/platform/windows/virtual_display.cpp
@@ -1,6 +1,7 @@
 #include "virtual_display.h"
 
 #include "src/config.h"
+#include "src/globals.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
 #include "src/platform/windows/display_helper_coordinator.h"
@@ -10,9 +11,11 @@
 #include "src/platform/windows/sudovda_recovery.h"
 #include "src/platform/windows/virtual_display_mtt.h"
 #include "src/process.h"
+#include "src/rtsp.h"
 #include "src/state_storage.h"
 #include "src/tdr_state.h"
 #include "src/uuid.h"
+#include "src/webrtc_stream.h"
 
 #include <algorithm>
 #include <atomic>
@@ -81,6 +84,10 @@ namespace VDISPLAY {
     constexpr auto DEVICE_RESTART_SETTLE_DELAY = std::chrono::milliseconds(200);
     constexpr auto VIRTUAL_DISPLAY_TEARDOWN_COOLDOWN = std::chrono::milliseconds(250);
     constexpr int ENSURE_DISPLAY_MAX_RETRY_FAILURES = 8;
+    // A temporary probe display retained for probe retries is reaped after this
+    // long with no session activity, so a failed startup probe can't leave a
+    // ghost monitor attached indefinitely (games enumerate/land on it).
+    constexpr auto ENSURE_DISPLAY_RETENTION_TIMEOUT = std::chrono::minutes(3);
     constexpr std::wstring_view SUDOVDA_HARDWARE_ID = L"root\\sudomaker\\sudovda";
     constexpr std::wstring_view SUDOVDA_FRIENDLY_NAME_W = L"SudoMaker Virtual Display Adapter";
 
@@ -98,6 +105,9 @@ namespace VDISPLAY {
     bool g_ensure_display_retained = false;
     GUID g_ensure_display_guid {};
     int g_ensure_display_failure_count = 0;
+    std::chrono::steady_clock::time_point g_ensure_display_retained_at {};
+
+    void schedule_ensure_display_reaper();
 
     bool guid_equal(const GUID &lhs, const GUID &rhs) {
       return std::memcmp(&lhs, &rhs, sizeof(GUID)) == 0;
@@ -4723,6 +4733,67 @@ uuid_util::uuid_t VDISPLAY::persistentVirtualDisplayUuid() {
   return ensure_persistent_guid();
 }
 
+namespace VDISPLAY {
+  namespace {
+    // Removes a retained temporary probe display once it has sat unused past
+    // ENSURE_DISPLAY_RETENTION_TIMEOUT with no streaming/app activity. While a
+    // session (or launched app) is alive the display may be its capture target,
+    // so the reaper re-arms instead of reaping.
+    void reap_retained_ensure_display() {
+      GUID guid {};
+      {
+        std::lock_guard<std::mutex> lock(g_ensure_display_state_mutex);
+        if (!g_ensure_display_retained) {
+          return;
+        }
+        if (std::chrono::steady_clock::now() - g_ensure_display_retained_at < ENSURE_DISPLAY_RETENTION_TIMEOUT) {
+          // Retention was refreshed since this reaper was armed; a newer reaper is scheduled.
+          return;
+        }
+        guid = g_ensure_display_guid;
+      }
+
+      const bool busy = rtsp_stream::session_count() > 0 ||
+                        webrtc_stream::has_active_sessions() ||
+                        proc::proc.running() > 0;
+      if (busy) {
+        {
+          std::lock_guard<std::mutex> lock(g_ensure_display_state_mutex);
+          if (g_ensure_display_retained && guid_equal(g_ensure_display_guid, guid)) {
+            g_ensure_display_retained_at = std::chrono::steady_clock::now();
+          }
+        }
+        schedule_ensure_display_reaper();
+        return;
+      }
+
+      {
+        std::lock_guard<std::mutex> lock(g_ensure_display_state_mutex);
+        if (!g_ensure_display_retained || !guid_equal(g_ensure_display_guid, guid)) {
+          return;
+        }
+        g_ensure_display_retained = false;
+        g_ensure_display_failure_count = 0;
+        std::memset(&g_ensure_display_guid, 0, sizeof(g_ensure_display_guid));
+      }
+
+      BOOST_LOG(info) << "Retained temporary virtual display expired with no session activity; removing it.";
+      if (!removeVirtualDisplay(guid)) {
+        BOOST_LOG(warning) << "Failed to remove expired temporary virtual display.";
+      }
+    }
+
+    void schedule_ensure_display_reaper() {
+      task_pool.pushDelayed(
+        []() {
+          reap_retained_ensure_display();
+        },
+        ENSURE_DISPLAY_RETENTION_TIMEOUT + std::chrono::seconds(5)
+      );
+    }
+  }  // namespace
+}  // namespace VDISPLAY
+
 VDISPLAY::ensure_display_result VDISPLAY::ensure_display() {
   ensure_display_result result {false, false, false, {}};
 
@@ -4752,6 +4823,7 @@ VDISPLAY::ensure_display_result VDISPLAY::ensure_display() {
       if (is_virtual_display_guid_tracked(result.temporary_guid)) {
         result.success = true;
         result.tracks_temporary_for_probe = true;
+        g_ensure_display_retained_at = std::chrono::steady_clock::now();
         BOOST_LOG(info) << "Reusing retained temporary virtual display for encoder probing (failure_count="
                         << g_ensure_display_failure_count << ").";
         return result;
@@ -4804,7 +4876,9 @@ VDISPLAY::ensure_display_result VDISPLAY::ensure_display() {
     g_ensure_display_retained = true;
     g_ensure_display_guid = result.temporary_guid;
     g_ensure_display_failure_count = 0;
+    g_ensure_display_retained_at = std::chrono::steady_clock::now();
   }
+  schedule_ensure_display_reaper();
 
   // Wait for DXGI to enumerate the new virtual display.
   // CCD (used by wait_for_virtual_display_ready) and DXGI are different enumeration
@@ -4863,6 +4937,14 @@ void VDISPLAY::cleanup_ensure_display(const ensure_display_result &result, bool 
         should_remove = true;
       }
     }
+
+    if (!should_remove) {
+      g_ensure_display_retained_at = std::chrono::steady_clock::now();
+    }
+  }
+
+  if (!should_remove) {
+    schedule_ensure_display_reaper();
   }
 
   if (!probe_succeeded) {

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1973,13 +1973,8 @@ namespace proc {
     return _app.name;
   }
 
-  std::string proc_t::get_running_app_exe_name() {
-    if (_app_id <= 0) {
-      return {};
-    }
-
+  std::string extract_command_exe_name(std::string_view cmd) {
     // First token of the command, honoring quotes.
-    std::string_view cmd {_app.cmd};
     while (!cmd.empty() && (cmd.front() == ' ' || cmd.front() == '\t')) {
       cmd.remove_prefix(1);
     }
@@ -2015,6 +2010,13 @@ namespace proc {
     }
 
     return std::string {token};
+  }
+
+  std::string proc_t::get_running_app_exe_name() {
+    if (_app_id <= 0) {
+      return {};
+    }
+    return extract_command_exe_name(_app.cmd);
   }
 
   bool proc_t::last_run_app_frame_gen_limiter_fix() const {

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1973,6 +1973,50 @@ namespace proc {
     return _app.name;
   }
 
+  std::string proc_t::get_running_app_exe_name() {
+    if (_app_id <= 0) {
+      return {};
+    }
+
+    // First token of the command, honoring quotes.
+    std::string_view cmd {_app.cmd};
+    while (!cmd.empty() && (cmd.front() == ' ' || cmd.front() == '\t')) {
+      cmd.remove_prefix(1);
+    }
+    if (cmd.empty()) {
+      return {};
+    }
+
+    std::string_view token;
+    if (cmd.front() == '"') {
+      auto end = cmd.find('"', 1);
+      if (end == std::string_view::npos) {
+        return {};
+      }
+      token = cmd.substr(1, end - 1);
+    } else {
+      token = cmd.substr(0, cmd.find(' '));
+    }
+
+    auto sep = token.find_last_of("\\/");
+    if (sep != std::string_view::npos) {
+      token = token.substr(sep + 1);
+    }
+
+    if (token.size() <= 4) {
+      return {};
+    }
+    auto suffix = token.substr(token.size() - 4);
+    auto lower_eq = [](char a, char b) {
+      return std::tolower(static_cast<unsigned char>(a)) == b;
+    };
+    if (!(lower_eq(suffix[0], '.') && lower_eq(suffix[1], 'e') && lower_eq(suffix[2], 'x') && lower_eq(suffix[3], 'e'))) {
+      return {};
+    }
+
+    return std::string {token};
+  }
+
   bool proc_t::last_run_app_frame_gen_limiter_fix() const {
     return _app.frame_gen_limiter_fix;
   }

--- a/src/process.h
+++ b/src/process.h
@@ -166,6 +166,14 @@ namespace proc {
     std::vector<ctx_t> get_apps() const;
     std::string get_app_image(int app_id);
     std::string get_last_run_app_name();
+
+    /**
+     * @brief Get the exe basename of the running app's command, e.g. "game.exe".
+     * @return Lower-risk best effort: empty when no app is running, the app has
+     *         no direct command (detached/URI/launcher indirection), or the
+     *         command's first token is not an .exe path.
+     */
+    std::string get_running_app_exe_name();
     bool last_run_app_frame_gen_limiter_fix() const;
     bool is_launch_deferred() const;
     void terminate(bool skip_display_revert = false);

--- a/src/process.h
+++ b/src/process.h
@@ -241,6 +241,14 @@ namespace proc {
 
   bool check_valid_png(const std::filesystem::path &path);
   std::string validate_app_image_path(std::string app_image_path);
+
+  /**
+   * @brief Extract the exe basename from a command line's first token.
+   * @param cmd The raw command string (may be quoted, may be a URI).
+   * @return "game.exe" style basename, or empty when the first token is not an
+   *         .exe path (URIs, scripts, empty commands).
+   */
+  std::string extract_command_exe_name(std::string_view cmd);
   void refresh(const std::string &file_name);
   std::optional<proc::proc_t> parse(const std::string &file_name);
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -2507,7 +2507,7 @@ namespace stream {
 #ifdef _WIN32
         VDISPLAY::restorePhysicalHdrProfiles();
         platf::rtss_set_sync_limiter_override(std::nullopt);
-        platf::frame_limiter_streaming_stop(is_paused);
+        platf::frame_limiter_streaming_stop();
 #endif
         platf::streaming_will_stop();
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -41,6 +41,7 @@ extern "C" {
 #include "webrtc_stream.h"
 #ifdef _WIN32
   #include "amf/amf_caps.h"
+  #include "platform/windows/frame_limiter.h"
   #include "platform/windows/render_stack_detect.h"
   #include "system_tray.h"
 #endif
@@ -2770,6 +2771,14 @@ namespace video {
           // already surfaced the message
         }
       }
+
+      // Native frame-gen capture fix: when the streamed game has DLSS Frame
+      // Generation loaded, engage the capture fix automatically instead of
+      // relying on the per-app gen1/gen2 toggles. The notify call no-ops if a
+      // manual fix is active or it already ran this session.
+      platf::frame_limiter_notify_frame_generation(
+        platf::render_stack::snapshot().has_dlss_fg
+      );
 #endif
     }
 

--- a/src/webrtc_stream.cpp
+++ b/src/webrtc_stream.cpp
@@ -4693,8 +4693,7 @@ namespace webrtc_stream {
       if (!rtsp_active) {
         VDISPLAY::restorePhysicalHdrProfiles();
         platf::rtss_set_sync_limiter_override(std::nullopt);
-        const bool keep_rtss_running = proc::proc.running() > 0;
-        platf::frame_limiter_streaming_stop(keep_rtss_running);
+        platf::frame_limiter_streaming_stop();
       }
   #endif
       if (!rtsp_sessions_active.load(std::memory_order_relaxed)) {

--- a/src_assets/common/assets/web/components/app-edit/AppEditFrameGenSection.vue
+++ b/src_assets/common/assets/web/components/app-edit/AppEditFrameGenSection.vue
@@ -70,7 +70,7 @@ const captureFixDescription = computed(() => {
     return 'Uses RTSS Front Edge Sync while NVIDIA Smooth Motion is active.';
   }
   if (modeModel.value === 'game-provided') {
-    return 'Uses NVIDIA Reflex for game-provided frame generation on NVIDIA systems, and falls back to RTSS Front Edge Sync on AMD systems.';
+    return 'Uses NVIDIA Reflex for game-provided frame generation on NVIDIA systems, and falls back to RTSS Front Edge Sync on AMD systems. LuminalShine detects DLSS Frame Generation during the stream and engages this fix automatically; the toggle forces it on regardless of detection.';
   }
   return 'Enable when the app uses frame generation. Lossless Scaling and NVIDIA Smooth Motion use RTSS Front Edge Sync, while Game Provided uses NVIDIA Reflex unless an AMD GPU is present.';
 });
@@ -395,6 +395,12 @@ const displayTargets = computed(() => props.health?.display.targets || []);
             :disabled="!hasFrameGenSelection"
           />
         </div>
+        <p class="text-[12px] opacity-60 leading-relaxed">
+          <i class="fas fa-wand-magic-sparkles mr-1" />Auto-engages: when the streamed game is
+          detected using DLSS Frame Generation, LuminalShine applies this capture fix for the
+          session on its own &mdash; no interaction required. Use the toggle only to force the fix
+          for games the detection misses.
+        </p>
       </div>
       <div class="space-y-3">
         <n-alert v-if="healthError" type="error" size="small">

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/FrameLimiterStep.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/FrameLimiterStep.vue
@@ -310,6 +310,10 @@ onMounted(() => {
         />
       </div>
 
+      <p class="text-xs opacity-70 leading-relaxed">
+        <i class="fas fa-wand-magic-sparkles mr-1" />{{ t('frameLimiter.framegenAutoNote') }}
+      </p>
+
       <ConfigFieldRenderer
         setting-key="frame_limiter_fps_limit"
         v-model="config.frame_limiter_fps_limit"

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -1268,6 +1268,7 @@
     "stepTitle": "Frame pacing and limiter",
     "enable": "Enable frame limiter",
     "enableHint": "LuminalShine applies the selected limiter provider at stream start and restores the previous driver setting when the stream ends.",
+    "framegenAutoNote": "When a streamed game is detected using DLSS Frame Generation, LuminalShine engages the frame-generation capture fix for that session automatically \u2014 no interaction is required. The per-app capture-fix toggle remains available as a manual override.",
     "providerLabel": "Limiter provider",
     "providerHint": "Auto prefers RTSS whenever it is available and falls back to the NVIDIA Control Panel limiter if needed. NVIDIA's limiter is not recommended because it cannot guarantee perfect frame pacing.",
     "limitLabel": "FPS limit override",

--- a/tests/unit/test_process.cpp
+++ b/tests/unit/test_process.cpp
@@ -270,3 +270,60 @@ TEST_F(ProcessPNGTest, ValidateAppImagePath_OldSteamDefault) {
   const std::string result = proc::validate_app_image_path("./assets/steam.png");
   EXPECT_EQ(result, SUNSHINE_ASSETS_DIR "/steam.png");
 }
+
+// Tests for extract_command_exe_name (per-app RTSS profile scoping)
+TEST(ExtractCommandExeName, PlainPath) {
+  EXPECT_EQ(proc::extract_command_exe_name(R"(C:\Games\game.exe)"), "game.exe");
+}
+
+TEST(ExtractCommandExeName, QuotedPathWithSpacesAndArgs) {
+  EXPECT_EQ(proc::extract_command_exe_name(R"("C:\Program Files\My Game\game.exe" --fullscreen -w 1920)"), "game.exe");
+}
+
+TEST(ExtractCommandExeName, UnquotedWithArgs) {
+  EXPECT_EQ(proc::extract_command_exe_name(R"(C:\Games\game.exe --launch)"), "game.exe");
+}
+
+TEST(ExtractCommandExeName, ForwardSlashes) {
+  EXPECT_EQ(proc::extract_command_exe_name("C:/Games/game.exe"), "game.exe");
+}
+
+TEST(ExtractCommandExeName, UppercaseExtension) {
+  EXPECT_EQ(proc::extract_command_exe_name(R"(C:\Games\GAME.EXE)"), "GAME.EXE");
+}
+
+TEST(ExtractCommandExeName, LeadingWhitespace) {
+  EXPECT_EQ(proc::extract_command_exe_name("   \tC:\\Games\\game.exe"), "game.exe");
+}
+
+TEST(ExtractCommandExeName, BareExeNoPath) {
+  EXPECT_EQ(proc::extract_command_exe_name("game.exe"), "game.exe");
+}
+
+TEST(ExtractCommandExeName, EmptyCommand) {
+  EXPECT_EQ(proc::extract_command_exe_name(""), "");
+}
+
+TEST(ExtractCommandExeName, WhitespaceOnly) {
+  EXPECT_EQ(proc::extract_command_exe_name("   "), "");
+}
+
+TEST(ExtractCommandExeName, SteamUri) {
+  EXPECT_EQ(proc::extract_command_exe_name("steam://rungameid/1234567"), "");
+}
+
+TEST(ExtractCommandExeName, BatchScript) {
+  EXPECT_EQ(proc::extract_command_exe_name(R"(C:\Games\start.bat)"), "");
+}
+
+TEST(ExtractCommandExeName, MissingClosingQuote) {
+  EXPECT_EQ(proc::extract_command_exe_name(R"("C:\Games\game.exe)"), "");
+}
+
+TEST(ExtractCommandExeName, TooShortToken) {
+  EXPECT_EQ(proc::extract_command_exe_name(".exe"), "");
+}
+
+TEST(ExtractCommandExeName, ExeSubstringButNotSuffix) {
+  EXPECT_EQ(proc::extract_command_exe_name(R"(C:\Games\game.exe.config)"), "");
+}


### PR DESCRIPTION
Fixes the three field-reported game-interference issues traced in the background-interference audit: games launched under LuminalShine failing to start (007: First Light), streamed titles losing frame rate (Forza Horizon 6), and a massive system-wide GPU perf collapse while LuminalShine idles in the background (3DMark/BF5 at ~20 FPS vs 120+ without it).

## Root causes addressed

1. **Ghost virtual display** — `cleanup_ensure_display()` retained a temporary probe display indefinitely after a failed encoder probe; games enumerate and land on it, and IddCx presentation tanks benchmark/game performance while LuminalShine runs. Now a `task_pool` reaper removes a retained probe display after **3 idle minutes** with no RTSP/WebRTC session and no launched app. Any `ensure_display()` reuse or keep-path refreshes the retention timestamp under the state mutex, and the reaper re-checks staleness before removal, so a display claimed by an imminent launch is never reaped.

2. **RTSS cap scope + lifetime** (the Forza cap and the likely 007 launch blocker):
   - The frame cap now targets a **per-app RTSS profile** (`game.exe.cfg`) resolved from the running app's command, falling back to the Global profile when the exe is unknown (desktop stream, URIs) or is a known launcher/bootstrapper (steam.exe, launcher.exe, …). Profiles we created are deleted on restore; the crash-recovery snapshot carries the profile name and created flag (old-format recovery files still restore to Global).
   - **RTSS.exe is never left running across paused sessions.** `keep_rtss_running` is gone: RTSS's hooks inject into every process that starts while it runs, which is exactly the pattern anti-tamper titles refuse to launch under. If LuminalShine started RTSS, it stops it at every limiter teardown; resume relaunches it.

3. **Native frame-generation capture fix** — the gen1/gen2 per-app toggles remain as manual overrides, but the encoder path now detects DLSS Frame Generation in the streamed game (`render_stack::snapshot().has_dlss_fg`) and engages the gen2 capture fix automatically: `frame_limiter_notify_frame_generation()` re-applies the limiter overrides with the fix once per session, off the encoder thread (task_pool) so first frames aren't stalled, and only when RTSS is actually available (never drops an NVCP cap without replacement).

4. **GPU scheduling priority revert** — capture init raises the whole process to REALTIME/HIGH GPU scheduling priority and nothing ever reverted it, so an idle host outranked every foreground game at the GPU scheduler from the first probe onward. New `platf::reset_gpu_scheduling_priority()` restores NORMAL after the startup encoder probe and in `streaming_will_stop()`.

## Notes for review

- No config keys added or changed — `test_config_consistency` unaffected.
- Behavior change to confirm intent: with `frame_limiter_enable=false`, a DLSS-FG game now auto-engages the RTSS capture fix for the stream's duration (restored at stop). This matches the "native, not a triggered option" direction; shout if it should additionally be gated on the limiter toggle.
- Known limitation: per-app RTSS scoping keys off the app command's exe; launcher-indirected titles fall back to the Global profile (previous behavior) rather than silently capping the wrong process.
- An adversarial review pass already ran over the first commit; its findings (profile self-aliasing on refresh-restart, NVCP-drop path, reaper/ensure GUID race, snapshot persistence for created profiles) are fixed in the second commit.

Verification: cannot compile Windows targets locally (macOS) — relying on `ci-windows` for build + `test_sunshine`. Manual field test plan: (1) idle host for >5 min after a failed probe → no extra monitor in Display settings; (2) stream with RTSS enabled → cap lands in `Profiles/<game>.exe.cfg`, Global untouched; (3) disconnect mid-app → `RTSS.exe` exits; (4) launch 007: First Light with LuminalShine idle → starts; (5) 3DMark with LuminalShine idle → parity with LuminalShine stopped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
