### PR TITLE
feat(web): LuminalVGD Options header dropdown with Control Panel and About pages

### DIFF
--- a/src_assets/common/assets/web/App.vue
+++ b/src_assets/common/assets/web/App.vue
@@ -65,6 +65,17 @@
                     <RouterLink to="/troubleshooting" :class="linkClass('/troubleshooting')">
                       <i class="fas fa-bug" /><span>{{ $t('navbar.troubleshoot') }}</span>
                     </RouterLink>
+                    <n-dropdown
+                      trigger="hover"
+                      :show-arrow="true"
+                      :options="vgdMenuOptions"
+                      @select="onNavSelect"
+                    >
+                      <button type="button" :class="vgdLinkClass()">
+                        <i class="fas fa-display" /><span>{{ $t('vgd.nav') }}</span>
+                        <i class="fas fa-chevron-down text-[10px] opacity-70" />
+                      </button>
+                    </n-dropdown>
                     <RouterLink to="/about" :class="linkClass('/about')">
                       <i class="fas fa-circle-info" /><span>{{ $t('navbar.about') }}</span>
                     </RouterLink>
@@ -220,6 +231,8 @@ watch(
       '/troubleshooting': 'navbar.troubleshoot',
       '/clients': 'clients.nav',
       '/webrtc': 'webrtc.nav',
+      '/vgd-control-panel': 'vgd.nav_control_panel',
+      '/vgd-about': 'vgd.nav_about',
     };
     const v = map[p] || 'LuminalShine';
     pageTitle.value = v;
@@ -266,8 +279,36 @@ function refreshPage() {
 }
 
 const { t } = useI18n();
+const navIcon = (cls: string) => () => h('i', { class: cls });
+
+// "LuminalVGD Options" dropdown, shared between the desktop nav and the
+// mobile menu (as a submenu).
+const vgdMenuOptions = computed(() => [
+  {
+    label: t('vgd.nav_control_panel'),
+    key: '/vgd-control-panel',
+    icon: navIcon('fas fa-sliders'),
+  },
+  { label: t('vgd.nav_about'), key: '/vgd-about', icon: navIcon('fas fa-circle-info') },
+]);
+
+const vgdLinkClass = () => {
+  const base =
+    'inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-[13px] transition-colors';
+  if (route.path.startsWith('/vgd-'))
+    return (
+      base +
+      ' font-semibold text-onPrimary bg-gradient-to-br from-primary/90 to-secondary/80 shadow-[0_8px_24px_-12px_rgba(255,176,32,0.55)]'
+    );
+  return base + ' text-[var(--sun-text-secondary)] hover:text-onDark hover:bg-white/5';
+};
+
+function onNavSelect(key: string | number): void {
+  if (typeof key === 'string') void router.push(key);
+}
+
 const mobileMenuOptions = computed(() => {
-  const icon = (cls: string) => () => h('i', { class: cls });
+  const icon = navIcon;
   if (statsOnly.value) {
     return [
       { label: t('stats.nav'), key: '/stats', icon: icon('fas fa-chart-line') },
@@ -286,6 +327,12 @@ const mobileMenuOptions = computed(() => {
     { label: t('webrtc.nav'), key: '/webrtc', icon: icon('fas fa-satellite-dish') },
     { label: t('navbar.configuration'), key: '/settings', icon: icon('fas fa-sliders') },
     { label: t('navbar.troubleshoot'), key: '/troubleshooting', icon: icon('fas fa-bug') },
+    {
+      label: t('vgd.nav'),
+      key: '__vgd',
+      icon: icon('fas fa-display'),
+      children: vgdMenuOptions.value,
+    },
     { label: t('navbar.about'), key: '/about', icon: icon('fas fa-circle-info') },
     { type: 'divider' as const },
     { label: t('navbar.logout'), key: '__logout', icon: icon('fas fa-sign-out-alt') },

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -344,7 +344,7 @@
     "virtual_display_backend_auto": "Auto (recommended) — SudoVDA",
     "virtual_display_backend_sudovda": "SudoVDA (default)",
     "virtual_display_backend_none": "No virtual display driver installed",
-    "virtual_display_backend_sudovda_warning": "Heads up: SudoVDA may hang on the latest Windows 11 release builds and on Windows 11 Insider Preview channels (WUDFHostProblem2). If your virtual display fails to come up, use Troubleshooting \u2192 Restart Virtual Display Driver.",
+    "virtual_display_backend_sudovda_warning": "Heads up: SudoVDA may hang on the latest Windows 11 release builds and on Windows 11 Insider Preview channels (WUDFHostProblem2). If your virtual display fails to come up, use Troubleshooting → Restart Virtual Display Driver.",
     "virtual_display_backend_future_note": "A first-party LuminalShine Virtual Display Driver is planned for a future release and will replace SudoVDA as the default once it ships.",
     "virtual_display_backend_none_warning": "No virtual display driver is installed. Per-client virtual displays will not work. Open the Start Menu and run \"Reconfigure LuminalShine\" (or relaunch the installer) and pick SudoVDA to install one.",
     "dd_pre_stream_setup": "Pre-stream setup",
@@ -1290,7 +1290,7 @@
     "stepTitle": "Frame pacing and limiter",
     "enable": "Enable frame limiter",
     "enableHint": "LuminalShine applies the selected limiter provider at stream start and restores the previous driver setting when the stream ends.",
-    "framegenAutoNote": "When a streamed game is detected using DLSS Frame Generation, LuminalShine engages the frame-generation capture fix for that session automatically \u2014 no interaction is required. The per-app capture-fix toggle remains available as a manual override.",
+    "framegenAutoNote": "When a streamed game is detected using DLSS Frame Generation, LuminalShine engages the frame-generation capture fix for that session automatically — no interaction is required. The per-app capture-fix toggle remains available as a manual override.",
     "providerLabel": "Limiter provider",
     "providerHint": "Auto prefers RTSS whenever it is available and falls back to the NVIDIA Control Panel limiter if needed. NVIDIA's limiter is not recommended because it cannot guarantee perfect frame pacing.",
     "limitLabel": "FPS limit override",
@@ -1342,5 +1342,24 @@
     },
     "noticeTitle": "RTSS recommended",
     "noticeCopy": "RTSS offers the most stable frame pacing. LuminalShine will use it automatically when available; NVIDIA's limiter is not recommended because it cannot guarantee perfect frame pacing."
+  },
+  "vgd": {
+    "about_check_updates": "Check for LuminalVGD updates",
+    "about_checking": "Checking for updates…",
+    "about_driver_card": "Driver identity",
+    "about_host_card": "LuminalShine pairing",
+    "about_no_release": "No public LuminalVGD releases yet — the driver is still in prototype.",
+    "about_official_site": "Official site",
+    "about_subtitle": "Information about the installed LuminalVGD driver and its pairing with this LuminalShine host.",
+    "about_title": "About LuminalVGD",
+    "about_update_error": "Update check failed — the release service could not be reached.",
+    "about_update_found": "Latest release: {tag} (published {date})",
+    "control_panel_subtitle": "Everything LuminalShine will configure for the LuminalVGD virtual display driver, as defined by the driver design documentation.",
+    "control_panel_title": "LuminalVGD Control Panel",
+    "nav": "LuminalVGD Options",
+    "nav_about": "About LuminalVGD",
+    "nav_control_panel": "LuminalVGD Control Panel",
+    "proto_notice": "LuminalVGD is currently in prototype and not currently available.",
+    "proto_visit": "Visit {link} for more information."
   }
 }

--- a/src_assets/common/assets/web/router.ts
+++ b/src_assets/common/assets/web/router.ts
@@ -11,6 +11,8 @@ const ClientManagementView = () => import('@/views/ClientManagementView.vue');
 const WebRtcClientView = () => import('@/views/WebRtcClientView.vue');
 const AboutView = () => import('@/views/AboutView.vue');
 const StatsView = () => import('@/views/StatsView.vue');
+const VgdControlPanelView = () => import('@/views/VgdControlPanelView.vue');
+const VgdAboutView = () => import('@/views/VgdAboutView.vue');
 
 const routes = [
   { path: '/', component: DashboardView },
@@ -27,6 +29,10 @@ const routes = [
   },
   { path: '/webrtc', component: WebRtcClientView, meta: { container: 'full' } },
   { path: '/stats', component: StatsView },
+  // Single-depth paths on purpose: the Vite build uses base './', so assets
+  // resolve relative to the URL — a nested route would request /vgd/assets/*.
+  { path: '/vgd-control-panel', component: VgdControlPanelView, meta: { container: 'lg' } },
+  { path: '/vgd-about', component: VgdAboutView, meta: { container: 'lg' } },
 ];
 
 const CHUNK_RELOAD_FLAG = 'sunshine:chunk-reload';

--- a/src_assets/common/assets/web/views/VgdAboutView.vue
+++ b/src_assets/common/assets/web/views/VgdAboutView.vue
@@ -1,0 +1,209 @@
+<template>
+  <div class="space-y-6">
+    <div>
+      <h1 class="text-2xl font-semibold tracking-tight text-dark dark:text-light">
+        {{ t('vgd.about_title') }}
+      </h1>
+      <p class="text-xs opacity-70 leading-snug mt-1">
+        {{ t('vgd.about_subtitle') }}
+      </p>
+    </div>
+
+    <n-alert type="warning" :show-icon="true">
+      <span class="font-semibold">{{ t('vgd.proto_notice') }}</span>
+      <i18n-t keypath="vgd.proto_visit" tag="span" class="block mt-0.5">
+        <template #link>
+          <a
+            :href="VGD_SITE_URL"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="underline underline-offset-2 hover:opacity-80 break-all"
+            >{{ VGD_SITE_URL }}</a
+          >
+        </template>
+      </i18n-t>
+    </n-alert>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <!-- Driver identity: static design-document facts until the driver
+           ships and /api/metadata starts carrying live handshake data. -->
+      <section class="rounded-xl border border-white/10 bg-white/[0.03] p-4 sm:p-5 space-y-3">
+        <div class="flex items-center gap-2">
+          <i class="fas fa-display text-primary" />
+          <h2 class="text-base font-semibold text-dark dark:text-light">
+            {{ t('vgd.about_driver_card') }}
+          </h2>
+        </div>
+        <dl class="space-y-2 text-sm">
+          <div v-for="row in driverRows" :key="row.label" class="flex justify-between gap-4">
+            <dt class="opacity-70">{{ row.label }}</dt>
+            <dd class="font-mono text-right break-all">{{ row.value }}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="rounded-xl border border-white/10 bg-white/[0.03] p-4 sm:p-5 space-y-3">
+        <div class="flex items-center gap-2">
+          <i class="fas fa-link text-primary" />
+          <h2 class="text-base font-semibold text-dark dark:text-light">
+            {{ t('vgd.about_host_card') }}
+          </h2>
+        </div>
+        <dl class="space-y-2 text-sm">
+          <div v-for="row in hostRows" :key="row.label" class="flex justify-between gap-4">
+            <dt class="opacity-70">{{ row.label }}</dt>
+            <dd class="font-mono text-right break-all">{{ row.value }}</dd>
+          </div>
+        </dl>
+      </section>
+    </div>
+
+    <section class="rounded-xl border border-white/10 bg-white/[0.03] p-4 sm:p-5 space-y-3">
+      <div class="flex items-center justify-between gap-4 flex-wrap">
+        <div class="flex items-center gap-2">
+          <i class="fas fa-cloud-arrow-down text-primary" />
+          <h2 class="text-base font-semibold text-dark dark:text-light">
+            {{ tr('vgd.about_updates_card', 'Updates') }}
+          </h2>
+        </div>
+        <div class="flex items-center gap-2">
+          <a
+            :href="VGD_SITE_URL"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-xs underline underline-offset-2 opacity-80 hover:opacity-100"
+          >
+            {{ t('vgd.about_official_site') }}
+          </a>
+          <n-button
+            type="primary"
+            size="small"
+            :loading="updateState === 'checking'"
+            :disabled="updateState === 'checking'"
+            @click="checkForUpdates"
+          >
+            {{ t('vgd.about_check_updates') }}
+          </n-button>
+        </div>
+      </div>
+      <div class="min-h-[1.5rem] text-sm">
+        <span v-if="updateState === 'checking'" class="opacity-70">
+          {{ t('vgd.about_checking') }}
+        </span>
+        <n-alert v-else-if="updateState === 'none'" type="info" :show-icon="true">
+          {{ t('vgd.about_no_release') }}
+        </n-alert>
+        <n-alert v-else-if="updateState === 'found'" type="success" :show-icon="true">
+          <a
+            :href="latestRelease.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="underline underline-offset-2"
+          >
+            {{ t('vgd.about_update_found', { tag: latestRelease.tag, date: latestRelease.date }) }}
+          </a>
+        </n-alert>
+        <n-alert v-else-if="updateState === 'error'" type="error" :show-icon="true">
+          {{ t('vgd.about_update_error') }}
+        </n-alert>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { storeToRefs } from 'pinia';
+import { NAlert, NButton } from 'naive-ui';
+import { useConfigStore } from '@/stores/config';
+
+const { t } = useI18n();
+const VGD_SITE_URL = 'https://apps.northebridge.com/en/LuminalVGD';
+// Public releases feed of the driver repo; returns 404 until the first
+// release ships, which the UI reports as "still in prototype".
+const VGD_RELEASES_API = 'https://api.github.com/repos/NortheBridge/LuminalVGD/releases/latest';
+
+const tr = (key: string, fallback: string) => {
+  const value = t(key);
+  return value === key ? fallback : value;
+};
+
+const store = useConfigStore();
+const { metadata } = storeToRefs(store);
+
+const driverRows = computed(() => [
+  {
+    label: tr('vgd.about_status', 'Status'),
+    value: tr('vgd.about_status_prototype', 'Prototype (pre-development)'),
+  },
+  {
+    label: tr('vgd.about_driver_version', 'Driver version'),
+    value: tr('vgd.about_not_installed', 'Not installed'),
+  },
+  { label: tr('vgd.about_protocol', 'Design protocol'), value: 'v0.3' },
+  {
+    label: tr('vgd.about_device', 'Device'),
+    value: 'Luminal Video Graphics Display (root\\luminal_vgd)',
+  },
+  { label: tr('vgd.about_provider', 'Provider'), value: 'NortheBridge Foundation' },
+]);
+
+const hostRows = computed(() => {
+  const md = (metadata.value || {}) as { version?: string; release_date?: string };
+  return [
+    {
+      label: tr('vgd.about_this_host', 'This LuminalShine'),
+      value: md?.version || '—',
+    },
+    {
+      label: tr('vgd.about_host_built', 'LuminalShine built'),
+      value: md?.release_date || '—',
+    },
+    { label: tr('vgd.about_shipped_with', 'Driver shipped with LuminalShine'), value: '—' },
+    { label: tr('vgd.about_driver_built', 'Driver built'), value: '—' },
+    { label: tr('vgd.about_signature', 'Driver signature'), value: '—' },
+  ];
+});
+
+type UpdateState = 'idle' | 'checking' | 'none' | 'found' | 'error';
+const updateState = ref<UpdateState>('idle');
+// Only meaningful while updateState === 'found'; the state machine gates it.
+const latestRelease = ref({ tag: '', date: '', url: '' });
+
+async function checkForUpdates(): Promise<void> {
+  updateState.value = 'checking';
+  try {
+    // Native fetch on purpose: the app's axios instance sends credentials
+    // and custom headers, which cross-origin GitHub rejects under CORS.
+    const res = await fetch(VGD_RELEASES_API, {
+      headers: { Accept: 'application/vnd.github+json' },
+    });
+    if (res.status === 404) {
+      updateState.value = 'none';
+      return;
+    }
+    if (!res.ok) {
+      updateState.value = 'error';
+      return;
+    }
+    const data: unknown = await res.json();
+    const rel = data as { tag_name?: unknown; published_at?: unknown; html_url?: unknown };
+    if (typeof rel.tag_name === 'string' && rel.tag_name) {
+      latestRelease.value = {
+        tag: rel.tag_name,
+        date:
+          typeof rel.published_at === 'string' && rel.published_at
+            ? rel.published_at.slice(0, 10)
+            : '?',
+        url: typeof rel.html_url === 'string' ? rel.html_url : VGD_SITE_URL,
+      };
+      updateState.value = 'found';
+      return;
+    }
+    updateState.value = 'none';
+  } catch {
+    updateState.value = 'error';
+  }
+}
+</script>

--- a/src_assets/common/assets/web/views/VgdControlPanelView.vue
+++ b/src_assets/common/assets/web/views/VgdControlPanelView.vue
@@ -1,0 +1,401 @@
+<template>
+  <!-- Prototype preview: every control is intentionally disabled and the
+       accent is forced grey (instead of sun-gold) via the local theme
+       override below until the LuminalVGD driver ships. -->
+  <n-config-provider :theme-overrides="greyOverrides">
+    <div class="space-y-6">
+      <div>
+        <h1 class="text-2xl font-semibold tracking-tight text-dark dark:text-light">
+          {{ t('vgd.control_panel_title') }}
+        </h1>
+        <p class="text-xs opacity-70 leading-snug mt-1">
+          {{ t('vgd.control_panel_subtitle') }}
+        </p>
+      </div>
+
+      <n-alert type="warning" :show-icon="true">
+        <span class="font-semibold">{{ t('vgd.proto_notice') }}</span>
+        <i18n-t keypath="vgd.proto_visit" tag="span" class="block mt-0.5">
+          <template #link>
+            <a
+              :href="VGD_SITE_URL"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="underline underline-offset-2 hover:opacity-80 break-all"
+              >{{ VGD_SITE_URL }}</a
+            >
+          </template>
+        </i18n-t>
+      </n-alert>
+
+      <section
+        v-for="group in groups"
+        :key="group.title"
+        class="rounded-xl border border-white/10 bg-white/[0.03] p-4 sm:p-5 space-y-4 opacity-90"
+      >
+        <div class="flex items-center gap-2">
+          <i :class="group.icon + ' text-neutral-400'" />
+          <h2 class="text-base font-semibold text-dark dark:text-light">{{ group.title }}</h2>
+        </div>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-x-8 gap-y-4">
+          <div
+            v-for="item in group.items"
+            :key="item.label"
+            class="flex items-start justify-between gap-4"
+          >
+            <div class="min-w-0">
+              <div class="text-sm font-medium text-neutral-400">{{ item.label }}</div>
+              <p class="text-xs opacity-60 leading-snug mt-0.5">{{ item.hint }}</p>
+            </div>
+            <div class="shrink-0 pt-0.5">
+              <n-switch
+                v-if="item.type === 'switch'"
+                :value="Boolean(item.value)"
+                :disabled="true"
+              />
+              <n-select
+                v-else-if="item.type === 'select'"
+                :value="String(item.value)"
+                :options="item.options"
+                :disabled="true"
+                size="small"
+                class="w-56"
+              />
+              <n-input-number
+                v-else-if="item.type === 'number'"
+                :value="Number(item.value)"
+                :disabled="true"
+                size="small"
+                class="w-36"
+              >
+                <template v-if="item.suffix" #suffix>{{ item.suffix }}</template>
+              </n-input-number>
+              <n-input
+                v-else
+                :value="String(item.value)"
+                :placeholder="item.placeholder"
+                :disabled="true"
+                size="small"
+                class="w-56"
+              />
+            </div>
+          </div>
+        </div>
+        <p v-if="group.footnote" class="text-[11px] opacity-50 leading-snug">
+          {{ group.footnote }}
+        </p>
+      </section>
+    </div>
+  </n-config-provider>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { NConfigProvider, NAlert, NSwitch, NSelect, NInputNumber, NInput } from 'naive-ui';
+import type { GlobalThemeOverrides } from 'naive-ui';
+
+const { t } = useI18n();
+
+const VGD_SITE_URL = 'https://apps.northebridge.com/en/LuminalVGD';
+
+// Neutral greys stand in for the sun-gold primary while the driver is in
+// prototype; delete this override when the panel goes live.
+const greyOverrides: GlobalThemeOverrides = {
+  common: {
+    primaryColor: '#9CA3AF',
+    primaryColorHover: '#9CA3AF',
+    primaryColorPressed: '#6B7280',
+    primaryColorSuppl: '#9CA3AF',
+  },
+};
+
+const tr = (key: string, fallback: string) => {
+  const value = t(key);
+  return value === key ? fallback : value;
+};
+
+interface PanelItem {
+  label: string;
+  hint: string;
+  type: 'switch' | 'select' | 'number' | 'text';
+  value: string | number | boolean;
+  options?: { label: string; value: string }[];
+  suffix?: string;
+  placeholder?: string;
+}
+
+interface PanelGroup {
+  title: string;
+  icon: string;
+  items: PanelItem[];
+  footnote?: string;
+}
+
+// Values shown are the design-document defaults (LuminalVGD proto v0.3 +
+// the LuminalShine host-side VgdConfig); nothing here is wired to config.
+const groups = computed<PanelGroup[]>(() => [
+  {
+    title: tr('vgd.group_backend', 'Backend & sessions'),
+    icon: 'fas fa-microchip',
+    items: [
+      {
+        label: tr('vgd.backend', 'Virtual display backend'),
+        hint: tr(
+          'vgd.backend_hint',
+          'LuminalVGD becomes the default backend once the driver ships; SudoVDA remains available.',
+        ),
+        type: 'select',
+        value: 'luminalvgd',
+        options: [
+          { label: tr('vgd.backend_auto', 'Automatic'), value: 'auto' },
+          { label: 'SudoVDA', value: 'sudovda' },
+          { label: 'LuminalVGD', value: 'luminalvgd' },
+        ],
+      },
+      {
+        label: tr('vgd.max_monitors', 'Maximum virtual monitors'),
+        hint: tr('vgd.max_monitors_hint', 'Global cap on concurrent virtual monitors (up to 16).'),
+        type: 'number',
+        value: 10,
+      },
+      {
+        label: tr('vgd.watchdog', 'Lease watchdog'),
+        hint: tr(
+          'vgd.watchdog_hint',
+          'Reaps a virtual monitor when its stream stops pinging; 0 disables the watchdog.',
+        ),
+        type: 'number',
+        value: 3,
+        suffix: 's',
+      },
+      {
+        label: tr('vgd.lease_timeout', 'Per-stream lease timeout'),
+        hint: tr(
+          'vgd.lease_timeout_hint',
+          'Per-monitor override of the watchdog (3–300 seconds, or driver default).',
+        ),
+        type: 'text',
+        value: '',
+        placeholder: tr('vgd.driver_default', 'Driver default'),
+      },
+    ],
+  },
+  {
+    title: tr('vgd.group_identity', 'Display identity & lifetime'),
+    icon: 'fas fa-fingerprint',
+    items: [
+      {
+        label: tr('vgd.stable_identity', 'Stable display identity'),
+        hint: tr(
+          'vgd.stable_identity_hint',
+          'Reuse the same monitor identity across reconnects so Windows restores resolution, HDR, and scaling.',
+        ),
+        type: 'switch',
+        value: true,
+      },
+      {
+        label: tr('vgd.keep_paused', 'Keep virtual display while paused'),
+        hint: tr(
+          'vgd.keep_paused_hint',
+          'How long a paused stream keeps its virtual display alive; 0 keeps it until resume.',
+        ),
+        type: 'number',
+        value: 0,
+        suffix: 's',
+      },
+      {
+        label: tr('vgd.permanent_pool', 'Permanent display pool'),
+        hint: tr(
+          'vgd.permanent_pool_hint',
+          'Always-on virtual displays that exist outside any stream and survive driver restarts (up to 4).',
+        ),
+        type: 'number',
+        value: 0,
+      },
+      {
+        label: tr('vgd.permanent_mode', 'Permanent display mode'),
+        hint: tr(
+          'vgd.permanent_mode_hint',
+          'Resolution and refresh rate for pool members; validated against the mode envelope.',
+        ),
+        type: 'text',
+        value: '',
+        placeholder: '1920×1080 @ 60 Hz',
+      },
+    ],
+  },
+  {
+    title: tr('vgd.group_modes', 'Modes & refresh'),
+    icon: 'fas fa-display',
+    items: [
+      {
+        label: tr('vgd.advertised_modes', 'Advertised modes'),
+        hint: tr(
+          'vgd.advertised_modes_hint',
+          'Up to four exact modes per monitor, native first — switching between them needs no monitor recreate.',
+        ),
+        type: 'text',
+        value: '',
+        placeholder: tr('vgd.advertised_modes_placeholder', 'Native mode (automatic)'),
+      },
+      {
+        label: tr('vgd.refresh_doubling', 'Refresh doubling for frame generation'),
+        hint: tr(
+          'vgd.refresh_doubling_hint',
+          'Advertise 2× the client refresh rate while frame generation is active.',
+        ),
+        type: 'switch',
+        value: true,
+      },
+    ],
+    footnote: tr(
+      'vgd.modes_footnote',
+      'Mode envelope: 320×200 to 7680×4320, even dimensions, millihertz-precise refresh (59.94 Hz supported), no refresh ceiling.',
+    ),
+  },
+  {
+    title: tr('vgd.group_color', 'Color & HDR'),
+    icon: 'fas fa-palette',
+    items: [
+      {
+        label: tr('vgd.bit_depth', 'Bit depth'),
+        hint: tr(
+          'vgd.bit_depth_hint',
+          'Advertised dynamic range and depth; gated by negotiated driver capabilities.',
+        ),
+        type: 'select',
+        value: '8',
+        options: [
+          { label: tr('vgd.depth_sdr8', '8-bit SDR (default)'), value: '8' },
+          { label: tr('vgd.depth_sdr10', '10-bit SDR'), value: '10' },
+          { label: tr('vgd.depth_hdr10', '10-bit HDR (HDR10)'), value: '110' },
+          { label: tr('vgd.depth_hdr12', '12-bit HDR'), value: '112' },
+        ],
+      },
+      {
+        label: tr('vgd.hdr', 'HDR'),
+        hint: tr('vgd.hdr_hint', 'Requires Windows 11 24H2 and an HDR-capable bit depth.'),
+        type: 'switch',
+        value: false,
+      },
+    ],
+  },
+  {
+    title: tr('vgd.group_gpu', 'GPU & performance'),
+    icon: 'fas fa-gauge-high',
+    items: [
+      {
+        label: tr('vgd.adapter', 'Preferred render adapter'),
+        hint: tr(
+          'vgd.adapter_hint',
+          'Match a GPU by name for hybrid-GPU systems; empty selects the adapter with the most VRAM.',
+        ),
+        type: 'text',
+        value: '',
+        placeholder: tr('vgd.adapter_placeholder', 'Largest VRAM (automatic)'),
+      },
+      {
+        label: tr('vgd.ring_slots', 'Frame ring slots'),
+        hint: tr(
+          'vgd.ring_slots_hint',
+          'Depth of the shared keyed-mutex texture ring between driver and host (1–8).',
+        ),
+        type: 'number',
+        value: 3,
+      },
+      {
+        label: tr('vgd.mutex_timeout', 'Keyed-mutex acquire timeout'),
+        hint: tr(
+          'vgd.mutex_timeout_hint',
+          'Bounded wait when acquiring a shared frame — the driver never waits unbounded.',
+        ),
+        type: 'number',
+        value: 100,
+        suffix: 'ms',
+      },
+      {
+        label: tr('vgd.dda_fallback', 'Desktop Duplication fallback'),
+        hint: tr(
+          'vgd.dda_fallback_hint',
+          'Allow DXGI Desktop Duplication as the last-resort capture path.',
+        ),
+        type: 'switch',
+        value: true,
+      },
+    ],
+  },
+  {
+    title: tr('vgd.group_edid', 'EDID & physical'),
+    icon: 'fas fa-ruler-combined',
+    items: [
+      {
+        label: tr('vgd.friendly_name', 'Monitor name'),
+        hint: tr('vgd.friendly_name_hint', 'Name shown by Windows in the EDID descriptor.'),
+        type: 'text',
+        value: 'Luminal VGD',
+      },
+      {
+        label: tr('vgd.physical_size', 'Physical size'),
+        hint: tr(
+          'vgd.physical_size_hint',
+          'Reported panel dimensions drive Windows DPI scaling; default is 600×340 mm (≈27″).',
+        ),
+        type: 'text',
+        value: '',
+        placeholder: '600 × 340 mm',
+      },
+      {
+        label: tr('vgd.edid_serial', 'EDID serial override'),
+        hint: tr(
+          'vgd.edid_serial_hint',
+          'Explicit EDID serial; 0 derives it from the display identity.',
+        ),
+        type: 'number',
+        value: 0,
+      },
+    ],
+  },
+  {
+    title: tr('vgd.group_recovery', 'Recovery & restore'),
+    icon: 'fas fa-rotate-left',
+    items: [
+      {
+        label: tr('vgd.restore_backoff', 'Restore probe backoff'),
+        hint: tr(
+          'vgd.restore_backoff_hint',
+          'First delay before probing a return to direct capture after a fallback.',
+        ),
+        type: 'number',
+        value: 1000,
+        suffix: 'ms',
+      },
+      {
+        label: tr('vgd.restore_backoff_max', 'Restore backoff ceiling'),
+        hint: tr('vgd.restore_backoff_max_hint', 'Upper bound of the doubling probe backoff.'),
+        type: 'number',
+        value: 30000,
+        suffix: 'ms',
+      },
+      {
+        label: tr('vgd.restore_frames', 'Stable frames before teardown'),
+        hint: tr(
+          'vgd.restore_frames_hint',
+          'Direct-capture frames required before the warm fallback path is torn down.',
+        ),
+        type: 'number',
+        value: 120,
+      },
+      {
+        label: tr('vgd.heartbeat', 'Driver heartbeat / stale threshold'),
+        hint: tr(
+          'vgd.heartbeat_hint',
+          'Liveness cadence and the age at which the host treats the driver as wedged.',
+        ),
+        type: 'text',
+        value: '500 / 2000 ms',
+      },
+    ],
+  },
+]);
+</script>


### PR DESCRIPTION
Toward **26.07.1-beta.2** — the LuminalVGD-ready UI surface.

## What's new

**Header**: a "LuminalVGD Options" dropdown in the desktop nav (and as a submenu in the mobile menu) with two entries: **LuminalVGD Control Panel** and **About LuminalVGD**. The trigger takes the standard active-pill styling when either page is open.

**/vgd-control-panel** — everything LuminalShine intends to configure for the LuminalVGD driver, sourced from the driver design documentation (`src/drivers/luminal-display` proto v0.3: `CreateMonitorRequest`, device-wide knobs, permanent display pool, host-side `VgdConfig`), grouped into Backend & sessions, Display identity & lifetime, Modes & refresh, Color & HDR, GPU & performance, EDID & physical, and Recovery & restore. Per the prototype status:
- every control is `disabled`
- a page-local `n-config-provider` theme override renders the accent **grey** where sun-gold would normally appear
- a notice at the top reads "LuminalVGD is currently in prototype and not currently available" and hyperlinks https://apps.northebridge.com/en/LuminalVGD

**/vgd-about** — driver identity (status, design protocol v0.3, device `root\luminal_vgd`, provider), pairing with this LuminalShine build (version/build date from `/api/metadata`, dashes for the not-yet-shipped driver fields, mirroring the Troubleshooting identity block), and a working **Check for LuminalVGD updates** button against the driver repo's public releases feed — returns "still in prototype" while no release exists (verified: the endpoint 404s today) and real version info once one ships.

## Notes for review

- **Single-depth routes on purpose**: the Vite build uses `base: './'`, so built asset URLs are relative — a nested route like `/vgd/control-panel` makes the browser request `/vgd/assets/*.js` and blanks the page (reproduced during visual verification). `/vgd-control-panel` + `/vgd-about` sidestep the landmine; flipping the base to `'/'` repo-wide is a separate discussion.
- The update check uses native `fetch` (not the app's axios instance) because cross-origin GitHub rejects credentialed requests under CORS.
- Verified: eslint clean on both new views, App.vue exactly at its 13-error baseline, vue-tsc at the 127-error baseline (zero new), vitest 10/10, production build, and puppeteer screenshots of both pages, the open dropdown, and the resting header.
- New locale section `vgd` appended to `en.json`; two new route chunks will appear as web-asset rows at the MSI golden gate on the next release build (expected churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)