### PR TITLE
fix: preserve the full credential record across hot config applies

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -962,9 +962,21 @@ namespace config {
     std::unordered_map<std::string, std::string> command_line_overrides;
 
     void reset_runtime_config_to_defaults() {
+      // The whole in-RAM credential record must survive a config apply:
+      // the conf file carries no credentials, so anything not preserved
+      // here is simply lost until the next reload_user_creds (= service
+      // restart). Losing password_kdf downgrades verification to legacy
+      // SHA-256 against an Argon2id hash — every login then rejects the
+      // valid admin password. Hot applies run on every stream start
+      // (per-app runtime overrides), so any new credential-record field
+      // added to sunshine_t MUST be preserved here alongside these.
       const auto preserved_username = sunshine.username;
       const auto preserved_password = sunshine.password;
       const auto preserved_salt = sunshine.salt;
+      const auto preserved_password_kdf = sunshine.password_kdf;
+      const auto preserved_argon2_m_cost_kib = sunshine.argon2_m_cost_kib;
+      const auto preserved_argon2_t_cost = sunshine.argon2_t_cost;
+      const auto preserved_argon2_parallel = sunshine.argon2_parallel;
       const auto preserved_config_file = sunshine.config_file;
       const auto preserved_cmd = sunshine.cmd;
 
@@ -980,6 +992,10 @@ namespace config {
       sunshine.username = preserved_username;
       sunshine.password = preserved_password;
       sunshine.salt = preserved_salt;
+      sunshine.password_kdf = preserved_password_kdf;
+      sunshine.argon2_m_cost_kib = preserved_argon2_m_cost_kib;
+      sunshine.argon2_t_cost = preserved_argon2_t_cost;
+      sunshine.argon2_parallel = preserved_argon2_parallel;
       sunshine.config_file = preserved_config_file;
       sunshine.cmd = preserved_cmd;
     }

--- a/tests/unit/test_config.cpp
+++ b/tests/unit/test_config.cpp
@@ -1,0 +1,52 @@
+// standard includes
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+// lib includes
+#include <gtest/gtest.h>
+
+// local includes
+#include "../tests_common.h"
+#include "src/config.h"
+
+// Regression test for the recurring admin-lockout bug: a hot config apply
+// (config::apply_config_now) resets the runtime config structs to defaults
+// and must preserve the ENTIRE in-RAM credential record — the config file
+// carries no credentials, so any field dropped here is lost until the next
+// service restart. When password_kdf was dropped, verification downgraded
+// to legacy SHA-256 against an Argon2id hash and every login rejected the
+// valid admin password. Hot applies run on every stream start (per-app
+// runtime overrides), so this lockout appeared "randomly" mid-uptime.
+TEST(ConfigApply, PreservesInRamCredentialRecord) {
+  namespace fs = std::filesystem;
+  const auto conf_path = fs::temp_directory_path() / "luminalshine_test_apply.conf";
+  {
+    std::ofstream out(conf_path);
+    out << "min_log_level = 2\n";
+  }
+  const auto saved_config_file = config::sunshine.config_file;
+  config::sunshine.config_file = conf_path.string();
+
+  config::sunshine.username = "test-admin";
+  config::sunshine.password = "argon2id-hash-placeholder";
+  config::sunshine.salt = "0123456789abcdef";
+  config::sunshine.password_kdf = "argon2id";
+  config::sunshine.argon2_m_cost_kib = 32768;
+  config::sunshine.argon2_t_cost = 4;
+  config::sunshine.argon2_parallel = 2;
+
+  config::apply_config_now();
+
+  EXPECT_EQ(config::sunshine.username, "test-admin");
+  EXPECT_EQ(config::sunshine.password, "argon2id-hash-placeholder");
+  EXPECT_EQ(config::sunshine.salt, "0123456789abcdef");
+  EXPECT_EQ(config::sunshine.password_kdf, "argon2id");
+  EXPECT_EQ(config::sunshine.argon2_m_cost_kib, 32768u);
+  EXPECT_EQ(config::sunshine.argon2_t_cost, 4u);
+  EXPECT_EQ(config::sunshine.argon2_parallel, 2u);
+
+  config::sunshine.config_file = saved_config_file;
+  std::error_code ec;
+  fs::remove(conf_path, ec);
+}


### PR DESCRIPTION
## Summary

Fixes the returned admin-lockout: the valid admin password was rejected locally and from other devices until a service restart.

**Root cause:** every config apply begins with `reset_runtime_config_to_defaults()`, whose credential preserve-list — itself the original fix for this same lockout — kept `username`/`password`/`salt` but not `password_kdf` or the `argon2_*` parameters, which the Argon2id feature added to `sunshine_t` later. Hot applies run on **every stream start** (per-app runtime overrides), so after the day's first stream the in-RAM KDF discriminator was empty: `verify_user_password` silently took the legacy SHA-256 path against the stored **Argon2id** hash — guaranteed mismatch, every login rejected until restart.

**Field evidence (dev box logs):** logins succeed at every fresh service start (Jul 25 07:58, Jul 26 13:06) and fail only after mid-session config applies (applies logged 10:51/12:34 → failures 12:38–12:43 on Jul 25; apply 05:47 → failures 13:03 on Jul 26). Zero cred-store or KDF errors ever logged — storage was never at fault; only the in-RAM copy degraded. The reset shortcut 'fixed' it by erasing the record and landing on a fresh (correctly loaded) one.

## Fix

- Preserve the entire credential record (`password_kdf`, `argon2_m_cost_kib`, `argon2_t_cost`, `argon2_parallel`) across the reset, with the preserve-list documented as a contract for future credential-record fields.
- Regression test `ConfigApply.PreservesInRamCredentialRecord`: applies config on top of a populated in-RAM record and asserts every field survives (fails on the pre-fix code, where the reset empties `password_kdf`).

## Notes

Security-wise this restores intended verification behavior (correct KDF selected per record); it adds no new surface. A pre-existing sharp edge remains out of scope: `apply_config` mutates `config::sunshine` without `creds_ram_mutex`, so a login racing an apply can still transiently read a half-reset record — transient only, and present before this change.

## Testing

- `test_sunshine --gtest_filter='ConfigApply.*'` passes locally (mingw-clang build)
- Full CI gates the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)