### PR TITLE
fix(vdisplay): LuminalVGD control-plane auth fix (driver build 11) + real error logging

### DIFF
--- a/src/platform/windows/virtual_display_vgd.cpp
+++ b/src/platform/windows/virtual_display_vgd.cpp
@@ -90,10 +90,17 @@ namespace VDISPLAY::vgd {
       }
       g_device = vgd_device_open();
       if (!g_device) {
+        // Win32 error 2/259: driver not installed (interface absent);
+        // error 5: the driver's SYSTEM/Administrators ACL refused this
+        // process — the 2026-07 streaming outage looked exactly like this.
+        BOOST_LOG(error) << "LuminalVGD control device open failed (Win32 error "
+                         << vgd_last_error() << ").";
         return DRIVER_STATUS::FAILED;
       }
       VgdCaps caps {};
-      if (vgd_handshake(g_device, &caps) != 0) {
+      if (const int hs = vgd_handshake(g_device, &caps); hs != 0) {
+        BOOST_LOG(error) << "LuminalVGD handshake failed: code " << hs
+                         << " (Win32 error " << vgd_last_error() << ").";
         vgd_device_close(g_device);
         g_device = nullptr;
         return DRIVER_STATUS::FAILED;


### PR DESCRIPTION
## Summary

Companion to [LuminalVGD PR #17](https://github.com/NortheBridge/LuminalVGD/pull/17) — restores streaming, which has been broken on installed deployments since the build-8 driver ACL landed (every control IOCTL refused → `Virtual display creation failed` → letterboxed physical-capture fallback with monitors left on).

- **Submodule bump** to LuminalVGD main `9b3dd33` (build 11): the host-side open now grants `SECURITY_SQOS_PRESENT | SECURITY_IMPERSONATION` (UMDF cannot evaluate caller identity without the client opting in), and the driver authorizes at IOCTL time with an INF-granted impersonation level.
- **`open_locked()` diagnostics**: logs which step failed (open vs handshake) with the real Win32 code via the new FFI `vgd_last_error()`. The outage was invisible in host logs because every failure collapsed into a silent `FAILED`.

## Validation

Live on the dev box with the installed SYSTEM service + signed driver build 11: `LuminalVGD driver ready: proto 0.3 build 11` at startup, per-client monitor created (3840x2160@240 Hz), exclusive topology applied, `LuminalVGD capture: consuming frame ring … (3 slots)` — streamed to macOS and LG C2 83" OLED at native resolution; black-bar and monitors-stay-on symptoms gone.

## Notes

- The released **26.08.0-beta.1 cannot stream** (bundles driver build 8 + pre-SQOS host); a beta.2 respin with a new pinned driver release is the follow-up (CI `LUMINALVGD_VERSION` pin + MSI golden re-baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)