### PR TITLE
Ring-consuming capture backend for LuminalVGD displays (tranche 3b)

### DIFF
--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -137,6 +137,7 @@ set(PLATFORM_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/platform/windows/display_vram.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/display_ram.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/display_wgc.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/display_vgd.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/audio.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/virtual_display.h"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/virtual_display.cpp"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2567,7 +2567,7 @@ editing the `conf` file in a text editor. Use the examples as reference.
             @endcode</td>
     </tr>
     <tr>
-        <td rowspan="6">Choices</td>
+        <td rowspan="7">Choices</td>
         <td>nvfbc</td>
         <td>Use NVIDIA Frame Buffer Capture to capture direct to GPU memory. This is usually the fastest method for
             NVIDIA cards. NvFBC does not have native Wayland support and does not work with XWayland.
@@ -2607,6 +2607,12 @@ editing the `conf` file in a text editor. Use the examples as reference.
             @note{Windows only.}
             @note{NVIDIA Ultra Low Latency Mode (ULLM) can hurt performance; avoid this by either using a monitor whose refresh rate exceeds the stream and capping FPS to stop ULLM from engaging, or simply disable Low Latency Mode in the driver.}
             @tip{On NVIDIA cards, selecting this option will resolve stream freezes caused by high VRAM utilization.}</td>
+    </tr>
+    <tr>
+        <td>vgd</td>
+        <td>Consume the LuminalVGD virtual display driver's frame ring directly, bypassing desktop-capture APIs entirely.
+            Used automatically when streaming from a LuminalVGD virtual display; falls back to WGC/DDA for physical displays.
+            @note{Windows only; requires the LuminalVGD driver.}</td>
     </tr>
 </table>
 

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -27,6 +27,10 @@
 #include "src/utility.h"
 #include "src/video.h"
 
+// Opaque LuminalVGD frame-ring handle (luminal_vgd.h); forward-declared so
+// only display_vgd.cpp needs the FFI header.
+struct VgdRingHandle;
+
 namespace platf::dxgi {
   extern const char *format_str[];
 
@@ -548,6 +552,63 @@ namespace platf::dxgi {
     std::string _display_name;
     bool _session_initialized_logged = false;
     bool _frame_locked = false;
+  };
+
+  /**
+   * @class display_vgd_vram_t
+   * @brief Capture backend that consumes the LuminalVGD driver's shared-texture
+   * frame ring directly (no WGC helper process, no desktop-capture API).
+   *
+   * The driver publishes every composed frame of its virtual monitor into a
+   * small ring of named keyed-mutex shared textures. This backend claims the
+   * freshest published slot (a cross-process CAS keeps the driver's writer off
+   * it), GPU-copies the pixels into a pooled img_d3d_t under the slot's keyed
+   * mutex, and releases the slot — claims are never held across encode.
+   */
+  class display_vgd_vram_t: public display_vram_t {
+  public:
+    ~display_vgd_vram_t() override;
+
+    /**
+     * @brief Factory: returns a ring-backed display for `display_name`, or
+     * nullptr when the display is not a live LuminalVGD monitor (callers fall
+     * back to WGC/DDA).
+     */
+    static std::shared_ptr<display_t> create(const ::video::config_t &config, const std::string &display_name);
+
+    int init(const ::video::config_t &config, const std::string &display_name);
+
+    capture_e snapshot(const pull_free_image_cb_t &pull_free_image_cb, std::shared_ptr<platf::img_t> &img_out, std::chrono::milliseconds timeout, bool cursor_visible) override;
+
+    int dummy_img(platf::img_t *img_base) override;
+
+  protected:
+    capture_e release_snapshot() override;
+
+  private:
+    struct slot_texture_t {
+      texture2d_t texture;
+      keyed_mutex_t mutex;
+    };
+
+    /// Open (or fetch the cached) named shared texture for a ring slot of the
+    /// current generation. Returns nullptr on open failure.
+    slot_texture_t *slot_texture(uint32_t generation, uint32_t slot);
+
+    ::VgdRingHandle *_ring = nullptr;
+    uint64_t _session_id = 0;
+    uint32_t _ring_slots = 0;
+    /// Generation the cached slot textures were opened for; a bump retires them.
+    uint32_t _texture_generation = 0;
+    std::vector<slot_texture_t> _slot_textures;
+    uint64_t _last_sequence = 0;
+    std::string _display_name;
+
+    // Broken-ring detection (see display_vgd.cpp): consecutive texture-open
+    // failures, and publish-vs-delivery stall tracking.
+    int _open_failures = 0;
+    uint64_t _published_at_last_delivery = 0;
+    std::chrono::steady_clock::time_point _last_delivery {};
   };
 
   class display_wgc_ipc_ram_t: public display_ram_t {

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -38,6 +38,7 @@ typedef enum _D3DKMT_GPU_PREFERENCE_QUERY_STATE : DWORD {
 #include "src/display_device.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
+#include "src/platform/windows/virtual_display_backend.h"
 #include "src/tdr_state.h"
 #include "src/video.h"
 #include "utf_utils.h"
@@ -1671,9 +1672,24 @@ namespace platf {
     const bool user_requested_ddx = capture_mode == "ddx";
     const bool default_to_wgc = dxgi::should_use_wgc_default();
     const bool wgc_requested = capture_mode.starts_with("wgc");
-    const bool prefer_wgc_backend = !user_requested_ddx && (wgc_requested || default_to_wgc);
+    const bool vgd_requested = capture_mode == "vgd";
+    const bool prefer_wgc_backend = !user_requested_ddx && !vgd_requested && (wgc_requested || default_to_wgc);
 
     if (hwdevice_type == mem_type_e::dxgi) {
+      // A LuminalVGD virtual monitor carries its own frame ring — consume it
+      // directly instead of re-capturing the desktop. create() returns null
+      // for non-VGD displays (or if the ring can't be mapped), falling back
+      // to WGC/DDA below; explicit capture=vgd also degrades rather than
+      // failing the stream.
+      if (!user_requested_ddx && !wgc_requested && (vgd_requested || VDISPLAY::is_luminalvgd_active())) {
+        if (auto disp = dxgi::display_vgd_vram_t::create(config, display_name)) {
+          return disp;
+        }
+        if (vgd_requested) {
+          BOOST_LOG(warning) << "capture=vgd requested but the LuminalVGD ring is unavailable for "
+                             << display_name << "; falling back to WGC/DDA.";
+        }
+      }
       if (prefer_wgc_backend) {
         auto disp = dxgi::display_wgc_ipc_vram_t::create(config, display_name);
         if (disp || wgc_requested) {

--- a/src/platform/windows/display_vgd.cpp
+++ b/src/platform/windows/display_vgd.cpp
@@ -1,0 +1,402 @@
+/**
+ * @file src/platform/windows/display_vgd.cpp
+ * @brief Capture backend consuming the LuminalVGD driver's frame ring.
+ *
+ * The LuminalVGD IddCx driver GPU-copies every composed frame of its virtual
+ * monitor into a ring of named keyed-mutex shared textures and publishes slot
+ * metadata through a shared section (see src/drivers/luminal-display,
+ * docs/DESIGN.md). This backend is the ring's reader:
+ *
+ *   claim freshest slot (cross-process CAS PUBLISHED -> READING)
+ *     -> AcquireSync(1, 100 ms) on the slot texture's keyed mutex
+ *     -> CopyResource into a pooled img_d3d_t (own mutex, key-0 convention)
+ *     -> ReleaseSync(1), release the claim
+ *
+ * The claim, not the mutex, is what keeps the driver's writer off the slot;
+ * both are held only for the duration of one GPU copy, so the ring never
+ * back-pressures on the encoder. Slot textures are opened by generation-
+ * stamped name once and cached; a generation bump (mode change, driver
+ * rebuild) retires the cache.
+ *
+ * Deliberately copy-based for now: adopting slot textures zero-copy into the
+ * encoder path would mix the ring's 0/1 keyed-mutex protocol with the
+ * encoder's key-0 convention (texture_lock_helper / encode devices acquire
+ * key 0) and hold claims across encode. Revisit once the encoder-side key
+ * plumbing is parameterized.
+ */
+
+// standard includes
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+// platform includes
+#include <winsock2.h>
+
+// local includes
+#include "src/logging.h"
+#include "src/platform/windows/display.h"
+#include "src/platform/windows/display_vram.h"
+#include "src/platform/windows/misc.h"
+#include "src/platform/windows/virtual_display_vgd.h"
+
+#include <luminal_vgd.h>
+
+namespace platf::dxgi {
+
+  using namespace std::literals;
+
+  namespace {
+
+    // Mirrors luminal-driver-proto KMTX_* — the reader side of the ring's
+    // keyed-mutex protocol (key 0 = driver pre-first-publish, key 1 after;
+    // both sides bound every acquire).
+    constexpr uint64_t kVgdMutexKeyHost = 1;
+    constexpr uint32_t kVgdMutexTimeoutMs = 100;
+
+    // proto ring_state::*
+    constexpr uint32_t kRingStateActive = 1;
+    constexpr uint32_t kRingStateRebuilding = 2;
+    constexpr uint32_t kRingStateDead = 3;
+
+    /// Driver heartbeats the ring header at least every 500 ms even when no
+    /// frames flow; treat several missed beats as a dead worker.
+    constexpr auto kHeartbeatStale = std::chrono::milliseconds(2000);
+
+    /// Circuit breaker: a session whose ring consistently fails to deliver
+    /// (texture opens failing, or frames publishing that we can never claim)
+    /// is remembered here so the factory's next attempt refuses and the
+    /// stream falls back to WGC/DDA instead of staying black.
+    std::atomic<uint64_t> g_broken_session {0};
+
+    /// Consecutive slot-texture open failures before giving up on the ring.
+    constexpr int kMaxOpenFailures = 20;
+
+    /// If the driver is publishing frames but none reach us for this long,
+    /// the reader side is broken (claim CAS or texture path) — bail out.
+    constexpr auto kDeliveryStall = std::chrono::seconds(5);
+
+    // SEH-isolated mutex ops: the virtual display (and with it the D3D
+    // device backing the shared texture) can vanish mid-stream; keyed-mutex
+    // calls on a dead device may access-violate inside dxgi.dll. Same
+    // compiler split as display_wgc.cpp's seh_release_ipc_frame_.
+#if defined(_MSC_VER) || defined(__clang__)
+    HRESULT seh_acquire_sync(IDXGIKeyedMutex *mutex, uint64_t key, DWORD timeout_ms) noexcept {
+      __try {
+        return mutex->AcquireSync(key, timeout_ms);
+      } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return DXGI_ERROR_DEVICE_REMOVED;
+      }
+    }
+
+    HRESULT seh_release_sync(IDXGIKeyedMutex *mutex, uint64_t key) noexcept {
+      __try {
+        return mutex->ReleaseSync(key);
+      } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return DXGI_ERROR_DEVICE_REMOVED;
+      }
+    }
+#else
+    HRESULT seh_acquire_sync(IDXGIKeyedMutex *mutex, uint64_t key, DWORD timeout_ms) noexcept {
+      return mutex->AcquireSync(key, timeout_ms);
+    }
+
+    HRESULT seh_release_sync(IDXGIKeyedMutex *mutex, uint64_t key) noexcept {
+      return mutex->ReleaseSync(key);
+    }
+#endif
+
+  }  // namespace
+
+  display_vgd_vram_t::~display_vgd_vram_t() {
+    _slot_textures.clear();
+    if (_ring) {
+      vgd_ring_close(_ring);
+      _ring = nullptr;
+    }
+  }
+
+  std::shared_ptr<display_t> display_vgd_vram_t::create(const ::video::config_t &config, const std::string &display_name) {
+    auto disp = std::make_shared<display_vgd_vram_t>();
+    if (disp->init(config, display_name)) {
+      return nullptr;
+    }
+    return disp;
+  }
+
+  int display_vgd_vram_t::init(const ::video::config_t &config, const std::string &display_name) {
+    auto target = VDISPLAY::vgd::ring_target_for_display(display_name);
+    if (!target) {
+      // Not a LuminalVGD monitor (or no live session) — caller falls back.
+      return -1;
+    }
+    if (g_broken_session.load(std::memory_order_acquire) == target->session_id) {
+      BOOST_LOG(warning) << "LuminalVGD capture: ring of session 0x" << std::hex
+                         << target->session_id << std::dec
+                         << " marked broken earlier; using fallback capture.";
+      return -1;
+    }
+
+    if (display_base_t::init(config, display_name, true /* skip_dd_test: ring capture doesn't use Desktop Duplication */)) {
+      return -1;
+    }
+
+    // The driver creates the ring section at monitor plug; capture starts
+    // well after that, but tolerate a beat of PnP lag.
+    VgdRingHandle *ring = nullptr;
+    for (int attempt = 0; attempt < 10 && !ring; ++attempt) {
+      ring = vgd_ring_open(target->session_id, target->ring_slots);
+      if (!ring) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
+    }
+    if (!ring) {
+      BOOST_LOG(warning) << "LuminalVGD capture: ring section did not appear for session 0x"
+                         << std::hex << target->session_id << std::dec << "; falling back.";
+      return -1;
+    }
+
+    _ring = ring;
+    _session_id = target->session_id;
+    _ring_slots = target->ring_slots;
+    _display_name = display_name;
+    _last_delivery = std::chrono::steady_clock::now();
+    capture_format = DXGI_FORMAT_UNKNOWN;  // latched from the first claimed frame
+
+    BOOST_LOG(info) << "LuminalVGD capture: consuming frame ring of session 0x"
+                    << std::hex << _session_id << std::dec << " (" << _ring_slots
+                    << " slots) for " << display_name;
+    return 0;
+  }
+
+  display_vgd_vram_t::slot_texture_t *display_vgd_vram_t::slot_texture(uint32_t generation, uint32_t slot) {
+    if (_texture_generation != generation) {
+      _slot_textures.clear();
+      _texture_generation = generation;
+    }
+    if (_slot_textures.empty()) {
+      _slot_textures.resize(_ring_slots);
+    }
+    if (slot >= _slot_textures.size()) {
+      return nullptr;
+    }
+
+    auto &entry = _slot_textures[slot];
+    if (entry.texture) {
+      return &entry;
+    }
+
+    uint16_t name[96] {};
+    vgd_slot_texture_name(_session_id, generation, slot, name);
+
+    device1_t device1;
+    HRESULT status = device->QueryInterface(__uuidof(ID3D11Device1), (void **) &device1);
+    if (FAILED(status)) {
+      BOOST_LOG(error) << "LuminalVGD capture: ID3D11Device1 unavailable [0x"sv << util::hex(status).to_string_view() << ']';
+      return nullptr;
+    }
+
+    texture2d_t texture;
+    status = device1->OpenSharedResourceByName(
+      reinterpret_cast<LPCWSTR>(name),
+      DXGI_SHARED_RESOURCE_READ,
+      __uuidof(ID3D11Texture2D),
+      (void **) &texture
+    );
+    if (FAILED(status)) {
+      BOOST_LOG(warning) << "LuminalVGD capture: OpenSharedResourceByName failed for slot "
+                         << slot << " gen " << generation << " [0x"sv
+                         << util::hex(status).to_string_view() << ']';
+      return nullptr;
+    }
+
+    keyed_mutex_t mutex;
+    status = texture->QueryInterface(__uuidof(IDXGIKeyedMutex), (void **) &mutex);
+    if (FAILED(status)) {
+      BOOST_LOG(error) << "LuminalVGD capture: slot texture has no keyed mutex [0x"sv << util::hex(status).to_string_view() << ']';
+      return nullptr;
+    }
+
+    entry.texture.reset(texture.release());
+    entry.mutex.reset(mutex.release());
+    return &entry;
+  }
+
+  capture_e display_vgd_vram_t::snapshot(const pull_free_image_cb_t &pull_free_image_cb, std::shared_ptr<platf::img_t> &img_out, std::chrono::milliseconds timeout, bool cursor_visible) {
+    // The IddCx path composes the cursor into the frame (no hardware-cursor
+    // DDIs yet), so cursor_visible needs no handling here.
+    (void) cursor_visible;
+
+    if (!_ring) {
+      return capture_e::error;
+    }
+
+    VgdRingStatus status {};
+    if (vgd_ring_status(_ring, &status) != 0) {
+      return capture_e::reinit;
+    }
+    if (status.state == kRingStateDead) {
+      BOOST_LOG(warning) << "LuminalVGD capture: ring is DEAD; reinitializing.";
+      return capture_e::reinit;
+    }
+    if (status.qpc_frequency != 0 && status.heartbeat_qpc != 0) {
+      const auto beats_behind = qpc_time_difference(qpc_counter(), static_cast<int64_t>(status.heartbeat_qpc));
+      if (beats_behind > kHeartbeatStale) {
+        BOOST_LOG(warning) << "LuminalVGD capture: ring heartbeat stale ("
+                           << std::chrono::duration_cast<std::chrono::milliseconds>(beats_behind).count()
+                           << " ms); reinitializing.";
+        return capture_e::reinit;
+      }
+    }
+    if (status.state == kRingStateRebuilding) {
+      // The driver is retiring/recreating textures (mode change, swapchain
+      // reassignment). Frames resume under a new generation shortly.
+      return capture_e::timeout;
+    }
+
+    // The driver is publishing but nothing has reached the encoder for a
+    // while: the reader side is broken (claim CAS, texture path). Blacklist
+    // this session's ring so the reinit falls back to WGC/DDA instead of
+    // leaving the stream black.
+    if (status.frames_published > _published_at_last_delivery &&
+        std::chrono::steady_clock::now() - _last_delivery > kDeliveryStall) {
+      BOOST_LOG(error) << "LuminalVGD capture: driver published frames but none were delivered for "
+                       << std::chrono::duration_cast<std::chrono::seconds>(kDeliveryStall).count()
+                       << " s; disabling ring capture for this session.";
+      g_broken_session.store(_session_id, std::memory_order_release);
+      return capture_e::reinit;
+    }
+
+    // Claim the freshest published frame, honoring the caller's timeout.
+    // There is no wake event — the section is pure shared memory — so poll at
+    // 1 ms granularity; the base capture loop paces us to the client rate and
+    // usually calls with timeout 0.
+    VgdFrame frame {};
+    bool claimed = false;
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (true) {
+      if (vgd_ring_claim(_ring, &frame)) {
+        if (frame.sequence != _last_sequence) {
+          claimed = true;
+          break;
+        }
+        // Freshest published frame is the one we already delivered.
+        vgd_ring_release(_ring, frame.index);
+      }
+      if (std::chrono::steady_clock::now() >= deadline) {
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    if (!claimed) {
+      return capture_e::timeout;
+    }
+
+    auto claim_guard = util::fail_guard([&]() {
+      vgd_ring_release(_ring, frame.index);
+    });
+
+    auto *slot = slot_texture(frame.generation, frame.index);
+    if (!slot) {
+      // Generation likely moved on between claim and open; retry next call —
+      // but a persistent failure means the shared textures are unreachable.
+      if (++_open_failures >= kMaxOpenFailures) {
+        BOOST_LOG(error) << "LuminalVGD capture: slot textures unreachable after "
+                         << _open_failures << " attempts; disabling ring capture for this session.";
+        g_broken_session.store(_session_id, std::memory_order_release);
+        return capture_e::reinit;
+      }
+      return capture_e::timeout;
+    }
+    _open_failures = 0;
+
+    const HRESULT acquire = seh_acquire_sync(slot->mutex.get(), kVgdMutexKeyHost, kVgdMutexTimeoutMs);
+    if (acquire == static_cast<HRESULT>(WAIT_TIMEOUT)) {
+      return capture_e::timeout;
+    }
+    if (acquire != S_OK && acquire != static_cast<HRESULT>(WAIT_ABANDONED)) {
+      BOOST_LOG(warning) << "LuminalVGD capture: slot mutex acquire failed [0x"sv << util::hex(acquire).to_string_view() << ']';
+      return capture_e::reinit;
+    }
+    auto mutex_guard = util::fail_guard([&]() {
+      seh_release_sync(slot->mutex.get(), kVgdMutexKeyHost);
+    });
+
+    const auto host_processing_timestamp = std::chrono::steady_clock::now();
+    auto frame_timestamp = host_processing_timestamp;
+    if (frame.present_qpc != 0) {
+      frame_timestamp = host_processing_timestamp - qpc_time_difference(qpc_counter(), static_cast<int64_t>(frame.present_qpc));
+    }
+
+    D3D11_TEXTURE2D_DESC desc;
+    slot->texture->GetDesc(&desc);
+
+    if (capture_format == DXGI_FORMAT_UNKNOWN) {
+      capture_format = desc.Format;
+      BOOST_LOG(info) << "Capture format [" << dxgi_format_to_string(capture_format) << ']';
+    }
+    if (desc.Width != static_cast<UINT>(width_before_rotation) || desc.Height != static_cast<UINT>(height_before_rotation)) {
+      BOOST_LOG(info) << "Capture size changed ["sv << width_before_rotation << 'x' << height_before_rotation
+                      << " -> "sv << desc.Width << 'x' << desc.Height << ']';
+      return capture_e::reinit;
+    }
+    if (capture_format != desc.Format) {
+      BOOST_LOG(info) << "Capture format changed ["sv << dxgi_format_to_string(capture_format)
+                      << " -> "sv << dxgi_format_to_string(desc.Format) << ']';
+      return capture_e::reinit;
+    }
+
+    std::shared_ptr<platf::img_t> img;
+    if (!pull_free_image_cb(img)) {
+      return capture_e::interrupted;
+    }
+    auto d3d_img = std::static_pointer_cast<img_d3d_t>(img);
+
+    // Lazily create the pooled GPU texture + encoder handle (idempotent).
+    if (complete_img(d3d_img.get(), false)) {
+      return capture_e::error;
+    }
+
+    // Pooled textures follow the capture<->encoder key-0 convention.
+    const HRESULT dst_acquire = seh_acquire_sync(d3d_img->capture_mutex.get(), 0, 3000);
+    if (dst_acquire != S_OK && dst_acquire != static_cast<HRESULT>(WAIT_ABANDONED)) {
+      BOOST_LOG(error) << "LuminalVGD capture: pooled texture mutex acquire failed [0x"sv << util::hex(dst_acquire).to_string_view() << ']';
+      return capture_e::error;
+    }
+
+    device_ctx->CopyResource(d3d_img->capture_texture.get(), slot->texture.get());
+
+    seh_release_sync(d3d_img->capture_mutex.get(), 0);
+
+    // Copy done: hand the slot back before the encoder ever sees the image.
+    mutex_guard.disable();
+    seh_release_sync(slot->mutex.get(), kVgdMutexKeyHost);
+    claim_guard.disable();
+    vgd_ring_release(_ring, frame.index);
+    _last_sequence = frame.sequence;
+    _last_delivery = host_processing_timestamp;
+    _published_at_last_delivery = status.frames_published;
+
+    d3d_img->blank = false;
+    d3d_img->format = capture_format;
+    d3d_img->pixel_pitch = get_pixel_pitch();
+    d3d_img->row_pitch = d3d_img->pixel_pitch * d3d_img->width;
+    d3d_img->data = (std::uint8_t *) d3d_img->capture_texture.get();
+    img->frame_timestamp = frame_timestamp;
+    img->host_processing_timestamp = host_processing_timestamp;
+    img_out = img;
+
+    return capture_e::ok;
+  }
+
+  capture_e display_vgd_vram_t::release_snapshot() {
+    // Claims and mutexes are released within snapshot(); nothing is held
+    // across the push to the encoder.
+    return capture_e::ok;
+  }
+
+  int display_vgd_vram_t::dummy_img(platf::img_t *img_base) {
+    return complete_img(img_base, true);
+  }
+
+}  // namespace platf::dxgi

--- a/src/platform/windows/virtual_display_vgd.cpp
+++ b/src/platform/windows/virtual_display_vgd.cpp
@@ -26,6 +26,10 @@ namespace VDISPLAY::vgd {
       uint64_t session_id;
       uint64_t display_id;
       std::string client_name;
+      uint32_t ring_slots;
+      /// GDI display name ("\\\\.\\DISPLAY274") once the monitor surfaced;
+      /// empty while the display is still inactive pre-APPLY.
+      std::wstring display_name;
     };
 
     struct GuidKey {
@@ -252,6 +256,10 @@ namespace VDISPLAY::vgd {
         result.display_name = names.front();
         result.monitor_device_path = monitor_device_path_of(names.front());
         result.device_id = resolveVirtualDisplayDeviceId(names.front());
+        std::lock_guard relock(g_mutex);
+        if (auto again = g_sessions.find(key_of(guid)); again != g_sessions.end()) {
+          again->second.display_name = names.front();
+        }
       }
       return result;
     }
@@ -292,6 +300,8 @@ namespace VDISPLAY::vgd {
       req.session_id,
       reply.display_id,
       s_client_name ? s_client_name : "",
+      reply.ring_slots,
+      {},
     };
     BOOST_LOG(info) << "LuminalVGD monitor created: session 0x" << std::hex << req.session_id
                     << " display 0x" << reply.display_id << std::dec << " connector "
@@ -313,6 +323,14 @@ namespace VDISPLAY::vgd {
           // Resolve the libdisplaydevice device id so the display-helper
           // topology layer can target the new monitor directly.
           result.device_id = resolveVirtualDisplayDeviceId(name);
+          {
+            // Record the GDI name so the ring capture backend can map
+            // this display back to its session.
+            std::lock_guard relock(g_mutex);
+            if (auto it = g_sessions.find(key_of(guid)); it != g_sessions.end()) {
+              it->second.display_name = name;
+            }
+          }
           return result;
         }
       }
@@ -372,6 +390,26 @@ namespace VDISPLAY::vgd {
     return "proto " + std::to_string(g_caps->proto_major) + '.' +
            std::to_string(g_caps->proto_minor) + " build " +
            std::to_string(g_caps->driver_build);
+  }
+
+  std::optional<RingTargetInfo> ring_target_for_display(const std::string &display_name) {
+    std::wstring wanted(display_name.begin(), display_name.end());
+    std::lock_guard lk(g_mutex);
+    if (g_sessions.empty()) {
+      return std::nullopt;
+    }
+    if (g_sessions.size() == 1) {
+      const auto &s = g_sessions.begin()->second;
+      return RingTargetInfo {s.session_id, s.ring_slots};
+    }
+    for (const auto &[k, s] : g_sessions) {
+      if (!s.display_name.empty() && s.display_name == wanted) {
+        return RingTargetInfo {s.session_id, s.ring_slots};
+      }
+    }
+    BOOST_LOG(warning) << "LuminalVGD: no tracked session matches display '"
+                       << display_name << "' (" << g_sessions.size() << " sessions).";
+    return std::nullopt;
   }
 
 }  // namespace VDISPLAY::vgd

--- a/src/platform/windows/virtual_display_vgd.h
+++ b/src/platform/windows/virtual_display_vgd.h
@@ -53,4 +53,17 @@ namespace VDISPLAY::vgd {
   /// diagnostics/web UI.
   std::optional<std::string> driver_version_string();
 
+  /// What the ring-consuming capture backend needs to map a session's
+  /// frame ring (see display_vgd.cpp).
+  struct RingTargetInfo {
+    uint64_t session_id;
+    uint32_t ring_slots;
+  };
+
+  /// Resolve the tracked session whose monitor backs `display_name`
+  /// (e.g. "\\\\.\\DISPLAY274"). With a single tracked session (the
+  /// common per-client case) that session is returned directly;
+  /// otherwise the session whose recorded display name matches wins.
+  std::optional<RingTargetInfo> ring_target_for_display(const std::string &display_name);
+
 }  // namespace VDISPLAY::vgd

--- a/src_assets/common/assets/web/configs/configSelectOptions.ts
+++ b/src_assets/common/assets/web/configs/configSelectOptions.ts
@@ -234,6 +234,7 @@ export function getConfigSelectOptions(
           { label: 'Windows Graphics Capture (variable)', value: 'wgc' },
           { label: 'Windows Graphics Capture (constant)', value: 'wgcc' },
           { label: 'Desktop Duplication API', value: 'ddx' },
+          { label: 'LuminalVGD frame ring (virtual displays)', value: 'vgd' },
         );
       } else if (platform === 'linux') {
         options.push(


### PR DESCRIPTION
## Summary
New `display_vgd_vram_t` capture backend: instead of re-capturing the virtual display's desktop through the WGC helper process, LuminalShine now claims published slots of the LuminalVGD driver's shared-texture frame ring directly — driver swapchain → shared texture → pooled encoder image → NVENC. No helper process, no IPC hop, no desktop-capture API in the virtual-display path.

- Claim freshest slot (cross-process CAS keeps the writer off it) → `AcquireSync(1, 100 ms)` (SEH-guarded) → GPU copy into pooled `img_d3d_t` → release; claims never span an encode.
- Slot textures opened by generation-stamped name once, cached; generation bump retires the cache; DEAD ring / stale heartbeat → reinit.
- Factory tries the ring first for LuminalVGD displays; new `capture = vgd` value forces the attempt; any failure falls back to WGC/DDA.
- Circuit breaker blacklists a session's ring on persistent texture-open failures or a published-but-undelivered stall, so a broken ring degrades to WGC instead of a black stream.
- Lifecycle backend records ring slot counts + GDI display names (`vgd::ring_target_for_display`).
- Web UI option + configuration.md entry.

Copy-based by design for now: zero-copy slot adoption would mix the ring's 0/1 mutex protocol with the encoder's key-0 convention. Tracked as a follow-up.

## Verification (live, RTX 5080 → Moonlight)
- `LuminalVGD capture: consuming frame ring of session … (3 slots) for \.\DISPLAY274`; `Capture format [DXGI_FORMAT_B8G8R8A8_UNORM]` latched on first claim.
- No `luminalshine_wgc_capture.exe` launched during the stream.
- Frame processing latency avg ~4.5 ms (parity with the WGC path), sustained ~120 fps bursts, stable stream.
- First real cross-process consumer of the driver's shared textures (probe only exercised slot-state CAS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)