### PR TITLE
fix(update): rank hotfix-suffixed prerelease tags by their leading number

### DIFF
--- a/src/version_compare.h
+++ b/src/version_compare.h
@@ -92,6 +92,21 @@ namespace version_compare {
     return ascii_lower(std::get<std::string>(version.prerelease.front())) == "stable";
   }
 
+  // Split a leading run of digits off an alphanumeric identifier
+  // ("1shfx01" -> {1, "shfx01"}). Returns -1 as the prefix when the
+  // identifier has no leading digits or the run is too long to be a
+  // plausible respin number.
+  inline std::pair<long long, std::string_view> split_numeric_prefix(const std::string &identifier) {
+    size_t digits = 0;
+    while (digits < identifier.size() && std::isdigit(static_cast<unsigned char>(identifier[digits])) != 0) {
+      ++digits;
+    }
+    if (digits == 0 || digits > 18) {
+      return {-1, std::string_view {identifier}};
+    }
+    return {std::stoll(identifier.substr(0, digits)), std::string_view {identifier}.substr(digits)};
+  }
+
   inline int compare_identifier_lists(
     const std::vector<prerelease_identifier_t> &lhs,
     const std::vector<prerelease_identifier_t> &rhs,
@@ -120,13 +135,41 @@ namespace version_compare {
         continue;
       }
 
+      // LuminalShine hotfix tags glue a suffix onto the respin number
+      // ("beta.1shfx01" = hotfix on beta.1). Strict semver would rank any
+      // such alphanumeric identifier above every numeric one, making
+      // beta.1shfx01 "newer" than beta.2. Instead, rank identifiers with a
+      // leading number by that number first, with the suffixed form as a
+      // respin above its base but below the next number.
       if (left_is_num != right_is_num) {
+        const auto &alpha = std::get<std::string>(left_is_num ? right : left);
+        const auto [prefix, suffix] = split_numeric_prefix(alpha);
+        if (prefix < 0) {
+          // No leading digits: keep strict semver (numeric < alphanumeric).
+          return left_is_num ? -1 : 1;
+        }
+        const long long num = std::get<int>(left_is_num ? left : right);
+        if (num != prefix) {
+          return (left_is_num ? num < prefix : prefix < num) ? -1 : 1;
+        }
+        // Equal number: the pure number is the base, the suffixed form the respin.
         return left_is_num ? -1 : 1;
       }
 
       const auto &left_value = std::get<std::string>(left);
       const auto &right_value = std::get<std::string>(right);
       if (left_value != right_value) {
+        const auto [left_prefix, left_suffix] = split_numeric_prefix(left_value);
+        const auto [right_prefix, right_suffix] = split_numeric_prefix(right_value);
+        if (left_prefix >= 0 && right_prefix >= 0) {
+          if (left_prefix != right_prefix) {
+            return left_prefix < right_prefix ? -1 : 1;
+          }
+          if (left_suffix != right_suffix) {
+            return left_suffix < right_suffix ? -1 : 1;
+          }
+          continue;
+        }
         return left_value < right_value ? -1 : 1;
       }
     }

--- a/tests/unit/test_version_compare.cpp
+++ b/tests/unit/test_version_compare.cpp
@@ -23,3 +23,18 @@ TEST(VersionCompareTest, StableRespinsStillCompareWithinTheirChannel) {
   EXPECT_GT(version_compare::compare_semver("1.14.14-stable.1", "1.14.14-rc.9"), 0);
   EXPECT_EQ(version_compare::compare_semver("1.14.14+build.1", "1.14.14+build.2"), 0);
 }
+
+TEST(VersionCompareTest, HotfixSuffixedPrereleasesRankByLeadingNumber) {
+  // "beta.1shfx01" is a hotfix on beta.1: above its base, below beta.2.
+  EXPECT_LT(version_compare::compare_semver("26.07.1-beta.1shfx01", "26.07.1-beta.2"), 0);
+  EXPECT_GT(version_compare::compare_semver("26.07.1-beta.2", "26.07.1-beta.1shfx01"), 0);
+  EXPECT_GT(version_compare::compare_semver("26.07.1-beta.1shfx01", "26.07.1-beta.1"), 0);
+  EXPECT_LT(version_compare::compare_semver("26.07.1-beta.1shfx01", "26.07.1-beta.1shfx02"), 0);
+  EXPECT_EQ(version_compare::compare_semver("26.07.1-beta.1shfx01", "26.07.1-beta.1shfx01"), 0);
+}
+
+TEST(VersionCompareTest, NonNumericAlphanumericsKeepStrictSemverOrder) {
+  // No leading digits: strict semver still ranks numeric below alphanumeric.
+  EXPECT_LT(version_compare::compare_semver("1.0.0-beta.1", "1.0.0-beta.rc"), 0);
+  EXPECT_LT(version_compare::compare_semver("1.0.0-alpha.1", "1.0.0-beta.1"), 0);
+}


### PR DESCRIPTION
## Summary
The update check reported `26.07.1-beta.1shfx01` as a newer prerelease than `26.07.1-beta.2`. Strict semver ranks any alphanumeric identifier (`1shfx01`) above every numeric one (`2`), but LuminalShine's hotfix tags glue a suffix onto the respin number — `beta.1shfx01` means "hotfix on beta.1" and must sort above `beta.1`, below `beta.2`.

`compare_identifier_lists` now splits a leading digit run off alphanumeric identifiers and ranks by that number first (suffixed form = respin above its numeric base; suffixes compare lexically on ties). Identifiers without leading digits keep strict semver ordering, and the existing `-stable.N` respin rules are untouched.

## Verification
`test_sunshine --gtest_filter=VersionCompareTest.*`: 5/5 pass, including new `HotfixSuffixedPrereleasesRankByLeadingNumber` and `NonNumericAlphanumericsKeepStrictSemverOrder` regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)