### PR TITLE
fix(vdisplay): never select or touch SudoVDA at runtime; unstick driver status

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -2394,32 +2394,42 @@ namespace confighttp {
       // Non-fatal; keep metadata response minimal if enumeration fails.
     }
 
-    // Virtual display backend status — surfaces the active driver (SudoVDA)
+    // Virtual display backend status — surfaces the active driver (LuminalVGD)
     // plus its current health enum so the web UI can render an
     // accurate indicator instead of guessing.
     //
     // Lazy probe: proc::vDisplayDriverStatus is only flipped from UNKNOWN to a
     // real state by proc::initVDisplayDriver(), which on a typical desktop host
     // (physical monitors present, no active stream yet) is never called until
-    // streaming starts. That left the web UI permanently showing "unknown."
-    // We kick off a single one-shot probe the first time the metadata endpoint
-    // is hit while still in UNKNOWN, so the dashboard and Audio/Video tab can
-    // surface a real status without waiting for a stream session. Subsequent
-    // failures (FAILED / VERSION_INCOMPATIBLE / WATCHDOG_FAILED) stay sticky so
-    // we don't repeatedly slam a broken driver — the user can still act on the
-    // result via the installer's reconfigure flow.
+    // streaming starts. Probe on demand whenever the metadata endpoint is hit
+    // while the status is not OK, rate-limited to one attempt per 10 s. A
+    // once-only probe used to leave a transient startup failure (driver
+    // installed after the service started, PnP race at boot) sticky as
+    // "Failed to initialize" until the next stream, and made the Audio/Video
+    // tab's "Re-check driver" button a no-op. The rate limit keeps a genuinely
+    // broken/missing driver from being slammed on every dashboard poll.
     try {
-      static std::once_flag s_vdisplay_probe_once;
-      if (proc::vDisplayDriverStatus == VDISPLAY::DRIVER_STATUS::UNKNOWN) {
-        std::call_once(s_vdisplay_probe_once, []() {
-          try {
-            proc::initVDisplayDriver();
-          } catch (...) {
-            // initVDisplayDriver swallows most errors itself; this is belt-
-            // and-braces so a probe failure can't take down the metadata
-            // endpoint.
-          }
-        });
+      using probe_clock = std::chrono::steady_clock;
+      static std::mutex s_vdisplay_probe_mutex;
+      static probe_clock::time_point s_vdisplay_last_probe {};
+      bool do_probe = false;
+      if (proc::vDisplayDriverStatus != VDISPLAY::DRIVER_STATUS::OK) {
+        std::lock_guard lk(s_vdisplay_probe_mutex);
+        const auto now = probe_clock::now();
+        if (s_vdisplay_last_probe == probe_clock::time_point {} ||
+            now - s_vdisplay_last_probe >= std::chrono::seconds(10)) {
+          s_vdisplay_last_probe = now;
+          do_probe = true;
+        }
+      }
+      if (do_probe) {
+        try {
+          proc::initVDisplayDriver();
+        } catch (...) {
+          // initVDisplayDriver swallows most errors itself; this is belt-
+          // and-braces so a probe failure can't take down the metadata
+          // endpoint.
+        }
       }
       output_tree["virtual_display_backend"] = VDISPLAY::active_backend_name();
       output_tree["virtual_display_driver_status"] = static_cast<int>(proc::vDisplayDriverStatus);

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -378,7 +378,7 @@ namespace nvhttp {
         if (proc::vDisplayDriverStatus != VDISPLAY::DRIVER_STATUS::OK) {
           proc::initVDisplayDriver();
           if (proc::vDisplayDriverStatus != VDISPLAY::DRIVER_STATUS::OK) {
-            BOOST_LOG(warning) << "SudaVDA driver unavailable (status=" << static_cast<int>(proc::vDisplayDriverStatus) << "). Continuing with best-effort virtual display creation.";
+            BOOST_LOG(warning) << "Virtual display driver unavailable (status=" << static_cast<int>(proc::vDisplayDriverStatus) << "). Continuing with best-effort virtual display creation.";
           }
         }
         if (!config::video.adapter_name.empty()) {

--- a/src/platform/windows/virtual_display.cpp
+++ b/src/platform/windows/virtual_display.cpp
@@ -2892,6 +2892,11 @@ namespace VDISPLAY {
     // process initialization in most cases. Without it the dispatch flag
     // would still be NONE and we'd fall through to SudoVDA defaults.
     select_backend();
+    if (!is_sudovda_active()) {
+      // LuminalVGD needs no registry defaults — and recreating the SudoMaker
+      // key here would undo the installer's SudoVDA eviction on every start.
+      return;
+    }
     constexpr const wchar_t *REG_PATH = L"SOFTWARE\\SudoMaker\\SudoVDA";
     HKEY key = nullptr;
     REGSAM access = KEY_WRITE;
@@ -2944,6 +2949,12 @@ namespace VDISPLAY {
     select_backend();
     if (is_luminalvgd_active()) {
       return vgd::open_device();
+    }
+    if (!is_sudovda_active()) {
+      // No backend installed — fail fast instead of spinning the legacy
+      // SudoVDA open/retry ladder (seconds of sleeps plus device-restart
+      // recovery) against a device that cannot exist.
+      return DRIVER_STATUS::FAILED;
     }
     // Idempotency: a prior driver handle may still be open — the recovery
     // monitor and the several proc::initVDisplayDriver() call sites can
@@ -3082,6 +3093,9 @@ namespace VDISPLAY {
   bool ensure_driver_is_ready() {
     if (is_luminalvgd_active()) {
       return vgd::driver_ready();
+    }
+    if (!is_sudovda_active()) {
+      return false;
     }
     return ensure_driver_is_ready_impl(RestartCooldownBehavior::skip);
   }

--- a/src/platform/windows/virtual_display_backend.cpp
+++ b/src/platform/windows/virtual_display_backend.cpp
@@ -2,10 +2,10 @@
  * @file src/platform/windows/virtual_display_backend.cpp
  * @brief Picks the active virtual-display backend at startup.
  *
- * SudoVDA is the only shipped backend (default until the planned LuminalShine
- * first-party VDD ships). Emits a caveat when selected because SudoVDA can
- * hang on the latest Windows 11 release builds and on Windows 11 Insider
- * Preview channels (WUDFHostProblem2 / HostTimeout).
+ * LuminalVGD (the first-party IddCx driver) is the only supported backend.
+ * SudoVDA was retired in 2026-07 — the installer evicts it and the runtime
+ * never selects it; the legacy `virtual_display_backend` config tokens
+ * ("sudovda", "mtt") map forward to auto with a warning.
  */
 
 #include "src/platform/windows/virtual_display_backend.h"
@@ -16,9 +16,7 @@
 #include "src/platform/windows/virtual_display_vgd.h"
 
 #include <atomic>
-#include <chrono>
 #include <mutex>
-#include <thread>
 
 namespace VDISPLAY {
 
@@ -42,40 +40,6 @@ namespace VDISPLAY {
       return b;
     }
 
-    bool sudovda_appears_installed() {
-      // Mirror the existing detection logic in virtual_display.cpp's
-      // `find_sudovda_device_instance_id()`. We don't link to that helper
-      // directly to keep this file independent; a registry probe is enough
-      // for "is the user-mode side present" and the existing SudoVDA code
-      // will fail-open if the device isn't actually responsive.
-      //
-      // Bounded one-shot retry: on Windows 11 Insider Preview Canary
-      // builds the UMDF host that publishes the SudoVDA registry tree
-      // can lag the SunshineService start by a few hundred milliseconds
-      // on cold boot. A single hit-and-miss probe loses that race and
-      // we fall through to BackendType::NONE for the entire process
-      // lifetime. Retry up to ~750 ms total before giving up — plenty
-      // of headroom on Canary, still negligible on systems where the
-      // key is already present (we exit on the first attempt).
-      constexpr int max_attempts = 4;
-      constexpr auto retry_backoff = std::chrono::milliseconds(250);
-      for (int attempt = 0; attempt < max_attempts; ++attempt) {
-        HKEY key = nullptr;
-        if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\SudoMaker\\SudoVDA", 0,
-                          KEY_READ, &key) == ERROR_SUCCESS) {
-          RegCloseKey(key);
-          if (attempt > 0) {
-            BOOST_LOG(info) << "SudoVDA registry key appeared on attempt " << (attempt + 1)
-                            << " (~" << (attempt * retry_backoff.count()) << " ms after first probe).";
-          }
-          return true;
-        }
-        if (attempt + 1 < max_attempts) {
-          std::this_thread::sleep_for(retry_backoff);
-        }
-      }
-      return false;
-    }
   }  // namespace
 
   BackendType select_backend() {
@@ -85,41 +49,22 @@ namespace VDISPLAY {
     }
 
     const std::string preference = config::video.virtual_display_backend;
-    if (preference == "mtt") {
-      BOOST_LOG(warning) << "virtual_display_backend=mtt is no longer supported (MTT VDD was removed); "
+    if (preference == "mtt" || preference == "sudovda") {
+      BOOST_LOG(warning) << "virtual_display_backend=" << preference
+                         << " is no longer supported (LuminalVGD is the only backend); "
                             "falling back to auto selection.";
     }
 
     const bool luminalvgd_installed = vgd::driver_appears_installed();
-    const bool sudovda_installed = sudovda_appears_installed();
 
-    BackendType chosen = BackendType::NONE;
-    if (preference == "sudovda") {
-      chosen = sudovda_installed ? BackendType::SUDOVDA : BackendType::NONE;
-    } else if (preference == "luminalvgd") {
-      chosen = luminalvgd_installed ? BackendType::LUMINALVGD : BackendType::NONE;
-      if (!luminalvgd_installed) {
-        BOOST_LOG(warning) << "virtual_display_backend=luminalvgd but the LuminalVGD driver is not "
-                              "installed/reachable; per-client virtual displays are disabled.";
-      }
-    } else {  // auto (and the removed "mtt")
-      // Capture ladder (LuminalVGD DESIGN.md §2): the first-party driver is
-      // primary the moment it is installed; SudoVDA remains the fallback
-      // until it is retired.
-      chosen = luminalvgd_installed ? BackendType::LUMINALVGD
-             : sudovda_installed    ? BackendType::SUDOVDA
-                                    : BackendType::NONE;
-    }
+    const BackendType chosen = luminalvgd_installed ? BackendType::LUMINALVGD : BackendType::NONE;
 
     if (chosen == BackendType::LUMINALVGD) {
       BOOST_LOG(info) << "Virtual-display backend: LuminalVGD (first-party IddCx driver).";
-    } else if (chosen == BackendType::SUDOVDA) {
-      BOOST_LOG(info) << "Virtual-display backend: SudoVDA (legacy). Heads up: SudoVDA can hang "
-                         "on the latest Windows 11 release builds and on Windows 11 Insider "
-                         "Preview channels (WUDFHostProblem2 / HostTimeout). Install the "
-                         "LuminalVGD driver to use the first-party backend.";
     } else {
-      BOOST_LOG(warning) << "No virtual-display backend installed; per-client virtual displays will not work.";
+      BOOST_LOG(warning) << "The LuminalVGD driver is not installed/reachable; per-client "
+                            "virtual displays will not work. Install the LuminalVGD driver "
+                            "(drivers\\luminalvgd\\install.ps1 or the installer) to enable them.";
     }
 
     selected_backend().store(chosen, std::memory_order_release);

--- a/src/platform/windows/virtual_display_backend.h
+++ b/src/platform/windows/virtual_display_backend.h
@@ -2,15 +2,15 @@
  * @file src/platform/windows/virtual_display_backend.h
  * @brief Selects the active virtual-display driver backend.
  *
- * LuminalShine currently ships a single virtual-display driver:
- *   - SudoVDA — default backend, controlled via custom IOCTLs. Slated to be
- *     replaced by a first-party LuminalShine VDD in a future release; until
- *     then it ships as the recommended driver.
+ * LuminalShine ships a single virtual-display driver:
+ *   - LuminalVGD — the first-party IddCx driver. SudoVDA was retired in
+ *     2026-07 and is never selected; its enum value remains only until the
+ *     legacy code excision completes.
  *
  * Public functions in `virtual_display.h` dispatch to the active backend
- * through this thin selector. The backend is chosen at startup based on the
- * `virtual_display_backend` config option and which drivers are actually
- * installed; once chosen it remains fixed for the process lifetime.
+ * through this thin selector. The backend is LuminalVGD when the driver is
+ * installed, NONE otherwise; once chosen it remains fixed for the process
+ * lifetime.
  */
 #pragma once
 
@@ -21,17 +21,17 @@ namespace VDISPLAY {
   enum class BackendType : int {
     /// No virtual-display driver available.
     NONE = 0,
-    /// SudoVDA (legacy default; being replaced by LuminalVGD).
+    /// SudoVDA (retired 2026-07; never selected — kept until code excision).
     SUDOVDA = 1,
-    /// LuminalVGD — the first-party IddCx driver (preferred when installed).
+    /// LuminalVGD — the first-party IddCx driver (the only supported backend).
     LUMINALVGD = 2,
   };
 
   /// Select and initialize the backend for this process.
   ///
-  /// Inspects `config::video.virtual_display_backend` (auto/sudovda) and picks
-  /// accordingly, logging the SudoVDA Win11/Insider caveat when SudoVDA is
-  /// selected.
+  /// Picks LuminalVGD when the driver is installed, NONE otherwise. Legacy
+  /// `virtual_display_backend` tokens ("sudovda", "mtt") log a warning and
+  /// map to auto.
   ///
   /// Idempotent: calling more than once returns the already-chosen backend.
   BackendType select_backend();

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -766,7 +766,7 @@ namespace proc {
   void initVDisplayDriver() {
     VDISPLAY::ensureVirtualDisplayRegistryDefaults();
     if (!VDISPLAY::ensure_driver_is_ready()) {
-      BOOST_LOG(warning) << "SudoVDA driver reported unavailable during initialization; attempting to continue.";
+      BOOST_LOG(warning) << "Virtual display driver reported unavailable during initialization; attempting to continue.";
     }
     vDisplayDriverStatus = VDISPLAY::openVDisplayDevice();
     if (vDisplayDriverStatus == VDISPLAY::DRIVER_STATUS::OK) {

--- a/src/webrtc_stream.cpp
+++ b/src/webrtc_stream.cpp
@@ -285,7 +285,7 @@ namespace webrtc_stream {
         proc::initVDisplayDriver();
         if (proc::vDisplayDriverStatus != VDISPLAY::DRIVER_STATUS::OK) {
           BOOST_LOG(warning)
-            << "SudaVDA driver unavailable (status=" << static_cast<int>(proc::vDisplayDriverStatus)
+            << "Virtual display driver unavailable (status=" << static_cast<int>(proc::vDisplayDriverStatus)
             << "). Continuing with best-effort virtual display creation.";
         }
       }


### PR DESCRIPTION
Runtime follow-up to #85/#86 (installer-side SudoVDA removal). The executable still contained the SudoVDA auto-fallback ladder, so hosts without the LuminalVGD driver silently activated SudoVDA, and the runtime recreated registry state the installer had just evicted.

## Changes

- **`select_backend()` is LuminalVGD-or-none.** The SudoVDA registry probe (and its 750 ms boot-race retry loop) is gone; legacy `virtual_display_backend` tokens (`sudovda`, `mtt`) log a warning and map to auto.
- **`ensureVirtualDisplayRegistryDefaults()` no longer recreates `HKLM\SOFTWARE\SudoMaker\SudoVDA`.** It early-returns unless SudoVDA is the active backend (never, now) — previously every service start undid the installer''s eviction.
- **Fail fast with no backend.** `openVDisplayDevice()` / `ensure_driver_is_ready()` return immediately instead of running the legacy SudoVDA open/retry ladder (seconds of sleeps plus device-restart recovery) against a device that cannot exist.
- **About-page "Failed to initialize" no longer sticks.** `/api/metadata` used a `std::once_flag` probe: one transient failure at startup (driver installed after service start, PnP race at boot) pinned the status until the next stream, and made the Audio/Video "Re-check driver" button a no-op. The probe now retries while status != OK, rate-limited to one attempt per 10 s so a genuinely missing driver is not slammed by dashboard polling.
- Genericized SudoVDA-specific log strings on shared code paths (including two "SudaVDA" typos).

## Testing

- Full rebuild (clang/UCRT64, Release) clean.
- `test_sunshine`: 205/206 pass; the one failure (`ConfigHttpCheckAuthTest.given_disallowed_ip_address...`) is a pre-existing string mismatch on `main` (`origin_forbidden` vs `Forbidden`) in code this PR does not touch.
- Verified the linked binary no longer contains the "Virtual-display backend: SudoVDA (legacy)" selection string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)