### PR TITLE
Make the config-consistency suite functional in CI and gate on it

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -779,6 +779,17 @@ jobs:
         working-directory: build/tests
         run: ./test_sunshine.exe --gtest_color=yes --gtest_output=xml:test_results.xml
 
+      - name: Config consistency gate
+        # Unlike the advisory run above, the config-consistency suite reads
+        # only repo files copied into build/tests at configure time — no
+        # display adapter, network, Playnite, or locale-set dependency — so
+        # it is reliable on the runner and gates the build. A failure here
+        # means a config option is inconsistent across src/config.cpp,
+        # stores/config.ts, docs/configuration.md, and en.json.
+        shell: msys2 {0}
+        working-directory: build/tests
+        run: ./test_sunshine.exe --gtest_color=yes --gtest_filter='ConfigConsistencyTest.*'
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1499,6 +1499,32 @@ editing the `conf` file in a text editor. Use the examples as reference.
     </tr>
 </table>
 
+### dd_paused_virtual_display_timeout_secs
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            Optional grace delay in seconds before removing virtual displays while a session is paused and
+            revert-on-disconnect is disabled. A value of 0 keeps the virtual display alive until the session
+            is resumed or the app exits.
+            @warning{Removing a virtual display while a game is still running can cause crashes. This option
+            helps prevent returning to a stuck virtual screen after inactivity.}
+            @note{Applies to Windows only.}
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}0@endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}
+            dd_paused_virtual_display_timeout_secs = 300
+            @endcode</td>
+    </tr>
+</table>
+
 ### dd_always_restore_from_golden
 
 <table>
@@ -2183,6 +2209,33 @@ editing the `conf` file in a text editor. Use the examples as reference.
     </tr>
 </table>
 
+### tpm_binding
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            When enabled, the saved admin username and password blob is encrypted with a non-exportable
+            RSA-2048 key sealed in the local TPM (Microsoft Platform Crypto Provider) before being written
+            to Windows Credential Manager. An attacker who acquires the credential bytes cannot decrypt
+            them without the original TPM. Silently does nothing on hosts without a TPM 2.0 chip.
+            Toggling this off rewrites the credential as plain on the next save; toggling it on rewrites
+            it sealed on the next save.
+            @note{Applies to Windows only.}
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}true@endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}
+            tpm_binding = false
+            @endcode</td>
+    </tr>
+</table>
+
 ### session_token_ttl_seconds
 
 <table>
@@ -2672,6 +2725,29 @@ editing the `conf` file in a text editor. Use the examples as reference.
     </tr>
 </table>
 
+### lossless_scaling_legacy_auto_detect
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            Use the legacy timer-based auto-apply flow for Lossless Scaling instead of the hotkey method.
+            Not recommended unless the hotkey method fails, because detection can be less reliable.
+            @note{Applies to Windows only.}
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}false@endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}
+            lossless_scaling_legacy_auto_detect = true
+            @endcode</td>
+    </tr>
+</table>
+
 ### encoder
 
 <table>
@@ -2711,6 +2787,31 @@ editing the `conf` file in a text editor. Use the examples as reference.
     <tr>
         <td>software</td>
         <td>Encoding occurs on the CPU</td>
+    </tr>
+</table>
+
+### session_monitor
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            Push per-stream telemetry (encode latency, throughput, FPS, host CPU/RAM, connection-quality
+            events) to the LuminalShineSessionMonitor sidecar service. Powers the Session Details slide-out
+            on the Dashboard with live and historical charts. When disabled the streaming host emits no
+            session frames and the Dashboard's Session History card stays empty for future streams.
+            Existing recorded sessions are unaffected.
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}true@endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}
+            session_monitor = false
+            @endcode</td>
     </tr>
 </table>
 
@@ -3016,40 +3117,6 @@ They appear in the Frame Limiter section of the settings UI.
     </tr>
 </table>
 
-### nvenc_vbv_increase
-
-<table>
-    <tr>
-        <td>Description</td>
-        <td colspan="2">
-            Single-frame VBV/HRD percentage increase.
-            By default Sunshine uses single-frame VBV/HRD, which means any encoded video frame size is not expected to
-            exceed requested bitrate divided by requested frame rate. Relaxing this restriction can be beneficial and
-            act as low-latency variable bitrate, but may also lead to packet loss if the network doesn't have buffer
-            headroom to handle bitrate spikes. Maximum accepted value is 400, which corresponds to 5x increased
-            encoded video frame upper size limit.
-            @note{This option only applies when using NVENC [encoder](#encoder).}
-            @warning{Can lead to network packet loss.}
-        </td>
-    </tr>
-    <tr>
-        <td>Default</td>
-        <td colspan="2">@code{}
-            0
-            @endcode</td>
-    </tr>
-    <tr>
-        <td>Range</td>
-        <td colspan="2">0-400</td>
-    </tr>
-    <tr>
-        <td>Example</td>
-        <td colspan="2">@code{}
-            nvenc_vbv_increase = 0
-            @endcode</td>
-    </tr>
-</table>
-
 ### nvenc_split_encode
 
 <table>
@@ -3082,6 +3149,40 @@ They appear in the Frame Limiter section of the settings UI.
         <td>Example</td>
         <td colspan="2">@code{}
             nvenc_split_encode = enabled
+            @endcode</td>
+    </tr>
+</table>
+
+### nvenc_vbv_increase
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            Single-frame VBV/HRD percentage increase.
+            By default Sunshine uses single-frame VBV/HRD, which means any encoded video frame size is not expected to
+            exceed requested bitrate divided by requested frame rate. Relaxing this restriction can be beneficial and
+            act as low-latency variable bitrate, but may also lead to packet loss if the network doesn't have buffer
+            headroom to handle bitrate spikes. Maximum accepted value is 400, which corresponds to 5x increased
+            encoded video frame upper size limit.
+            @note{This option only applies when using NVENC [encoder](#encoder).}
+            @warning{Can lead to network packet loss.}
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}
+            0
+            @endcode</td>
+    </tr>
+    <tr>
+        <td>Range</td>
+        <td colspan="2">0-400</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}
+            nvenc_vbv_increase = 0
             @endcode</td>
     </tr>
 </table>
@@ -3556,6 +3657,43 @@ They appear in the Frame Limiter section of the settings UI.
     </tr>
 </table>
 
+### amd_split_encode
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            Controls AMF dual-VCN split-frame encoding. Splits each frame into two tiles and lets the AMF
+            driver dispatch them to separate hardware encoder instances on dual-VCN parts (RDNA 3 7900-series,
+            RDNA 4 9070-series), cutting encode latency under sustained 4K AV1 / HEVC load.
+            Auto enables it whenever the active GPU advertises 2 or more hardware encoder instances; enabled
+            forces it on (silently falls back to single-tile on single-VCN parts); disabled never uses it.
+            @note{This option only applies when using HEVC or AV1 with the amdvce [encoder](#encoder).
+            H.264 is not supported.}
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}
+            auto
+            @endcode</td>
+    </tr>
+    <tr>
+        <td>Possible Values</td>
+        <td colspan="2">@code{}
+            auto
+            enabled
+            disabled
+            @endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}
+            amd_split_encode = enabled
+            @endcode</td>
+    </tr>
+</table>
+
 ## VideoToolbox Encoder
 
 ### vt_coder
@@ -3812,6 +3950,79 @@ They appear in the Frame Limiter section of the settings UI.
 <tr>
         <td>zerolatency</td>
         <td>good for fast encoding and low-latency streaming</td>
+    </tr>
+</table>
+
+## Steam Library Integration
+
+These options control the read-only Steam library scanner that surfaces installed Steam games (and
+optionally non-Steam shortcuts) in the Moonlight app list. They appear in the Steam Library Integration
+section of the settings UI.
+
+### steam_auto_sync
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            Scan the local Steam install for every installed game and surface them in the Moonlight app
+            list under a dedicated Steam Games section. The scan is read-only and runs every 30 seconds in
+            the background so newly-installed games appear automatically. Generated entries live in a
+            separate steam_apps.json file so they cannot corrupt the hand-curated apps.json. Each game
+            launches via the steam://rungameid/&lt;appid&gt; URL protocol.
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}false@endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}steam_auto_sync = true@endcode</td>
+    </tr>
+</table>
+
+### steam_include_family_shared
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            When auto-sync is on, also list games available via Steam Family Sharing in addition to games
+            owned outright. Family-shared games are detected from each game's appmanifest (a non-empty
+            SharedDepots block) and launch identically to owned games.
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}true@endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}steam_include_family_shared = false@endcode</td>
+    </tr>
+</table>
+
+### nonsteam_shortcuts_auto_sync
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            Also scan every Steam user's "Add a Non-Steam Game" shortcuts (kept in each user's
+            shortcuts.vdf) and surface them in Moonlight after the Steam Games section. Each shortcut
+            launches via its stored Exe path with the StartDir as the working directory and any
+            LaunchOptions appended. Generated entries live in a separate nonsg_apps.json file.
+            Independent of the main Steam auto-sync toggle.
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}false@endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}nonsteam_shortcuts_auto_sync = true@endcode</td>
     </tr>
 </table>
 

--- a/src_assets/common/assets/web/configs/tabs/Capture.vue
+++ b/src_assets/common/assets/web/configs/tabs/Capture.vue
@@ -451,7 +451,7 @@ const shouldShowSoftware = computed(() => showAll() || props.currentTab === 'sw'
             <ConfigSwitchField
               id="lossless_scaling_legacy_auto_detect"
               v-model="losslessLegacyAutoDetect"
-              :label="$t('config.lossless_scaling_legacy_auto_detect_label')"
+              :label="$t('config.lossless_scaling_legacy_auto_detect')"
               :desc="$t('config.lossless_scaling_legacy_auto_detect_desc')"
               class="flex-1"
               size="small"

--- a/src_assets/common/assets/web/public/assets/locale/cs.json
+++ b/src_assets/common/assets/web/public/assets/locale/cs.json
@@ -555,7 +555,7 @@
     "frame_limiter_enable": "Povolit omezovač rámce",
     "frame_limiter_provider": "Poskytovatel omezovače rámců",
     "lossless_scaling_path": "Spustitelný soubor Lossless Scaling",
-    "lossless_scaling_legacy_auto_detect_label": "Použijte starší bezeztrátovou automatickou detekci",
+    "lossless_scaling_legacy_auto_detect": "Použijte starší bezeztrátovou automatickou detekci",
     "lossless_scaling_legacy_auto_detect_desc": "Místo klávesové zkratky Lossless Scaling používá tok automatického použití založený na časovači. Nedoporučuje se, pokud metoda klávesových zkratek selže, protože detekce může být méně spolehlivá.",
     "rtss_frame_limit_type": "Typ limitu rámce RTSS",
     "rtss_install_path": "instalační cesta RTSS",

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -605,7 +605,7 @@
     "frame_limiter_enable": "Enable frame limiter",
     "frame_limiter_provider": "Frame limiter provider",
     "lossless_scaling_path": "Lossless Scaling executable",
-    "lossless_scaling_legacy_auto_detect_label": "Use legacy Lossless auto-detection",
+    "lossless_scaling_legacy_auto_detect": "Use legacy Lossless auto-detection",
     "lossless_scaling_legacy_auto_detect_desc": "Uses a timer-based auto-apply flow instead of the Lossless Scaling hotkey. Not recommended unless the hotkey method fails, because detection can be less reliable.",
     "rtss_frame_limit_type": "RTSS frame limit type",
     "rtss_install_path": "RTSS install path",

--- a/src_assets/common/assets/web/public/assets/locale/en_GB.json
+++ b/src_assets/common/assets/web/public/assets/locale/en_GB.json
@@ -156,7 +156,7 @@
     "capture_wgc_auto": "Windows Graphics Capture (variable)",
     "capture_ddx_legacy": "Desktop Duplication API (legacy)",
     "capture_autodetect_legacy": "Automatic (legacy fallback)",
-    "lossless_scaling_legacy_auto_detect_label": "Use legacy Lossless auto-detection",
+    "lossless_scaling_legacy_auto_detect": "Use legacy Lossless auto-detection",
     "lossless_scaling_legacy_auto_detect_desc": "Uses a timer-based auto-apply flow instead of the Lossless Scaling hotkey. Not recommended unless the hotkey method fails, because detection can be less reliable.",
     "cert": "Certificate",
     "cert_desc": "The certificate used for the web UI and Moonlight client pairing. For best compatibility, this should have an RSA-2048 public key.",

--- a/src_assets/common/assets/web/public/assets/locale/en_US.json
+++ b/src_assets/common/assets/web/public/assets/locale/en_US.json
@@ -156,7 +156,7 @@
     "capture_wgc_auto": "Windows Graphics Capture (variable)",
     "capture_ddx_legacy": "Desktop Duplication API (legacy)",
     "capture_autodetect_legacy": "Automatic (legacy fallback)",
-    "lossless_scaling_legacy_auto_detect_label": "Use legacy Lossless auto-detection",
+    "lossless_scaling_legacy_auto_detect": "Use legacy Lossless auto-detection",
     "lossless_scaling_legacy_auto_detect_desc": "Uses a timer-based auto-apply flow instead of the Lossless Scaling hotkey. Not recommended unless the hotkey method fails, because detection can be less reliable.",
     "cert": "Certificate",
     "cert_desc": "The certificate used for the web UI and Moonlight client pairing. For best compatibility, this should have an RSA-2048 public key.",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,7 @@ set(INTEGRATION_TEST_FILES
     "docs/configuration.md"
     "src_assets/common/assets/web/public/assets/locale/en.json"
     "src_assets/common/assets/web/configs/tabs/General.vue"
+    "src_assets/common/assets/web/stores/config.ts"
     "src_assets/linux/misc/60-sunshine.rules"
 )
 

--- a/tests/integration/test_config_consistency.cpp
+++ b/tests/integration/test_config_consistency.cpp
@@ -40,6 +40,7 @@ protected:
       {"VideoToolbox Encoder", "vt"},
       {"VA-API Encoder", "vaapi"},
       {"Software Encoder", "sw"},
+      {"Steam Library Integration", "steamlibrary"},
       {"Playnite Integration", "playnite"}
     };
   }
@@ -652,7 +653,9 @@ TEST_F(ConfigConsistencyTest, AllConfigOptionsExistInAllFiles) {
   // Options that are internal/special and shouldn't be in UI/docs
   const std::set<std::string, std::less<>> internalOptions = {
     "flags",  // Internal config flags, not user-configurable
-    "rtss_disable_vsync_ullm"  // Legacy alias for frame_limiter_disable_vsync
+    "rtss_disable_vsync_ullm",  // Legacy alias for frame_limiter_disable_vsync
+    "dd_wa_hdr_toggle",  // Legacy HDR workaround, parsed only to consume the key
+    "dd_wa_hdr_toggle_delay"  // Legacy HDR workaround, parsed only to consume the key
   };
 
   std::vector<std::string> missingFromFiles;


### PR DESCRIPTION
## Problem

`test_config_consistency.cpp` falls back to reading `src_assets/common/assets/web/stores/config.ts` (`defaultGroups`) because `config.html` no longer exists in the Vue SPA fork — but `INTEGRATION_TEST_FILES` in `tests/CMakeLists.txt` never copied that file into the build dir. In CI, `extractConfigHtmlOptions` therefore returned an empty map, `AllConfigOptionsExistInAllFiles` flagged every single option as missing, and the whole suite failed inside the advisory (`continue-on-error: true`) test step. Net effect: the suite gated nothing, and real config drift accumulated unnoticed.

## Fixes

**Make the suite see the store** — add `stores/config.ts` to `INTEGRATION_TEST_FILES`.

**Fix the real drift the working suite then surfaced:**
- `docs/configuration.md` was missing entries for `dd_paused_virtual_display_timeout_secs`, `amd_split_encode`, `lossless_scaling_legacy_auto_detect`, `session_monitor`, `tpm_binding`, and the entire Steam Library Integration section (`steam_auto_sync`, `steam_include_family_shared`, `nonsteam_shortcuts_auto_sync`) — all added, in UI order so the order-consistency test stays green.
- NVENC docs listed `nvenc_vbv_increase` before `nvenc_split_encode`; the UI has them the other way — docs reordered to match.
- `en.json` had `lossless_scaling_legacy_auto_detect_label` where every other option uses the bare option name as the label key — renamed in `en`, `en_GB`, `en_US`, `cs` and the `Capture.vue` reference.

**Test updates for legitimate fork realities:**
- Map the `steamlibrary` UI tab to the new "Steam Library Integration" doc section.
- Treat `dd_wa_hdr_toggle` / `dd_wa_hdr_toggle_delay` as internal: `config.cpp` parses them only to consume the keys of the removed legacy HDR workaround (same treatment as `rtss_disable_vsync_ullm`).

**Gate CI on the suite** — new "Config consistency gate" step in `ci-windows.yml` running `--gtest_filter=ConfigConsistencyTest.*` without `continue-on-error`. Unlike the environment-sensitive display/Playnite/network tests that keep the full run advisory, this suite only parses repo files copied at configure time, so it is deterministic on the runner. The full advisory run and its `test_results.xml` artifact are unchanged.

## Verification

Ran locally from `build/tests` (same working directory as CI): all 5 `ConfigConsistencyTest` tests pass. Pre-existing `LocaleConsistencyTest` failures (General.vue locale listing) are untouched by this PR and remain advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)