### PR TITLE
ci: pin actions/upload-artifact at v7.0.1 everywhere

### DIFF
--- a/.github/workflows/ci-archlinux.yml
+++ b/.github/workflows/ci-archlinux.yml
@@ -154,7 +154,7 @@ jobs:
         if: >-
           always() &&
           (steps.build.outcome == 'success' || steps.build.outcome == 'failure')
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-Archlinux
           path: |
@@ -176,7 +176,7 @@ jobs:
           ls -la artifacts/
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: build-Archlinux
           path: artifacts/

--- a/.github/workflows/ci-flatpak.yml
+++ b/.github/workflows/ci-flatpak.yml
@@ -207,7 +207,7 @@ jobs:
           tar -czf ./artifacts/flathub.tar.gz -C ./flathub .
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: build-Linux-Flatpak-${{ matrix.arch }}
           path: artifacts/

--- a/.github/workflows/ci-freebsd.yml
+++ b/.github/workflows/ci-freebsd.yml
@@ -260,7 +260,7 @@ jobs:
         if: >-
           always() &&
           (steps.test_report.outcome == 'success')
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-FreeBSD-${{ matrix.bsd_release }}-${{ matrix.cmake_processor }}
           path: |
@@ -269,7 +269,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: build-FreeBSD-${{ matrix.bsd_release }}-${{ matrix.cmake_processor }}
           path: artifacts/

--- a/.github/workflows/ci-homebrew.yml
+++ b/.github/workflows/ci-homebrew.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload Artifacts
         if: matrix.release
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: build-Homebrew
           path: homebrew/
@@ -160,7 +160,7 @@ jobs:
           always() &&
           matrix.release != true &&
           (steps.test.outcome == 'success' || steps.test.outcome == 'failure')
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-Homebrew-${{ matrix.os_name }}-${{ matrix.os_version }}
           path: |
@@ -204,7 +204,7 @@ jobs:
 
       - name: Upload Artifacts (Beta)
         if: matrix.release
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: beta-Homebrew
           path: homebrew/

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -194,7 +194,7 @@ jobs:
         if: >-
           always() &&
           (steps.test_report.outcome == 'success')
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-Linux-${{ matrix.name }}
           path: |
@@ -203,7 +203,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: build-Linux-${{ matrix.name }}
           path: artifacts/

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -573,7 +573,7 @@ jobs:
         # — which is exactly when we need the candidate output to debug
         # what drifted. Without this, a failing diff hides its own input.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: msi-compat-dump
           path: msi_compat/
@@ -766,7 +766,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: test-results-${{ matrix.name }}
           path: build/tests/test_results.xml
@@ -787,7 +787,7 @@ jobs:
             a "../artifacts/LuminalShine_x64-debuginfo.7z" "*.dbg"
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: build-${{ matrix.name }}
           path: artifacts/

--- a/.github/workflows/coverage-web.yml
+++ b/.github/workflows/coverage-web.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-web
           # vitest.config.ts writes lcov.info into <repoRoot>/coverage/web/.

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -244,7 +244,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always() && steps.test.outcome != 'cancelled'
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-windows
           path: |

--- a/.github/workflows/update-pages.yml
+++ b/.github/workflows/update-pages.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Upload artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: prep
           path: gh-pages-template/


### PR DESCRIPTION
Upgrades all sixteen `actions/upload-artifact` references (fifteen SHA-pinned `v6.0.0`, one stray unpinned `@v4` on the msi-compat-dump upload — the source of the Node 20 deprecation warnings) to [v7.0.1](https://github.com/marketplace/actions/upload-a-build-artifact?version=v7.0.1), SHA-pinned per repo convention (`043fb46d`).

- Artifacts remain on the v4+ backend format, so the existing `download-artifact` v7.0.0/v8.0.1 consumers (`ci.yml` release job, copr, jekyll) are unaffected.
- `coverage-windows.yml`'s upload runs on this PR, so v7.0.1 is exercised by the PR's own checks; the `ci-windows.yml` release-artifact uploads get exercised on the next release dispatch.
- Groundwork for nightly.link consumption of build artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)