### PR TITLE
VGD capture: recoverable failures reinit instead of killing all sessions

### DIFF
--- a/src/platform/windows/display_vgd.cpp
+++ b/src/platform/windows/display_vgd.cpp
@@ -531,13 +531,18 @@ namespace platf::dxgi {
             return capture_e::interrupted;
           }
           auto d3d_img = std::static_pointer_cast<img_d3d_t>(img);
+          // Recoverable conditions must be `reinit`, never `error`: `error`
+          // kills the capture thread and with it EVERY session, while this
+          // path runs continuously whenever the cursor moves over an idle
+          // desktop. A mutex timeout / DEVICE_REMOVED here (the display can
+          // vanish mid-stream) is exactly what reinit + fallback exist for.
           if (complete_img(d3d_img.get(), false)) {
-            return capture_e::error;
+            return capture_e::reinit;
           }
           const HRESULT dst_acquire = seh_acquire_sync(d3d_img->capture_mutex.get(), 0, 3000);
           if (dst_acquire != S_OK && dst_acquire != static_cast<HRESULT>(WAIT_ABANDONED)) {
-            BOOST_LOG(error) << "LuminalVGD capture: pooled texture mutex acquire failed [0x"sv << util::hex(dst_acquire).to_string_view() << ']';
-            return capture_e::error;
+            BOOST_LOG(warning) << "LuminalVGD capture: pooled texture mutex acquire failed [0x"sv << util::hex(dst_acquire).to_string_view() << "]; reinitializing."sv;
+            return capture_e::reinit;
           }
           device_ctx->CopyResource(d3d_img->capture_texture.get(), _last_frame.get());
           if (cursor_visible && (_cursor_alpha.visible || _cursor_xor.visible)) {
@@ -626,15 +631,19 @@ namespace platf::dxgi {
     auto d3d_img = std::static_pointer_cast<img_d3d_t>(img);
 
     // Lazily create the pooled GPU texture + encoder handle (idempotent).
+    // Recoverable failures are `reinit`, not `error`: `error` tears down
+    // the capture thread and every session, while a mutex timeout or
+    // DEVICE_REMOVED (the virtual display can vanish mid-stream) is what
+    // reinit + WGC/DDA fallback exist for.
     if (complete_img(d3d_img.get(), false)) {
-      return capture_e::error;
+      return capture_e::reinit;
     }
 
     // Pooled textures follow the capture<->encoder key-0 convention.
     const HRESULT dst_acquire = seh_acquire_sync(d3d_img->capture_mutex.get(), 0, 3000);
     if (dst_acquire != S_OK && dst_acquire != static_cast<HRESULT>(WAIT_ABANDONED)) {
-      BOOST_LOG(error) << "LuminalVGD capture: pooled texture mutex acquire failed [0x"sv << util::hex(dst_acquire).to_string_view() << ']';
-      return capture_e::error;
+      BOOST_LOG(warning) << "LuminalVGD capture: pooled texture mutex acquire failed [0x"sv << util::hex(dst_acquire).to_string_view() << "]; reinitializing."sv;
+      return capture_e::reinit;
     }
 
     device_ctx->CopyResource(d3d_img->capture_texture.get(), slot->texture.get());


### PR DESCRIPTION
## Summary
Host-side half of the 2026-07-23 critical field-failure fix (driver half: LuminalVGD [PR #15](https://github.com/NortheBridge/LuminalVGD/pull/15), merged — callout-safe cursor lifecycle, build 7).

`capture_e::error` from `display_vgd_vram_t::snapshot()` tears down the capture thread and every session's image queues at once. The pooled-texture mutex timeout and `complete_img` failure are recoverable conditions (the virtual display can vanish mid-stream; reinit + WGC/DDA fallback exist for exactly that), yet both the claimed-frame path and the cursor-only redelivery path returned `error` — and the redelivery path runs continuously whenever the cursor moves over an idle desktop (LG magic remote, controller-as-mouse). Both now return `reinit`. Found by adversarial review of the field failure.

Also bumps the `luminal-display` submodule to LuminalVGD main `447685a`.

## Verification
Driver build 7 signed + installed; two live LG sessions (short + ~12.5 min) with clean logs, working cursor, clean teardowns, and zero new LiveKernelEvent 1b8 during or after streaming (the residual build-6 wedge fired every ~72 s right up until the build-7 install recycled the device, then stopped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)