### PR TITLE
chore(ci): pin LuminalVGD v0.1.0-alpha.2 (Milestone 1, build 11)

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -341,7 +341,7 @@ jobs:
           # (github.com/NortheBridge/LuminalVGD releases). Bump on driver
           # releases. SudoVDA is gone by decision (2026-07-23) — the MSI's
           # drivers\luminalvgd\install.ps1 also removes it wherever found.
-          LUMINALVGD_VERSION: 'v0.1.0-alpha.1'
+          LUMINALVGD_VERSION: 'v0.1.0-alpha.2'
         run: |
           $ErrorActionPreference = 'Stop'
           $packageDir = Join-Path $PWD 'src_assets/windows/drivers/luminalvgd/driver-package'

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -147,7 +147,7 @@ jobs:
         # sign/install them in the coverage workflow.
         shell: pwsh
         env:
-          LUMINALVGD_VERSION: 'v0.1.0-alpha.1'
+          LUMINALVGD_VERSION: 'v0.1.0-alpha.2'
         run: |
           $ErrorActionPreference = 'Stop'
           $packageDir = Join-Path $PWD 'src_assets/windows/drivers/luminalvgd/driver-package'


### PR DESCRIPTION
alpha.1 bundles driver build 8, whose control-surface ACL refuses every
IOCTL; installers built against it cannot stream.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
