### PR TITLE
perf: take the RTSS/NVCP ladder off the RTSP ANNOUNCE thread

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -2683,15 +2683,31 @@ namespace stream {
           defer_stream_start_actions(std::move(deferred));
           BOOST_LOG(info) << "Stream-start actions deferred until user session is ready.";
         } else {
-          platf::frame_limiter_streaming_start(
-            session.config.monitor.framerate,
-            session.config.gen1_framegen_fix,
-            session.config.gen2_framegen_fix,
-            lossless_rtss_limit,
-            session.config.frame_generation_provider,
-            using_smooth_motion
-          );
-          platf::streaming_will_start();
+          // Off the ANNOUNCE thread: the RTSS/NVCP ladder (process launch
+          // under impersonation, DRS load/set/save) plus streaming_will_start's
+          // nvprefs pass can take 3-22 s, and it used to run inline here —
+          // the RTSP 200 OK, the client's ~10 s no-video deadline, and our
+          // own recv_ping timeout (counting since the video thread spawned)
+          // all waited on it. These actions tune game pacing, not
+          // capture/encode viability — the SYSTEM-deferral path above
+          // already runs the identical pair arbitrarily late with no
+          // completion gate — so schedule them and answer the client now.
+          // The liveness recheck mirrors apply_deferred_stream_start:
+          // a session stopped before the task runs must not re-apply
+          // overrides whose teardown-side restore may already be running.
+          task_pool.push([fps = session.config.monitor.framerate,
+                          gen1 = session.config.gen1_framegen_fix,
+                          gen2 = session.config.gen2_framegen_fix,
+                          lossless_rtss_limit,
+                          provider = session.config.frame_generation_provider,
+                          using_smooth_motion]() {
+            if (session::active_sessions.load(std::memory_order_acquire) == 0) {
+              BOOST_LOG(info) << "Skipping stream-start platform actions; session already stopped.";
+              return;
+            }
+            platf::frame_limiter_streaming_start(fps, gen1, gen2, lossless_rtss_limit, provider, using_smooth_motion);
+            platf::streaming_will_start();
+          });
         }
 #else
         platf::streaming_will_start();


### PR DESCRIPTION
Task #32 (first-frame latency, part 1). The first-session RTSS/NVCP ladder (3-22 s worst case) ran inline in the ANNOUNCE handler — the RTSP 200 OK waited on it, the client's ~10 s no-video deadline burned, and our own recv_ping timeout could expire and kill the session. Scheduled on task_pool with a liveness recheck (mirroring the SYSTEM-deferral path, which has always run the same pair late with no completion gate). NvEnc pre-warm on probe-cache-skip is a tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)