### PR TITLE
ci: per-commit unsigned nightly build with portable-ZIP artifact

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -11,6 +11,14 @@ on:
       release_version:
         required: true
         type: string
+      nightly:
+        # Unsigned per-commit build for nightly.link consumption: signing
+        # and the MSI golden/invariant gates are skipped (the version base
+        # differs from the release baseline by design), and only the
+        # portable ZIP is uploaded, under a stable artifact name.
+        required: false
+        type: boolean
+        default: false
     # Secrets are forwarded from ci.yml via `secrets: inherit`. They are
     # declared optional here so the build still runs while SIGN_ARTIFACTS
     # is disabled (no values present) and only enforced inside the signing
@@ -62,6 +70,10 @@ jobs:
   build_windows:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    env:
+      # Shadows the workflow-level gate: nightly builds always ship
+      # unsigned regardless of the release signing configuration above.
+      SIGN_ARTIFACTS: ${{ inputs.nightly && 'false' || 'true' }}
     defaults:
       run:
         shell: msys2 {0}
@@ -527,6 +539,7 @@ jobs:
           cpack -G ZIP
 
       - name: MSI upgrade-compatibility check
+        if: inputs.nightly != true
         # MSI table compatibility oracle. Dumps the freshly built MSI's
         # upgrade-critical tables and diffs them against the committed
         # baseline (tests/fixtures/msi_golden/msi_baseline.txt). PR 4
@@ -551,6 +564,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "MSI upgrade-compatibility diff failed (see above)." }
 
       - name: MSI invariants gate
+        if: inputs.nightly != true
         # Hard gate that runs after the diff. Where the diff says "this
         # MSI matches the committed snapshot," this asserts "this MSI
         # carries the upgrade-load-bearing values regardless of what the
@@ -572,7 +586,7 @@ jobs:
         # if: always() so the dump uploads even when the diff step fails
         # — which is exactly when we need the candidate output to debug
         # what drifted. Without this, a failing diff hides its own input.
-        if: always()
+        if: always() && inputs.nightly != true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: msi-compat-dump
@@ -773,6 +787,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Package Windows Debug Info
+        if: inputs.nightly != true
         shell: pwsh
         working-directory: build
         run: |
@@ -787,8 +802,21 @@ jobs:
             a "../artifacts/LuminalShine_x64-debuginfo.7z" "*.dbg"
 
       - name: Upload Artifacts
+        if: inputs.nightly != true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: build-${{ matrix.name }}
           path: artifacts/
           if-no-files-found: error
+
+      - name: Upload nightly portable ZIP
+        # Stable artifact name so nightly.link can address the latest
+        # push-to-main build:
+        # https://nightly.link/NortheBridge/luminalshine/workflows/nightly-windows/main/luminalshine-nightly-portable.zip
+        if: inputs.nightly == true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: luminalshine-nightly-portable
+          path: artifacts/LuminalShine_x64-portable.zip
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -1,0 +1,42 @@
+---
+# Per-commit unsigned Windows build for nightly.link consumption.
+#
+# Every push to main runs the full ci-windows.yml packaging build in
+# nightly mode: signing and the MSI golden/invariant gates are skipped,
+# tests still run, and the portable ZIP is uploaded under the stable
+# artifact name `luminalshine-nightly-portable`. The latest build is then
+# permanently addressable at:
+#   https://nightly.link/NortheBridge/luminalshine/workflows/nightly-windows/main/luminalshine-nightly-portable.zip
+#
+# The pull_request trigger is path-filtered to the two workflow files so
+# changes to the nightly pipeline validate themselves end to end on the
+# PR; ordinary PRs never pay the ~30 min build.
+name: Nightly (Windows)
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/nightly-windows.yml'
+      - '.github/workflows/ci-windows.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  nightly-windows:
+    name: Nightly
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ci-windows.yml
+    with:
+      release_commit: ${{ github.sha }}
+      # 0.0.<run>-nightly keeps nightly binaries unmistakably below any
+      # real release (MSI stamps 0.0.<run>.0) while staying unique per run.
+      release_version: 0.0.${{ github.run_number }}-nightly
+      nightly: true


### PR DESCRIPTION
Implements the true-nightly path discussed after #74: nightly.link can only serve **push**-triggered runs, and the packaging build lived behind dispatch-only `ci.yml`.

## Changes

**`ci-windows.yml`** gains an optional `nightly` input (default false — release calls from `ci.yml` are untouched):
- job-level `SIGN_ARTIFACTS` shadow → nightly builds are **unsigned** regardless of the release signing gate
- MSI upgrade-compatibility check, invariants gate, and compat-dump upload are skipped (nightly's `0.0.x` version base intentionally differs from the release golden)
- debug-info 7z and the 339 MB `build-*` artifact are skipped; instead the portable ZIP uploads as **`luminalshine-nightly-portable`** (stable name, 14-day retention)
- tests still run — the nightly doubles as a per-commit packaging smoke test

**`nightly-windows.yml`** (new): calls the above on every push to `main` with `release_version: 0.0.<run>-nightly` (MSI stamps `0.0.<run>.0`, unmistakably below any real release). A path-filtered `pull_request` trigger covers exactly these two workflow files — so **this PR runs the nightly end to end as its own validation**, and ordinary PRs never pay the ~30 min build.

## Resulting permanent link

https://nightly.link/NortheBridge/luminalshine/workflows/nightly-windows/main/luminalshine-nightly-portable.zip (live after first push-to-main run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)