### PR TITLE
Ring capture reliability: monotonic delivery, reassignment grace, cancel-race fix

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -608,6 +608,9 @@ namespace platf::dxgi {
     // failures, and how long a newer-than-delivered frame has sat unclaimed.
     int _open_failures = 0;
     std::optional<std::chrono::steady_clock::time_point> _undelivered_since;
+    // How long the driver's heartbeat has been stale (swapchain unassigned
+    // during mode transitions stops the worker without marking the ring).
+    std::optional<std::chrono::steady_clock::time_point> _heartbeat_stale_since;
   };
 
   class display_wgc_ipc_ram_t: public display_ram_t {

--- a/src/platform/windows/display_vgd.cpp
+++ b/src/platform/windows/display_vgd.cpp
@@ -60,8 +60,14 @@ namespace platf::dxgi {
     constexpr uint32_t kRingStateDead = 3;
 
     /// Driver heartbeats the ring header at least every 500 ms even when no
-    /// frames flow; treat several missed beats as a dead worker.
+    /// frames flow; treat several missed beats as the worker being stopped.
     constexpr auto kHeartbeatStale = std::chrono::milliseconds(2000);
+
+    /// How long to wait out a stale heartbeat before reinitializing: mode
+    /// transitions unassign the swapchain (worker stops, heartbeat halts)
+    /// for a few seconds; only a persistently silent ring is worth the
+    /// cost of a capture teardown.
+    constexpr auto kHeartbeatReinitGrace = std::chrono::seconds(10);
 
     /// Circuit breaker: a session whose ring consistently fails to deliver
     /// (texture opens failing, or frames publishing that we can never claim)
@@ -241,11 +247,28 @@ namespace platf::dxgi {
     if (status.qpc_frequency != 0 && status.heartbeat_qpc != 0) {
       const auto beats_behind = qpc_time_difference(qpc_counter(), static_cast<int64_t>(status.heartbeat_qpc));
       if (beats_behind > kHeartbeatStale) {
-        BOOST_LOG(warning) << "LuminalVGD capture: ring heartbeat stale ("
-                           << std::chrono::duration_cast<std::chrono::milliseconds>(beats_behind).count()
-                           << " ms); reinitializing.";
-        return capture_e::reinit;
+        // The heartbeat stops whenever the OS unassigns the swapchain
+        // (game fullscreen/mode transitions) — the worker isn't dead, it's
+        // between assignments, and frames resume within seconds. Tearing
+        // the capture pipeline down for that turns a sub-second hiccup
+        // into a multi-second outage (encoder teardown + re-detection +
+        // settle), so wait out a grace window first.
+        const auto now = std::chrono::steady_clock::now();
+        if (!_heartbeat_stale_since) {
+          _heartbeat_stale_since = now;
+          BOOST_LOG(info) << "LuminalVGD capture: ring heartbeat stale ("
+                          << std::chrono::duration_cast<std::chrono::milliseconds>(beats_behind).count()
+                          << " ms); waiting out a possible swapchain reassignment.";
+        }
+        if (now - *_heartbeat_stale_since > kHeartbeatReinitGrace) {
+          BOOST_LOG(warning) << "LuminalVGD capture: ring heartbeat stale for "
+                             << std::chrono::duration_cast<std::chrono::seconds>(now - *_heartbeat_stale_since).count()
+                             << " s; reinitializing.";
+          return capture_e::reinit;
+        }
+        return capture_e::timeout;
       }
+      _heartbeat_stale_since.reset();
     }
     if (status.state == kRingStateRebuilding) {
       // The driver is retiring/recreating textures (mode change, swapchain

--- a/src/platform/windows/display_vgd.cpp
+++ b/src/platform/windows/display_vgd.cpp
@@ -284,11 +284,15 @@ namespace platf::dxgi {
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     while (true) {
       if (vgd_ring_claim(_ring, &frame)) {
-        if (frame.sequence != _last_sequence) {
+        if (frame.sequence > _last_sequence) {
           claimed = true;
           break;
         }
-        // Freshest published frame is the one we already delivered.
+        // At or below the last delivered sequence: either the frame we
+        // already delivered, or an OLDER still-published leftover that
+        // became the "freshest" after we released the newest slot —
+        // delivering it would send frames out of order. Release and wait
+        // for something genuinely new.
         vgd_ring_release(_ring, frame.index);
       }
       if (std::chrono::steady_clock::now() >= deadline) {

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -654,6 +654,16 @@ namespace stream {
       deferred_stream_start_state().reset();
     }
 
+    // Re-check liveness after consuming the deferred state: session::stop can
+    // run (e.g. ping timeout on the video/audio thread) between the caller's
+    // gate and this point. A cancelled session must not start its start-side
+    // platform actions — the teardown's frame-limiter/NVCP restore may already
+    // be executing on another thread inside the 10s hang watchdog.
+    if (session::active_sessions.load(std::memory_order_acquire) == 0) {
+      BOOST_LOG(info) << "Skipping deferred stream-start actions; session is already stopping.";
+      return false;
+    }
+
     BOOST_LOG(info) << "Stream-start actions applied after user session became available.";
     platf::frame_limiter_streaming_start(
       deferred->fps,
@@ -1425,7 +1435,16 @@ namespace stream {
 #ifdef _WIN32
       if (session::running_sessions.load(std::memory_order_relaxed) > 0) {
         (void) display_helper_integration::apply_pending_if_ready();
-        (void) apply_deferred_stream_start_actions_if_ready();
+        // Gate the deferred RTSS/NVCP start actions on active_sessions, not
+        // running_sessions: after "Initial Ping Timeout" the session is
+        // STOPPING (active_sessions == 0) while its threads are still being
+        // joined (running_sessions == 1). Applying start-side driver
+        // overrides in that window races the teardown's restore path —
+        // observed 2026-07-22 as concurrent NvAPI DRS transactions that
+        // wedged post-join cleanup past the 10s hang watchdog.
+        if (session::active_sessions.load(std::memory_order_acquire) > 0) {
+          (void) apply_deferred_stream_start_actions_if_ready();
+        }
       }
 #endif
 
@@ -2522,6 +2541,20 @@ namespace stream {
 #ifdef _WIN32
         VDISPLAY::restorePhysicalHdrProfiles();
         platf::rtss_set_sync_limiter_override(std::nullopt);
+        // The NVCP restore inside frame_limiter_streaming_stop tears down and
+        // re-creates an NvAPI DRS session (Initialize/LoadSettings/SaveSettings).
+        // Those calls serialize on the driver's settings store and have been
+        // observed to exceed 10 seconds when the display stack is busy (e.g.
+        // right after rapid virtual-display churn) or when a start-side NvAPI
+        // user (nvprefs / frame_limiter_nvcp) is still mid-transaction on
+        // another thread (2026-07-22 crash bundles). That is slow progress,
+        // not a wedge — and both nvprefs and frame_limiter_nvcp keep on-disk
+        // undo files as a crash backstop. Re-arm the hang watchdog with a
+        // longer bound for this stage so we don't _Exit() out from under a
+        // driver call that would complete on its own.
+        task_pool.cancel(force_kill);
+        force_kill = task_pool.pushDelayed(task, 60s).task_id;
+        BOOST_LOG(debug) << "Restoring frame limiter / NVIDIA Control Panel state..."sv;
         platf::frame_limiter_streaming_stop();
 #endif
         platf::streaming_will_stop();


### PR DESCRIPTION
## Summary
Pairs with LuminalVGD [#13](https://github.com/NortheBridge/LuminalVGD/pull/13) (atomic writer take-CAS, driver build 3). Three fixes from long-run live testing:

1. **Monotonic ring delivery** — after the newest slot is released, older still-published leftovers legitimately become the freshest claimable frame; the `!=` dedupe would deliver them out of order. Deliver only `sequence > last delivered`.
2. **Swapchain-reassignment grace** — game fullscreen/mode transitions unassign the driver's swapchain (worker stops, heartbeat halts, resumes seconds later). Treating that as a dead worker tore down the whole capture pipeline, turning a sub-second hiccup into a 9–43 s frozen-video outage (observed at a DLSS-FG game menu). Now waits a 10 s grace window returning timeout; frames resume the moment the swapchain reattaches.
3. **Cancel-during-start crash fix** — a session cancelled by Initial Ping Timeout still ran its deferred RTSS/NVCP start actions (gate used `running_sessions`, which only drops at teardown end), then an unlogged nvprefs NvAPI transaction contended with teardown's NVCP restore inside the 10 s hang watchdog → `Fatal: Wedged in phase: post-join cleanup (5)` and process death (reproduced twice: LG C2, Xbox Series X). Deferred actions now gate on `active_sessions` with a re-check before driver work, and the cleanup phase re-arms the watchdog to 60 s around the NVCP restore (video/audio/control joins keep 10 s).
4. Submodule → LuminalVGD main (take-CAS protocol, build 3).

## Verification (live)
- 22-minute Xbox Series X session storm: 6+ legs, three Initial Ping Timeouts, one disconnect racing capture startup — zero crashes, zero ring stalls, zero WGC fallbacks, all legs `Session ended` cleanly.
- 10-minute driver-level soak (vgd-probe): 0 stalls.
- Known follow-ups tracked: immediate-reconnect RTSP refusal while the prior leg drains (pre-existing), LG game-menu validation of the grace window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)