### PR TITLE
HDR10 virtual displays end to end (LuminalVGD)

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -538,7 +538,8 @@ namespace nvhttp {
           vd_fps,
           virtual_display_guid,
           base_vd_fps_millihz,
-          framegen_refresh_active
+          framegen_refresh_active,
+          launch_session->enable_hdr
         );
 
         if (display_info) {

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -605,10 +605,9 @@ namespace platf::dxgi {
     std::string _display_name;
 
     // Broken-ring detection (see display_vgd.cpp): consecutive texture-open
-    // failures, and publish-vs-delivery stall tracking.
+    // failures, and how long a newer-than-delivered frame has sat unclaimed.
     int _open_failures = 0;
-    uint64_t _published_at_last_delivery = 0;
-    std::chrono::steady_clock::time_point _last_delivery {};
+    std::optional<std::chrono::steady_clock::time_point> _undelivered_since;
   };
 
   class display_wgc_ipc_ram_t: public display_ram_t {

--- a/src/platform/windows/display_helper_request_helpers.cpp
+++ b/src/platform/windows/display_helper_request_helpers.cpp
@@ -14,6 +14,7 @@
   #include "src/platform/windows/misc.h"
   #include "src/platform/windows/virtual_display.h"
   #include "src/platform/windows/virtual_display_backend.h"
+  #include "src/platform/windows/virtual_display_vgd.h"
   #include "src/process.h"
 
   #include <algorithm>
@@ -303,10 +304,12 @@ namespace display_helper_integration::helpers {
 
     auto vd_cfg = *cfg;
 
-    // The LuminalVGD driver does not advertise HDR10 yet; asking Windows to
-    // enable HDR on its monitor makes the whole ApplySettings call fail.
-    if (vd_cfg.m_hdr_state == display_device::HdrState::Enabled && VDISPLAY::is_luminalvgd_active()) {
-      BOOST_LOG(warning) << "LuminalVGD does not support HDR yet; applying the virtual display in SDR.";
+    // Asking Windows to enable HDR on a monitor without HDR10 caps fails
+    // the whole ApplySettings call — downgrade to SDR when the installed
+    // LuminalVGD driver doesn't advertise HDR10.
+    if (vd_cfg.m_hdr_state == display_device::HdrState::Enabled &&
+        VDISPLAY::is_luminalvgd_active() && !VDISPLAY::vgd::driver_supports_hdr()) {
+      BOOST_LOG(warning) << "Installed LuminalVGD driver lacks HDR10 caps; applying the virtual display in SDR.";
       vd_cfg.m_hdr_state = std::nullopt;
     }
 

--- a/src/platform/windows/display_vgd.cpp
+++ b/src/platform/windows/display_vgd.cpp
@@ -160,7 +160,6 @@ namespace platf::dxgi {
     _session_id = target->session_id;
     _ring_slots = target->ring_slots;
     _display_name = display_name;
-    _last_delivery = std::chrono::steady_clock::now();
     capture_format = DXGI_FORMAT_UNKNOWN;  // latched from the first claimed frame
 
     BOOST_LOG(info) << "LuminalVGD capture: consuming frame ring of session 0x"
@@ -254,17 +253,26 @@ namespace platf::dxgi {
       return capture_e::timeout;
     }
 
-    // The driver is publishing but nothing has reached the encoder for a
-    // while: the reader side is broken (claim CAS, texture path). Blacklist
-    // this session's ring so the reinit falls back to WGC/DDA instead of
-    // leaving the stream black.
-    if (status.frames_published > _published_at_last_delivery &&
-        std::chrono::steady_clock::now() - _last_delivery > kDeliveryStall) {
-      BOOST_LOG(error) << "LuminalVGD capture: driver published frames but none were delivered for "
-                       << std::chrono::duration_cast<std::chrono::seconds>(kDeliveryStall).count()
-                       << " s; disabling ring capture for this session.";
-      g_broken_session.store(_session_id, std::memory_order_release);
-      return capture_e::reinit;
+    // A frame NEWER than the one we last delivered sitting unclaimed for a
+    // long stretch means the reader side is broken (claim CAS, texture
+    // path) — blacklist the ring so the reinit falls back to WGC/DDA
+    // instead of leaving the stream black. Cumulative publish counters are
+    // deliberately NOT used here: an idle desktop (driver publishing
+    // nothing new) is indistinguishable from a stall by counters alone.
+    if (status.latest_sequence > _last_sequence) {
+      const auto now = std::chrono::steady_clock::now();
+      if (!_undelivered_since) {
+        _undelivered_since = now;
+      } else if (now - *_undelivered_since > kDeliveryStall) {
+        BOOST_LOG(error) << "LuminalVGD capture: a newer frame (seq " << status.latest_sequence
+                         << " vs delivered " << _last_sequence << ") sat unclaimed for "
+                         << std::chrono::duration_cast<std::chrono::seconds>(kDeliveryStall).count()
+                         << " s; disabling ring capture for this session.";
+        g_broken_session.store(_session_id, std::memory_order_release);
+        return capture_e::reinit;
+      }
+    } else {
+      _undelivered_since.reset();
     }
 
     // Claim the freshest published frame, honoring the caller's timeout.
@@ -374,8 +382,7 @@ namespace platf::dxgi {
     claim_guard.disable();
     vgd_ring_release(_ring, frame.index);
     _last_sequence = frame.sequence;
-    _last_delivery = host_processing_timestamp;
-    _published_at_last_delivery = status.frames_published;
+    _undelivered_since.reset();
 
     d3d_img->blank = false;
     d3d_img->format = capture_format;

--- a/src/platform/windows/virtual_display.cpp
+++ b/src/platform/windows/virtual_display.cpp
@@ -3820,15 +3820,13 @@ namespace VDISPLAY {
     uint32_t fps,
     const GUID &guid,
     uint32_t base_fps_millihz,
-    bool framegen_refresh_active
+    bool framegen_refresh_active,
+    bool enable_hdr
   ) {
     if (is_luminalvgd_active()) {
-      if (s_hdr_profile && *s_hdr_profile) {
-        BOOST_LOG(info) << "LuminalVGD: HDR profile requested but the backend is SDR-only for now.";
-      }
       return vgd::create_virtual_display(
         s_client_uid, s_client_name, width, height, fps, guid, base_fps_millihz,
-        framegen_refresh_active);
+        framegen_refresh_active, enable_hdr);
     }
     constexpr int kMaxInitializationAttempts = 3;
     const auto requested_uuid = guid_to_uuid(guid);

--- a/src/platform/windows/virtual_display.h
+++ b/src/platform/windows/virtual_display.h
@@ -77,7 +77,8 @@ namespace VDISPLAY {
     uint32_t fps,
     const GUID &guid,
     uint32_t base_fps_millihz = 0,
-    bool framegen_refresh_active = false
+    bool framegen_refresh_active = false,
+    bool enable_hdr = false
   );
 
   // Apply an HDR color profile to a physical output (best-effort).

--- a/src/platform/windows/virtual_display_vgd.cpp
+++ b/src/platform/windows/virtual_display_vgd.cpp
@@ -233,7 +233,8 @@ namespace VDISPLAY::vgd {
     uint32_t fps_millihz,
     const GUID &guid,
     uint32_t base_fps_millihz,
-    bool framegen_refresh_active
+    bool framegen_refresh_active,
+    bool enable_hdr
   ) {
     const auto before = luminal_display_names();
 
@@ -269,8 +270,18 @@ namespace VDISPLAY::vgd {
     req.display_id = display_id_for_client(s_client_uid);
     req.adapter_luid = 0;        // driver default (largest VRAM)
     req.lease_timeout_ms = 0;    // driver default; ping thread feeds it
-    req.bit_depth = 8;           // SDR-8 (HDR arrives with driver caps::HDR10)
-    req.hdr = 0;
+    // HDR10 when the client asked for it and the driver advertises the cap;
+    // otherwise SDR-8. The driver's EDID grows the CTA-861.3 HDR block and
+    // Windows offers advanced color on the monitor.
+    const bool hdr = enable_hdr && g_caps && (g_caps->caps & VGD_CAP_HDR10);
+    // Proto wire encoding (SudoVDA-ported): Sdr8=8, Sdr10=10, Hdr10=110,
+    // Hdr12=112 — HDR depths carry a leading "1"; plain 10 with hdr=1 is
+    // rejected as BAD_BIT_DEPTH.
+    req.bit_depth = hdr ? 110 : 8;
+    req.hdr = hdr ? 1 : 0;
+    if (enable_hdr && !hdr) {
+      BOOST_LOG(info) << "LuminalVGD: client requested HDR but the installed driver lacks HDR10 caps; creating SDR monitor.";
+    }
     req.flags = 0;
     req.mode_count = 1;
     // Callers pass millihertz (nvhttp/webrtc normalize Hz → mHz before the
@@ -390,6 +401,11 @@ namespace VDISPLAY::vgd {
     return "proto " + std::to_string(g_caps->proto_major) + '.' +
            std::to_string(g_caps->proto_minor) + " build " +
            std::to_string(g_caps->driver_build);
+  }
+
+  bool driver_supports_hdr() {
+    std::lock_guard lk(g_mutex);
+    return g_caps && (g_caps->caps & VGD_CAP_HDR10);
   }
 
   std::optional<RingTargetInfo> ring_target_for_display(const std::string &display_name) {

--- a/src/platform/windows/virtual_display_vgd.h
+++ b/src/platform/windows/virtual_display_vgd.h
@@ -42,8 +42,13 @@ namespace VDISPLAY::vgd {
     uint32_t fps_millihz,
     const GUID &guid,
     uint32_t base_fps_millihz,
-    bool framegen_refresh_active
+    bool framegen_refresh_active,
+    bool enable_hdr = false
   );
+
+  /// True when the connected driver advertises HDR10 (caps gate for
+  /// requesting HDR monitors and for skipping the SDR topology downgrade).
+  bool driver_supports_hdr();
 
   bool remove_virtual_display(const GUID &guid);
   bool remove_all_virtual_displays();

--- a/src/webrtc_stream.cpp
+++ b/src/webrtc_stream.cpp
@@ -420,7 +420,8 @@ namespace webrtc_stream {
         vd_fps,
         virtual_display_guid,
         base_vd_fps_millihz,
-        framegen_refresh_active
+        framegen_refresh_active,
+        session->enable_hdr
       );
 
       if (display_info) {


### PR DESCRIPTION
## Summary
Pairs with LuminalVGD [#12](https://github.com/NortheBridge/LuminalVGD/pull/12) (HDR10 driver, build 2):

- `enable_hdr` threads from the Moonlight/WebRTC session into `createVirtualDisplay`; HDR-capable driver + HDR-requesting client → monitor created with `hdr=1, bit_depth=110` (proto wire encoding `Sdr8=8/Sdr10=10/Hdr10=110/Hdr12=112`).
- Topology SDR downgrade now conditioned on `vgd::driver_supports_hdr()` — HDR-capable installs apply `hdr_state: Enabled`.
- Ring-capture stall detector re-keyed to `latest_sequence` vs last-delivered sequence; the cumulative-counter version false-fired on idle desktops and blacklisted a healthy ring.
- Submodule → LuminalVGD main (HDR10 driver).

## Verification (live, RTX 5080 → Moonlight HDR + YUV 4:4:4)
- HDR monitor 3456×2160@240; Windows advanced color from the driver's CTA-861.3 EDID (993-nit metadata visible in capture); exclusive topology, APPLY with HDR enabled.
- Ring carries FP16 scRGB; `HEVC Main10 yuv444`, `Sent HDR mode: true`; extended session incl. idle periods, no stall-detector trips, ~5 ms frame latency.
- AV1 HDR 10-bit probes clean; AV1 4:4:4 is an NVENC hardware limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)