### PR TITLE
feat: Session Details v2 — identity panel, range selector, pills, stats variant

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -2113,7 +2113,26 @@ namespace confighttp {
       return;
     }
     const std::string id = request->path_match[1];
-    forward_session_mon_response(response, session_mon::proxy::get("/api/sessions/" + id));
+    // Forward only the whitelisted numeric range params (from/to = epoch
+    // seconds, step = bucket seconds) so the panel's range selector can
+    // fetch a decimated window instead of re-downloading the full ring
+    // on every poll. Anything else in the query is dropped.
+    std::string upstream = "/api/sessions/" + id;
+    char sep = '?';
+    const auto query = request->parse_query_string();
+    for (const char *key : {"from", "to", "step"}) {
+      const auto it = query.find(key);
+      if (it == query.end() || it->second.empty() ||
+          it->second.find_first_not_of("0123456789") != std::string::npos) {
+        continue;
+      }
+      upstream += sep;
+      upstream += key;
+      upstream += '=';
+      upstream += it->second;
+      sep = '&';
+    }
+    forward_session_mon_response(response, session_mon::proxy::get(upstream));
   }
 
   /// GET /api/sessions/<id>/export.json — same content as
@@ -2435,6 +2454,30 @@ namespace confighttp {
       output_tree["virtual_display_driver_status"] = static_cast<int>(proc::vDisplayDriverStatus);
       output_tree["virtual_display_driver_ready"] =
         proc::vDisplayDriverStatus == VDISPLAY::DRIVER_STATUS::OK;
+      // Host identity for the Session Details panel: the LuminalShine
+      // host name (the configured sunshine_name, falling back to the
+      // machine hostname — same resolution nvhttp advertises), CPU
+      // model, total RAM, and aggregate dedicated VRAM (summed over
+      // hardware adapters — same denominator the session monitor's
+      // VRAM series uses).
+      output_tree["host_name"] = config::nvhttp.sunshine_name.empty() ?
+                                   platf::get_host_name() :
+                                   config::nvhttp.sunshine_name;
+      if (auto cpu = platf::cpu_model(); !cpu.empty()) {
+        output_tree["cpu_model"] = cpu;
+      }
+      if (const auto total_ram = platf::total_physical_memory_bytes(); total_ram > 0) {
+        output_tree["total_physical_memory"] = total_ram;
+      }
+      {
+        std::uint64_t total_vram = 0;
+        for (const auto &gpu : platf::enumerate_gpus()) {
+          total_vram += gpu.dedicated_video_memory;
+        }
+        if (total_vram > 0) {
+          output_tree["total_dedicated_vram"] = total_vram;
+        }
+      }
       const auto vdd_info = platf::diag::query_virtual_display_driver_info();
       if (vdd_info.version) {
         output_tree["virtual_display_backend_version"] = *vdd_info.version;

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -2305,6 +2305,49 @@ namespace platf {
     return result;
   }
 
+  std::string cpu_model() {
+    HKEY key = nullptr;
+    if (RegOpenKeyExW(
+          HKEY_LOCAL_MACHINE,
+          L"HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0",
+          0,
+          KEY_READ,
+          &key)
+        != ERROR_SUCCESS) {
+      return {};
+    }
+    wchar_t buf[256] {};
+    DWORD size = sizeof(buf) - sizeof(wchar_t);
+    DWORD type = 0;
+    std::string out;
+    if (RegQueryValueExW(
+          key,
+          L"ProcessorNameString",
+          nullptr,
+          &type,
+          reinterpret_cast<LPBYTE>(buf),
+          &size)
+          == ERROR_SUCCESS &&
+        type == REG_SZ) {
+      out = to_utf8(buf);
+      // Some firmware pads the marketing name with spaces.
+      const auto first = out.find_first_not_of(' ');
+      const auto last = out.find_last_not_of(' ');
+      out = (first == std::string::npos) ? std::string {} : out.substr(first, last - first + 1);
+    }
+    RegCloseKey(key);
+    return out;
+  }
+
+  std::uint64_t total_physical_memory_bytes() {
+    MEMORYSTATUSEX status {};
+    status.dwLength = sizeof(status);
+    if (!GlobalMemoryStatusEx(&status)) {
+      return 0;
+    }
+    return status.ullTotalPhys;
+  }
+
   bool has_nvidia_gpu() {
     constexpr std::uint32_t NVIDIA_VENDOR_ID = 0x10DE;
     for (const auto &gpu : enumerate_gpus()) {

--- a/src/platform/windows/misc.h
+++ b/src/platform/windows/misc.h
@@ -188,4 +188,15 @@ namespace platf {
   std::vector<gpu_info_t> enumerate_gpus();
   bool has_nvidia_gpu();
   windows_version_info_t query_windows_version();
+
+  /**
+   * @brief Marketing name of the CPU (registry ProcessorNameString),
+   *        trimmed; empty string when the query fails.
+   */
+  std::string cpu_model();
+
+  /**
+   * @brief Total physical RAM in bytes (GlobalMemoryStatusEx); 0 on failure.
+   */
+  std::uint64_t total_physical_memory_bytes();
 }  // namespace platf

--- a/src/session_monitor_client.cpp
+++ b/src/session_monitor_client.cpp
@@ -531,6 +531,7 @@ namespace session_mon {
     nlohmann::json m;
     m["client_name"]            = md.client_name;
     m["device"]                 = md.device;
+    m["client_uuid"]            = md.client_uuid;
     m["protocol"]               = md.protocol;
     m["codec"]                  = md.codec;
     m["resolution_w"]           = md.width;

--- a/src/session_monitor_client.h
+++ b/src/session_monitor_client.h
@@ -49,6 +49,7 @@ namespace session_mon {
   struct SessionMetadata {
     std::string  client_name;
     std::string  device;
+    std::string  client_uuid;  ///< Pairing UUID — lets the UI target /api/clients/disconnect.
     std::string  protocol;   ///< "RTSP", "RTP", "WebRTC"
     std::string  codec;      ///< "HEVC", "AV1", "H264"
     int          width                  = 0;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -2805,7 +2805,12 @@ namespace stream {
       if (config::stream.session_monitor) {
         session_mon::SessionMetadata md;
         md.client_name = launch_session.client_name;
-        md.device      = launch_session.client_name;   // best available — RTSP doesn't carry a separate "device" string
+        // Moonlight supplies a device string at launch; older clients
+        // send only the client name.
+        md.device      = launch_session.device_name.empty() ?
+                           launch_session.client_name :
+                           launch_session.device_name;
+        md.client_uuid = launch_session.client_uuid;
         md.protocol    = "RTSP";
         const int video_format = config.monitor.videoFormat;
         md.codec       = (video_format == 0) ? "H264" : (video_format == 1) ? "HEVC" : (video_format == 2) ? "AV1" : "?";
@@ -2817,9 +2822,19 @@ namespace stream {
         md.yuv444               = (config.monitor.chromaSamplingType == 1);
         md.audio_channels       = config.audio.channels;
         md.luminalshine_version = PROJECT_VERSION;
-        // application / cpu_model / gpu_model can come in later as
-        // metadata_update frames once the proc layer / platform
-        // helpers have resolved them.
+        if (launch_session.app_metadata) {
+          md.application = launch_session.app_metadata->name;
+        }
+#ifdef _WIN32
+        md.cpu_model = platf::cpu_model();
+        // The adapter the stream encodes on when pinned in config;
+        // otherwise the first hardware adapter.
+        if (!config::video.adapter_name.empty()) {
+          md.gpu_model = config::video.adapter_name;
+        } else if (const auto gpus = platf::enumerate_gpus(); !gpus.empty()) {
+          md.gpu_model = gpus.front().description;
+        }
+#endif
         session_mon::session_started(
           session_mon::make_id(launch_session.id),
           md

--- a/src_assets/common/assets/web/components/SessionDetailsPanel.vue
+++ b/src_assets/common/assets/web/components/SessionDetailsPanel.vue
@@ -26,6 +26,7 @@ import uPlot, { type Options as UPlotOptions, type AlignedData } from 'uplot';
 import 'uplot/dist/uPlot.min.css';
 import { http } from '@/http';
 import { useAuthStore } from '@/stores/auth';
+import { useConfigStore } from '@/stores/config';
 
 type Series = number[];
 interface SessionPayload {
@@ -35,6 +36,7 @@ interface SessionPayload {
   metadata: {
     client_name?: string;
     device?: string;
+    client_uuid?: string;
     protocol?: string;
     codec?: string;
     resolution_w?: number;
@@ -54,7 +56,7 @@ interface SessionPayload {
   series: Record<string, Array<[number, number]>>;
 }
 
-const props = defineProps<{ show: boolean; sessionId: string | null }>();
+const props = defineProps<{ show: boolean; sessionId: string | null; fullWidth?: boolean }>();
 const emit = defineEmits<{
   (e: 'update:show', v: boolean): void;
   (e: 'session-deleted', id: string): void;
@@ -64,6 +66,43 @@ const dialog = useDialog();
 const message = useMessage();
 const auth = useAuthStore();
 const isStatsOnly = computed(() => auth.isStatsOnly());
+
+// Host-level identity (host name, CPU/RAM/VRAM, LuminalVGD driver,
+// LuminalShine version) comes from /api/metadata — allowlisted for the
+// stats role, so the Overview tab renders fully in Session View Only.
+const configStore = useConfigStore();
+onMounted(() => {
+  void configStore.fetchMetadata();
+});
+const hostMeta = computed(() => (configStore.metadata ?? {}) as Record<string, unknown>);
+
+// ----- Range selector ------------------------------------------------------
+// 'Full Session' serves the whole ring, decimated server-side to ≤ ~900
+// mean-buckets; the minute windows fetch the trailing window at full
+// 1 Hz fidelity (anchored to the end timestamp for ended sessions).
+type RangeKey = 'full' | '3m' | '5m' | '15m';
+const RANGES: { key: RangeKey; label: string; seconds: number | null }[] = [
+  { key: 'full', label: 'Full Session', seconds: null },
+  { key: '3m', label: '3 min', seconds: 180 },
+  { key: '5m', label: '5 min', seconds: 300 },
+  { key: '15m', label: '15 min', seconds: 900 },
+];
+const range = ref<RangeKey>('full');
+
+function rangeQuery(): string {
+  const spec = RANGES.find((r) => r.key === range.value);
+  if (!spec) return '';
+  const end = session.value?.stream_ended_at ?? Math.floor(Date.now() / 1000);
+  if (spec.seconds == null) {
+    const s = session.value;
+    if (!s) return ''; // first load: full fidelity; poll refines with a step
+    const dur = Math.max(1, end - s.started_at);
+    const step = Math.max(1, Math.ceil(dur / 900));
+    return step > 1 ? `?step=${step}` : '';
+  }
+  const from = Math.max(0, end - spec.seconds);
+  return `?from=${from}&to=${end}`;
+}
 
 const session = ref<SessionPayload | null>(null);
 const loading = ref(false);
@@ -79,19 +118,85 @@ const headerLine = computed(() => {
   return `${app} · ${client}`;
 });
 
+// Health classification over the trailing minute of connection events:
+// sustained client loss (>1/s average) or heavy IDR recovery (>0.2/s)
+// reads as a struggling stream. Null until any connection series has
+// data, so the pill never guesses.
+const streamHealth = computed<'healthy' | 'poor' | null>(() => {
+  const s = session.value;
+  if (!s) return null;
+  const rate = (key: string): number | null => {
+    const pts = s.series?.[key];
+    if (!pts || pts.length === 0) return null;
+    const tail = pts.slice(-60);
+    let sum = 0;
+    for (const [, v] of tail) sum += v;
+    return sum / tail.length;
+  };
+  const losses = rate('client_losses');
+  const idr = rate('idr_requests');
+  if (losses == null && idr == null) return null;
+  return (losses ?? 0) > 1 || (idr ?? 0) > 0.2 ? 'poor' : 'healthy';
+});
+
 const chips = computed(() => {
   const m = session.value?.metadata ?? {};
-  const out: { label: string; tone: 'info' | 'primary' | 'success' | 'warning' | 'default' }[] = [];
+  const out: {
+    label: string;
+    tone: 'info' | 'primary' | 'success' | 'warning' | 'error' | 'default';
+  }[] = [];
   if (m.protocol) out.push({ label: m.protocol, tone: 'info' });
   if (m.codec) out.push({ label: m.codec, tone: 'primary' });
   if (m.resolution_w && m.resolution_h) {
     const fps = m.fps ? `@${m.fps}` : '';
     out.push({ label: `${m.resolution_w}×${m.resolution_h}${fps}`, tone: 'default' });
   }
-  if (m.hdr) out.push({ label: 'HDR', tone: 'warning' });
+  if (m.hdr) out.push({ label: 'HDR10', tone: 'warning' });
   if (m.yuv444 === true || m.yuv444 === 'true') out.push({ label: 'YUV444', tone: 'success' });
+  if (streamHealth.value === 'healthy') out.push({ label: 'Healthy Stream', tone: 'success' });
+  if (streamHealth.value === 'poor') out.push({ label: 'Poor Stream', tone: 'error' });
   if (m.audio_channels) out.push({ label: `${m.audio_channels}ch`, tone: 'default' });
   return out;
+});
+
+// ----- Identity panel (Overview tab) ---------------------------------------
+function gib(bytes: unknown): string {
+  const n = Number(bytes);
+  if (!Number.isFinite(n) || n <= 0) return '—';
+  return (n / 1024 ** 3).toFixed(0) + ' GB';
+}
+
+const identityRows = computed(() => {
+  const m = session.value?.metadata ?? {};
+  const h = hostMeta.value;
+  const res =
+    m.resolution_w && m.resolution_h
+      ? `${m.resolution_w}×${m.resolution_h}` + (m.fps ? ` @ ${m.fps}` : '')
+      : '—';
+  const vgd =
+    [h['virtual_display_backend_version'], h['vgd_handshake']].filter(Boolean).join(' · ') || '—';
+  return [
+    { label: 'Host Name', value: (h['host_name'] as string) || '—' },
+    { label: 'Device Name', value: m.device || m.client_name || '—' },
+    { label: 'Stream Resolution', value: res },
+    { label: 'Direct-to-Encode Mode', value: m.codec || '—' },
+    {
+      label: 'Bitrate Encode',
+      value: avgBitrate.value != null ? `${avgBitrate.value.toFixed(1)} Mbps` : '—',
+    },
+    // Moonlight has no upstream decode-stats channel; shown for parity
+    // with the encode figure until a protocol extension lands.
+    { label: 'Bitrate Decode', value: '—' },
+    { label: 'Stream Duration', value: durationText.value || '—' },
+    { label: 'Running App', value: m.application || '—' },
+    { label: 'Audio Channels', value: m.audio_channels ? `${m.audio_channels}` : '—' },
+    { label: 'CPU Model', value: m.cpu_model || (h['cpu_model'] as string) || '—' },
+    { label: 'GPU Model', value: m.gpu_model || '—' },
+    { label: 'RAM', value: gib(h['total_physical_memory']) },
+    { label: 'VRAM', value: gib(h['total_dedicated_vram']) },
+    { label: 'LuminalVGD Driver', value: vgd },
+    { label: 'LuminalShine', value: m.luminalshine_version || '—' },
+  ];
 });
 
 const durationText = computed(() => {
@@ -121,9 +226,10 @@ async function loadSession() {
   loading.value = true;
   errorText.value = '';
   try {
-    const r = await http.get(`./api/sessions/${encodeURIComponent(props.sessionId)}`, {
-      validateStatus: () => true,
-    });
+    const r = await http.get(
+      `./api/sessions/${encodeURIComponent(props.sessionId)}${rangeQuery()}`,
+      { validateStatus: () => true },
+    );
     if (r.status === 503) {
       errorText.value = 'Session monitor service is offline.';
       session.value = null;
@@ -176,6 +282,14 @@ watch(
     }
   },
 );
+
+watch(range, () => {
+  // Re-fetch the new window immediately; ended sessions don't poll, so
+  // a one-shot reload is the only way their charts pick up the range.
+  if (props.show && props.sessionId) {
+    void loadSession();
+  }
+});
 
 onBeforeUnmount(() => {
   stopPolling();
@@ -403,7 +517,10 @@ async function disconnectSession() {
     negativeText: 'Cancel',
     onPositiveClick: async () => {
       const m = session.value!.metadata ?? {};
-      const clientUuid = (m.device || m.client_name || '').trim();
+      // client_uuid is the pairing UUID the disconnect endpoint expects;
+      // device/client_name are display strings kept only as a fallback
+      // for sessions recorded before the uuid landed in the metadata.
+      const clientUuid = (m.client_uuid || m.device || m.client_name || '').trim();
       try {
         const r = await http.post(
           './api/clients/disconnect',
@@ -469,7 +586,7 @@ function close() {
 <template>
   <NDrawer
     :show="show"
-    :width="640"
+    :width="fullWidth ? '100%' : 640"
     placement="right"
     :auto-focus="false"
     :close-on-esc="true"
@@ -556,12 +673,45 @@ function close() {
             </div>
           </div>
         </div>
+
+        <!-- Chart range selector -->
+        <div class="flex items-center gap-1 mt-3" role="group" aria-label="Chart time range">
+          <button
+            v-for="r in RANGES"
+            :key="r.key"
+            type="button"
+            class="px-2 py-0.5 rounded-md text-[11px] font-semibold border transition-colors"
+            :class="
+              range === r.key
+                ? 'bg-primary/20 text-primary border-primary/40'
+                : 'bg-light/5 text-light/60 border-light/10 hover:text-light/90'
+            "
+            @click="range = r.key"
+          >
+            {{ r.label }}
+          </button>
+        </div>
       </header>
 
       <!-- Body -->
       <div v-if="loading && !session" class="py-8 text-center opacity-60">Loading…</div>
       <div v-else-if="errorText" class="py-8 text-center text-danger">{{ errorText }}</div>
       <NTabs v-else-if="session" type="line" animated class="mt-2">
+        <NTabPane name="overview" tab="Overview">
+          <div
+            class="grid grid-cols-2 gap-x-6 gap-y-2 rounded-lg p-4 bg-light/5 dark:bg-dark/30
+                   border border-light/10 text-sm"
+          >
+            <template v-for="row in identityRows" :key="row.label">
+              <div class="text-[11px] uppercase tracking-wider opacity-60 self-center">
+                {{ row.label }}
+              </div>
+              <div class="font-mono text-xs self-center truncate" :title="String(row.value)">
+                {{ row.value }}
+              </div>
+            </template>
+          </div>
+        </NTabPane>
         <NTabPane name="stream" tab="Stream">
           <div class="space-y-4">
             <div v-for="spec in STREAM_CHARTS" :key="spec.id" class="chart-card">

--- a/src_assets/common/assets/web/components/SessionHistoryCard.vue
+++ b/src_assets/common/assets/web/components/SessionHistoryCard.vue
@@ -31,12 +31,35 @@ interface Summary {
   };
 }
 
+const props = defineProps<{
+  /// Cap on ENDED sessions shown (active sessions always render).
+  /// The Dashboard shows 5; the stats-only view shows 10; omit for all.
+  historyLimit?: number;
+  /// Open the details panel as a full-viewport slideout (stats view).
+  fullWidthPanel?: boolean;
+}>();
+
 const sessions = ref<Summary[]>([]);
 const loading = ref(false);
 const monitorOffline = ref(false);
 
 const panelShow = ref(false);
 const panelSessionId = ref<string | null>(null);
+
+const displayedSessions = computed(() => {
+  if (props.historyLimit == null) return sessions.value;
+  const out: Summary[] = [];
+  let ended = 0;
+  for (const s of sessions.value) {
+    if (s.stream_ended_at == null) {
+      out.push(s);
+    } else if (ended < props.historyLimit) {
+      out.push(s);
+      ended++;
+    }
+  }
+  return out;
+});
 
 let pollTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -150,7 +173,7 @@ function rowSubLabel(s: Summary): string {
     <NSpin v-else-if="loading && sessions.length === 0" />
     <ul v-else class="divide-y divide-light/5 dark:divide-dark/30">
       <li
-        v-for="s in sessions"
+        v-for="s in displayedSessions"
         :key="s.id"
         class="py-2.5 flex items-center gap-3 hover:bg-light/5 dark:hover:bg-dark/30
                rounded-md px-2 -mx-2 cursor-pointer transition-colors"
@@ -181,6 +204,7 @@ function rowSubLabel(s: Summary): string {
     <SessionDetailsPanel
       v-model:show="panelShow"
       :session-id="panelSessionId"
+      :full-width="fullWidthPanel"
       @session-deleted="onPanelDeleted"
     />
   </NCard>

--- a/src_assets/common/assets/web/stores/config.ts
+++ b/src_assets/common/assets/web/stores/config.ts
@@ -57,6 +57,10 @@ export interface MetaInfo {
     av1_yuv444?: boolean;
     ref_frames_invalidation?: boolean;
   };
+  host_name?: string;
+  cpu_model?: string;
+  total_physical_memory?: number;
+  total_dedicated_vram?: number;
   virtual_display_backend?: string;
   virtual_display_backend_version?: string;
   virtual_display_driver_status?: number | string;

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -479,7 +479,9 @@
            LuminalShineSessionMonitor sidecar service via the
            main service's /api/sessions proxy. -->
       <div class="min-w-0">
-        <SessionHistoryCard />
+        <!-- Active sessions always show; historical entries cap at 5 —
+             the stats-only view carries the longer list. -->
+        <SessionHistoryCard :history-limit="5" />
       </div>
 
       <!-- Resources -->

--- a/src_assets/common/assets/web/views/StatsView.vue
+++ b/src_assets/common/assets/web/views/StatsView.vue
@@ -10,7 +10,9 @@
         </p>
       </div>
     </div>
-    <SessionHistoryCard />
+    <!-- Session View Only: the last 10 sessions, details opening as a
+         full-viewport slideout. -->
+    <SessionHistoryCard :history-limit="10" full-width-panel />
   </div>
 </template>
 

--- a/tools/luminalshine_sessionmon.cpp
+++ b/tools/luminalshine_sessionmon.cpp
@@ -225,12 +225,48 @@ namespace {
       }
     }
 
-    nlohmann::json to_json() const {
+    /// Serialize, optionally windowed to [from, to] (epoch seconds;
+    /// 0 = unbounded) and decimated to `step`-second buckets
+    /// (arithmetic mean per bucket, stamped with the bucket start).
+    /// Points are appended in time order, so the window is a
+    /// contiguous span.
+    nlohmann::json to_json(std::int64_t from, std::int64_t to, std::int64_t step) const {
       nlohmann::json out = nlohmann::json::array();
+      if (step < 1) {
+        step = 1;
+      }
+      std::int64_t bucket_start = 0;
+      double sum = 0.0;
+      int count = 0;
       for (const auto &p : points) {
-        out.push_back({p.ts, p.value});
+        if (from != 0 && p.ts < from) {
+          continue;
+        }
+        if (to != 0 && p.ts > to) {
+          break;
+        }
+        if (step == 1) {
+          out.push_back({p.ts, p.value});
+          continue;
+        }
+        const std::int64_t bucket = p.ts - (p.ts % step);
+        if (count > 0 && bucket != bucket_start) {
+          out.push_back({bucket_start, sum / count});
+          sum = 0.0;
+          count = 0;
+        }
+        bucket_start = bucket;
+        sum += p.value;
+        ++count;
+      }
+      if (count > 0) {
+        out.push_back({bucket_start, sum / count});
       }
       return out;
+    }
+
+    nlohmann::json to_json() const {
+      return to_json(0, 0, 1);
     }
   };
 
@@ -247,7 +283,7 @@ namespace {
     std::chrono::steady_clock::time_point last_flush  = std::chrono::steady_clock::now();
     std::map<std::string, Series>     series;
 
-    nlohmann::json to_json() const {
+    nlohmann::json to_json(std::int64_t from, std::int64_t to, std::int64_t step) const {
       nlohmann::json out;
       out["id"] = id;
       out["started_at"] = started_at_epoch;
@@ -259,10 +295,14 @@ namespace {
       out["metadata"] = metadata;
       nlohmann::json s = nlohmann::json::object();
       for (const auto &[name, series] : series) {
-        s[name] = series.to_json();
+        s[name] = series.to_json(from, to, step);
       }
       out["series"] = std::move(s);
       return out;
+    }
+
+    nlohmann::json to_json() const {
+      return to_json(0, 0, 1);
     }
   };
 
@@ -562,13 +602,60 @@ namespace {
     return http_response(200, "application/json", arr.dump());
   }
 
-  std::string handle_get_session(const std::string &id, bool as_attachment) {
+  /// Range parameters parsed off a query string. All optional;
+  /// zero/one means "full fidelity" (backwards compatible).
+  struct RangeParams {
+    std::int64_t from = 0;
+    std::int64_t to = 0;
+    std::int64_t step = 1;
+  };
+
+  RangeParams parse_range_params(std::string_view query) {
+    RangeParams out;
+    size_t pos = 0;
+    while (pos < query.size()) {
+      auto amp = query.find('&', pos);
+      if (amp == std::string_view::npos) {
+        amp = query.size();
+      }
+      const auto pair = query.substr(pos, amp - pos);
+      pos = amp + 1;
+      const auto eq = pair.find('=');
+      if (eq == std::string_view::npos) {
+        continue;
+      }
+      const auto key = pair.substr(0, eq);
+      std::int64_t value = 0;
+      bool numeric = eq + 1 < pair.size();
+      for (size_t i = eq + 1; i < pair.size(); ++i) {
+        const char c = pair[i];
+        if (c < '0' || c > '9') {
+          numeric = false;
+          break;
+        }
+        value = value * 10 + (c - '0');
+      }
+      if (!numeric) {
+        continue;  // malformed values are ignored, not errors
+      }
+      if (key == "from") {
+        out.from = value;
+      } else if (key == "to") {
+        out.to = value;
+      } else if (key == "step") {
+        out.step = value;
+      }
+    }
+    return out;
+  }
+
+  std::string handle_get_session(const std::string &id, bool as_attachment, const RangeParams &range = {}) {
     std::lock_guard<std::mutex> guard(g_store.mtx);
     auto it = g_store.sessions.find(id);
     if (it == g_store.sessions.end()) {
       return http_response(404, "application/json", "{\"error\":\"not found\"}");
     }
-    auto body = it->second.to_json().dump(2);
+    auto body = it->second.to_json(range.from, range.to, range.step).dump(2);
     std::string extra;
     if (as_attachment) {
       extra = "Content-Disposition: attachment; filename=\"luminalshine-session-" + id + ".json\"\r\n";
@@ -600,6 +687,15 @@ namespace {
   std::string route_request(std::string_view method, std::string_view path) {
     // Hand-rolled router — only a handful of routes so the
     // alternatives (regex / a routing library) would be overkill.
+    // Split any query string off the target first; range params apply
+    // to the session-detail GET only. Export always serves the full-
+    // fidelity ring — a downloaded archive must not be silently
+    // decimated by whatever range the panel happened to be viewing.
+    std::string_view query;
+    if (const auto q = path.find('?'); q != std::string_view::npos) {
+      query = path.substr(q + 1);
+      path = path.substr(0, q);
+    }
     if (method == "GET" && path == "/api/sessions") {
       return handle_list_sessions();
     }
@@ -615,7 +711,7 @@ namespace {
           rest.resize(rest.size() - export_suffix.size());
           return handle_get_session(rest, /*as_attachment=*/true);
         }
-        return handle_get_session(rest, /*as_attachment=*/false);
+        return handle_get_session(rest, /*as_attachment=*/false, parse_range_params(query));
       }
     }
     return http_response(404, "application/json", "{\"error\":\"no route\"}");


### PR DESCRIPTION
Task #41. Extends the existing SessionDetailsPanel/pipeline: 15-field Overview identity grid (host name, device, resolution, encode mode, bitrates, duration, app, audio channels, CPU/GPU/RAM/VRAM, LuminalVGD driver identity, LuminalShine version); Full/3/5/15-min range selector backed by new windowed+decimated series queries (`GET /api/sessions/<id>?from=&to=&step=`, export always full fidelity); HDR10 + Healthy/Poor Stream pills; stats-only login gets a full-viewport slideout with the last 10 sessions, Dashboard caps history at 5. Fills the always-empty metadata (application, cpu_model, gpu_model, real device name) and fixes the panel's Disconnect action (posted a display name where the API expects the pairing UUID; client_uuid now travels in session metadata). Decode bitrate renders '—' — Moonlight has no upstream decode-stats channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)