### PR TITLE
chore: track LuminalVGD as submodule at src/drivers/luminal-display

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,3 +91,11 @@
 [submodule "winget-pkgs"]
 	path = winget-pkgs
 	url = https://github.com/microsoft/winget-pkgs.git
+# LuminalVGD — the first-party LuminalShine virtual display driver
+# (AGPL-3.0/NALA dual-licensed, pre-development). Tracked here so the
+# driver sources can be pulled as a build requirement once integration
+# starts; nothing in the build graph consumes this path yet.
+[submodule "src/drivers/luminal-display"]
+	path = src/drivers/luminal-display
+	url = https://github.com/NortheBridge/LuminalVGD.git
+	branch = main


### PR DESCRIPTION
Adds [NortheBridge/LuminalVGD](https://github.com/NortheBridge/LuminalVGD) (branch `main`) as a git submodule at `src/drivers/luminal-display`, so the first-party VDD sources can be pulled as a build requirement when integration starts.

- Pointer-only change: nothing in CMake or CI consumes `src/drivers/luminal-display` yet.
- CI's `git submodule update --init --force --depth=1 --recursive` retry loop will clone it (public repo, 5 files).
- Entry annotated in `.gitmodules` following the file's documentation conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)