### PR TITLE
ci: fail signing steps on CodeSignTool errors, not just exit codes

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -507,15 +507,26 @@ jobs:
           try {
             foreach ($t in $targets) {
               Write-Host "Signing $($t.FullName)"
-              & $bat sign `
+              # CodeSignTool.bat exits 0 even when signing fails (e.g.
+              # "Error: The OTP is invalid"), so the exit-code check alone
+              # is not enough: scan its output for error markers AND
+              # positively verify the signature landed, so a broken
+              # credential fails here instead of 25 minutes later at
+              # "Verify signatures".
+              $out = & $bat sign `
                   -username="$env:SSLCOM_USERNAME" `
                   -password="$env:SSLCOM_PASSWORD" `
                   -credential_id="$env:SSLCOM_CREDENTIAL_ID" `
                   -totp_secret="$env:SSLCOM_TOTP_SECRET" `
                   -input_file_path="$($t.FullName)" `
-                  -override
-              if ($LASTEXITCODE -ne 0) {
-                throw "CodeSignTool failed for $($t.FullName) (exit $LASTEXITCODE)"
+                  -override 2>&1
+              $out | ForEach-Object { Write-Host $_ }
+              if ($LASTEXITCODE -ne 0 -or ($out -match '(?i)\berror\b')) {
+                throw "CodeSignTool failed for $($t.FullName) (exit $LASTEXITCODE; see output above)"
+              }
+              $sig = Get-AuthenticodeSignature -FilePath $t.FullName
+              if ($sig.Status -ne 'Valid') {
+                throw "$($t.FullName) is not validly signed after CodeSignTool run: $($sig.Status)"
               }
             }
           } finally {
@@ -613,14 +624,22 @@ jobs:
           Write-Host "Signing $($msi.FullName)"
           Push-Location $toolDir
           try {
-            & $bat sign `
+            # Exit code alone is unreliable — see "Sign built executables".
+            $out = & $bat sign `
                 -username="$env:SSLCOM_USERNAME" `
                 -password="$env:SSLCOM_PASSWORD" `
                 -credential_id="$env:SSLCOM_CREDENTIAL_ID" `
                 -totp_secret="$env:SSLCOM_TOTP_SECRET" `
                 -input_file_path="$($msi.FullName)" `
-                -override
-            if ($LASTEXITCODE -ne 0) { throw "CodeSignTool failed for MSI (exit $LASTEXITCODE)" }
+                -override 2>&1
+            $out | ForEach-Object { Write-Host $_ }
+            if ($LASTEXITCODE -ne 0 -or ($out -match '(?i)\berror\b')) {
+              throw "CodeSignTool failed for MSI (exit $LASTEXITCODE; see output above)"
+            }
+            $sig = Get-AuthenticodeSignature -FilePath $msi.FullName
+            if ($sig.Status -ne 'Valid') {
+              throw "MSI is not validly signed after CodeSignTool run: $($sig.Status)"
+            }
           } finally {
             Pop-Location
           }
@@ -650,14 +669,22 @@ jobs:
           Write-Host "Signing $exe"
           Push-Location $toolDir
           try {
-            & $bat sign `
+            # Exit code alone is unreliable — see "Sign built executables".
+            $out = & $bat sign `
                 -username="$env:SSLCOM_USERNAME" `
                 -password="$env:SSLCOM_PASSWORD" `
                 -credential_id="$env:SSLCOM_CREDENTIAL_ID" `
                 -totp_secret="$env:SSLCOM_TOTP_SECRET" `
                 -input_file_path="$exe" `
-                -override
-            if ($LASTEXITCODE -ne 0) { throw "CodeSignTool failed for bootstrapper (exit $LASTEXITCODE)" }
+                -override 2>&1
+            $out | ForEach-Object { Write-Host $_ }
+            if ($LASTEXITCODE -ne 0 -or ($out -match '(?i)\berror\b')) {
+              throw "CodeSignTool failed for bootstrapper (exit $LASTEXITCODE; see output above)"
+            }
+            $sig = Get-AuthenticodeSignature -FilePath $exe
+            if ($sig.Status -ne 'Valid') {
+              throw "Bootstrapper is not validly signed after CodeSignTool run: $($sig.Status)"
+            }
           } finally {
             Pop-Location
           }


### PR DESCRIPTION
Hardening from the 26.07.1-beta.2 release attempts (runs [29685491814](https://github.com/NortheBridge/luminalshine/actions/runs/29685491814), [29686748077](https://github.com/NortheBridge/luminalshine/actions/runs/29686748077)): SSL.com's CodeSignTool prints `Error: The OTP is invalid` but **exits 0**, so all three signing steps passed silently and the run only died at *Verify signatures*, ~25 minutes after the first failed sign call.

Each of the three sign sites (built EXEs, MSI, bootstrapper) now:
1. captures CodeSignTool output and echoes it,
2. throws on nonzero exit **or** an error marker in the output,
3. positively verifies `Get-AuthenticodeSignature` = `Valid` on the just-signed file.

A broken credential now fails at the first sign call with the tool's message right there. No behavior change when signing succeeds. Note: this PR's checks include the nightly self-validation (path filter), which exercises YAML validity and the unsigned path; the new signing code itself runs on the next release dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)