### PR TITLE
fix: MSI driver-script device scan takes seconds, not minutes

### DIFF
--- a/src_assets/windows/drivers/luminalvgd/install.ps1
+++ b/src_assets/windows/drivers/luminalvgd/install.ps1
@@ -20,7 +20,12 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $packageDir = Join-Path $scriptDir 'driver-package'
 
 function Get-DevicesByHardwareId([string]$HardwareId) {
-    Get-PnpDevice -ErrorAction SilentlyContinue | Where-Object {
+    # Every caller targets Display-class root devnodes (LuminalVGD,
+    # SudoVDA), and -Class Display is what keeps this fast: each
+    # Get-PnpDeviceProperty round-trip costs ~0.8 s, so an unfiltered scan
+    # of every devnode ran minutes per call inside the MSI. Phantom
+    # (not-present) devnodes keep their class and still match.
+    Get-PnpDevice -Class Display -ErrorAction SilentlyContinue | Where-Object {
         $ids = (Get-PnpDeviceProperty -InstanceId $_.InstanceId -KeyName 'DEVPKEY_Device_HardwareIds' -ErrorAction SilentlyContinue).Data
         $ids -and (@($ids) -contains $HardwareId)
     }
@@ -122,7 +127,9 @@ function Install-LuminalVgd {
     }
 
     Write-Host "[LuminalVGD] Adding driver package..."
-    pnputil /add-driver $inf /install | Out-Null
+    # Stage only — no /install: the UpdateDriverForPlugAndPlayDevices
+    # force-bind below performs the one device install/start.
+    pnputil /add-driver $inf | Out-Null
     if ($LASTEXITCODE -notin 0, 3010, 259) { throw "[LuminalVGD] pnputil /add-driver failed ($LASTEXITCODE)" }
     if ($LASTEXITCODE -eq 3010) { Write-Warning "[LuminalVGD] Windows reports a reboot is required to finish the driver update." }
 


### PR DESCRIPTION
## Summary
Companion to NortheBridge/LuminalVGD#19 (see its CLAUDE.md post-mortem): the ">30-minute install" was script-side per-device CIM enumeration, not the driver. `Get-DevicesByHardwareId` in `src_assets/windows/drivers/luminalvgd/install.ps1` cost ~6.5 minutes per scan on a ~500-devnode box and runs up to twice per MSI install (SudoVDA sweep + devnode existing-check) plus once per uninstall.

## Changes
- `Get-DevicesByHardwareId` pre-narrows with `-Class Display` (every caller targets Display-class root devnodes: LuminalVGD, SudoVDA). Phantom devnodes keep their Class, so the sweep still finds removed-but-remembered devices.
- `pnputil /add-driver` drops `/install` — the UpdateDriverForPlugAndPlayDevices force-bind performs the one device install.

## Verification
The identical function change in the LuminalVGD repo scripts was verified on the dev box with an elevated run: under 15 seconds end to end (previously ~13 minutes), correct devnode identified, driver bound. This copy reaches deployed boxes on the next MSI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)