### PR TITLE
fix: refuse ring capture for a never-activated virtual display

### DIFF
--- a/src/platform/windows/virtual_display_vgd.cpp
+++ b/src/platform/windows/virtual_display_vgd.cpp
@@ -422,7 +422,32 @@ namespace VDISPLAY::vgd {
       return std::nullopt;
     }
     if (g_sessions.size() == 1) {
-      const auto &s = g_sessions.begin()->second;
+      auto &s = g_sessions.begin()->second;
+      if (s.display_name.empty()) {
+        // The monitor may have activated after create()'s bounded poll
+        // gave up (activation completes at display-APPLY time); nothing
+        // else ever backfills the tracked name, so adopt it here.
+        auto names = luminal_display_names();
+        if (names.size() == 1) {
+          s.display_name = names.front();
+        }
+      }
+      if (s.display_name.empty()) {
+        // Never hand out the ring for a monitor the OS never activated:
+        // downstream capture init would bind an arbitrary mid-modeset
+        // physical output against this ring and spin a reinit storm
+        // whose overlapping NvEnc create/destroy cycles have corrupted
+        // the NVIDIA driver heap before (0xc0000374 fail-fast). Refuse
+        // here so platf::display falls back to WGC/DDA or the session
+        // fails cleanly.
+        BOOST_LOG(warning) << "LuminalVGD: sole session 0x" << std::hex << s.session_id << std::dec
+                           << " has no active GDI display (monitor never activated); "
+                           << "refusing ring capture.";
+        return std::nullopt;
+      }
+      if (!wanted.empty() && s.display_name != wanted) {
+        return std::nullopt;
+      }
       return RingTargetInfo {s.session_id, s.ring_slots};
     }
     for (const auto &[k, s] : g_sessions) {

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1536,7 +1536,12 @@ namespace video {
       display_names = std::move(old_display_names);
       return;
 #endif
-    } else if (display_names.empty()) {
+    } else if (display_names.empty() && !output_name.empty()) {
+      // Only seed a concrete configured name. Seeding the empty string
+      // made capture init bind "whatever output enumerates first" during
+      // topology churn — the amplifier behind the never-activated-
+      // virtual-display crash. An empty list retries via the callers'
+      // existing wait loops instead.
       display_names.emplace_back(output_name);
     }
 


### PR DESCRIPTION
Task #33. A monitor the OS never activates (no GDI device name — the cold-boot failure mode) still owns a live frame ring, and the single-session shortcut handed it to capture init with no name check. Capture then bound an arbitrary mid-modeset output and spun a reinit storm whose overlapping NvEnc create/destroy cycles are the documented cause of the 0xc0000374 NVIDIA shared-heap fail-fast. The ring lookup now re-resolves a late-activated name, refuses when none exists (clean WGC/DDA fallback), and `refresh_displays` no longer seeds the empty string as a display name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)