### PR TITLE
feat: TDR recovery hardening (post-0x10E field crash)

### DIFF
--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -38,6 +38,7 @@
 
 // local includes
 #include "src/config.h"
+#include "src/tdr_state.h"
 #include "src/logging.h"
 #include "src/utility.h"
 
@@ -137,6 +138,19 @@ namespace {
 }  // namespace
 
 namespace nvenc {
+
+  namespace {
+    /// Process-wide count of destroy_encoder drain timeouts that leaked
+    /// NVENC-registered resources (see the warning at the increment
+    /// site). Exposed via drain_leak_count() so session teardown can
+    /// schedule a clean host restart before the bounded registered-
+    /// resource pool (~64 on consumer cards) exhausts.
+    std::atomic<std::uint64_t> g_drain_leak_count {0};
+  }  // namespace
+
+  std::uint64_t drain_leak_count() {
+    return g_drain_leak_count.load(std::memory_order_relaxed);
+  }
 
   nvenc_base::nvenc_base(NV_ENC_DEVICE_TYPE device_type):
       device_type(device_type) {
@@ -856,7 +870,6 @@ namespace nvenc {
         // NV_ENC_ERR_OUT_OF_MEMORY on the next encoder init, which
         // would otherwise look like an unrelated "can't probe encoder"
         // failure miles away from the root cause.
-        static std::atomic<uint64_t> g_drain_leak_count {0};
         const auto leaked = g_drain_leak_count.fetch_add(1, std::memory_order_relaxed) + 1;
         BOOST_LOG(warning) << "NvEnc: destroy_encoder async drain timed out after "
                            << kDrainMs << "ms (last_frame=" << encoder_state.last_encoded_frame_index
@@ -1042,6 +1055,15 @@ namespace nvenc {
                       << ". A long since_last_encode (>200ms) typically indicates GPU TDR is in progress; "
                          "the encoder will tear down and the D3D11 retry path (D3D11CreateDeviceWithRecovery) will pick up.";
       BOOST_LOG(error) << "NvEnc: frame " << frame_index << " encode wait timeout";
+      // Record the stall as a TDR-class event immediately: this is the
+      // earliest observable symptom of a GPU hang, and downstream holders
+      // of shared GPU allocations (the LuminalVGD ring reader) key their
+      // release-before-recovery behavior off tdr::event_count().
+      tdr::mark_event(
+        tdr::source_t::encoder_stall,
+        0,
+        "NvEnc encode-wait timeout, frame=" + std::to_string(frame_index)
+      );
       // The GPU may still complete this picture's encode later and write
       // into output_bitstream / read from the registered input texture.
       // Flag so destroy_encoder knows to drain the completion event before

--- a/src/nvenc/nvenc_base.h
+++ b/src/nvenc/nvenc_base.h
@@ -201,4 +201,12 @@ namespace nvenc {
     } encoder_state;
   };
 
+  /**
+   * @brief Process-wide count of encoder-teardown drain timeouts that
+   *        leaked NVENC-registered resources. Non-zero means the bounded
+   *        per-process registration pool is shrinking; session teardown
+   *        uses this to schedule a clean host restart once idle.
+   */
+  std::uint64_t drain_leak_count();
+
 }  // namespace nvenc

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -606,6 +606,11 @@ namespace platf::dxgi {
     uint64_t _last_sequence = 0;
     std::string _display_name;
 
+    // TDR blast-radius shrink: tdr::event_count() snapshot taken at init.
+    // When it advances, snapshot() drops every shared GPU allocation this
+    // reader holds and reinitializes (see display_vgd.cpp).
+    std::uint64_t _tdr_marks_at_open = 0;
+
     // Broken-ring detection (see display_vgd.cpp): consecutive texture-open
     // failures, and how long a newer-than-delivered frame has sat unclaimed.
     int _open_failures = 0;

--- a/src/platform/windows/display_vgd.cpp
+++ b/src/platform/windows/display_vgd.cpp
@@ -36,6 +36,7 @@
 // local includes
 #include "src/logging.h"
 #include "src/platform/windows/display.h"
+#include "src/tdr_state.h"
 #include "src/platform/windows/display_vram.h"
 #include "src/platform/windows/misc.h"
 #include "src/platform/windows/virtual_display_vgd.h"
@@ -191,6 +192,7 @@ namespace platf::dxgi {
     _session_id = target->session_id;
     _ring_slots = target->ring_slots;
     _display_name = display_name;
+    _tdr_marks_at_open = tdr::event_count();
     capture_format = DXGI_FORMAT_UNKNOWN;  // latched from the first claimed frame
 
     // Hardware-cursor plane: with a cursor-capable driver (build >= 4) the
@@ -417,6 +419,23 @@ namespace platf::dxgi {
   capture_e display_vgd_vram_t::snapshot(const pull_free_image_cb_t &pull_free_image_cb, std::shared_ptr<platf::img_t> &img_out, std::chrono::milliseconds timeout, bool cursor_visible) {
     if (!_ring) {
       return capture_e::error;
+    }
+
+    // TDR blast-radius shrink: once any GPU-reset-class event is
+    // recorded (the encoder stall fires within ~100 ms of a hang), drop
+    // every shared GPU allocation this reader holds — the cached
+    // cross-process slot textures and the last-frame copy — and
+    // reinitialize. Fewer live shared allocations for VidMm to
+    // terminate while the driver stack recovers (a 0x10E_37 bugcheck in
+    // dxgmms2's pending-termination path took the whole machine down in
+    // the field); the factory re-opens the ring against a healthy
+    // device afterwards.
+    if (tdr::event_count() != _tdr_marks_at_open) {
+      BOOST_LOG(warning) << "LuminalVGD capture: GPU-reset event recorded; releasing shared ring "
+                            "textures and reinitializing for recovery.";
+      _slot_textures.clear();
+      _last_frame.reset();
+      return capture_e::reinit;
     }
 
     // Cursor-capable driver: frames arrive cursor-free; pull the live

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -41,6 +41,7 @@ extern "C" {
 #include "stream.h"
 #include "sync.h"
 #include "system_tray.h"
+#include "nvenc/nvenc_base.h"
 #include "tdr_state.h"
 #include "thread_safe.h"
 #ifdef _WIN32
@@ -502,6 +503,10 @@ namespace stream {
       std::atomic<std::uint32_t> idr_requests {0};
       std::atomic<std::uint32_t> ref_invalidations {0};
       std::chrono::steady_clock::time_point last_flush {};
+      // tdr::event_count() watermark, video thread only — the flush
+      // emits the delta as the gpu_resets series so Session Details
+      // charts show exactly where a GPU reset hit the stream.
+      std::uint64_t tdr_marks_seen {0};
     } telemetry;
 
     safe::mail_raw_t::event_t<bool> shutdown_event;
@@ -1596,6 +1601,9 @@ namespace stream {
     const auto now = std::chrono::steady_clock::now();
     if (t.last_flush == std::chrono::steady_clock::time_point {}) {
       t.last_flush = now;
+      // Baseline the GPU-reset watermark so pre-session events don't
+      // spike the first emitted bucket.
+      t.tdr_marks_seen = tdr::event_count();
       return;
     }
     const auto elapsed = now - t.last_flush;
@@ -1624,6 +1632,9 @@ namespace stream {
     s["client_losses"] = losses / secs;
     s["idr_requests"] = idr / secs;
     s["ref_invalidations"] = ref_inv / secs;
+    const auto tdr_now = tdr::event_count();
+    s["gpu_resets"] = static_cast<double>(tdr_now - t.tdr_marks_seen);
+    t.tdr_marks_seen = tdr_now;
     session_mon::sample_now(session_mon::make_id(session->launch_session_id), s);
   }
 
@@ -2492,6 +2503,24 @@ namespace stream {
 #ifdef _WIN32
         display_helper_integration::clear_pending_apply();
         clear_deferred_stream_start_actions();
+        // A drain-timed-out encoder teardown leaked NVENC-registered
+        // resources (the pool is bounded, ~64 on consumer cards; the
+        // leak site logs the running total). Now that the host is idle,
+        // recycle the process cleanly so the pool never exhausts inside
+        // a future session. Delayed + re-checked so an immediate
+        // reconnect always wins over the restart.
+        if (const auto leaks = nvenc::drain_leak_count(); leaks > 0) {
+          BOOST_LOG(warning) << "NvEnc drain-leak events this process: " << leaks
+                             << "; scheduling a clean host restart now that no sessions remain.";
+          task_pool.pushDelayed([]() {
+            if (session::active_sessions.load(std::memory_order_acquire) > 0) {
+              BOOST_LOG(info) << "Skipping post-leak host restart; a new session is active.";
+              return;
+            }
+            BOOST_LOG(info) << "Restarting host to reclaim leaked NVENC registrations.";
+            platf::restart();
+          }, 15s);
+        }
 #endif
         // Only revert on disconnect when explicitly enabled by config.
         bool revert_display_config {config::video.dd.config_revert_on_disconnect};

--- a/src/tdr_state.cpp
+++ b/src/tdr_state.cpp
@@ -122,6 +122,8 @@ namespace tdr {
         return "virtual display enumerate";
       case source_t::query_display_config:
         return "QueryDisplayConfig";
+      case source_t::encoder_stall:
+        return "encoder stall";
     }
     return "unknown";
   }

--- a/src/tdr_state.h
+++ b/src/tdr_state.h
@@ -38,6 +38,10 @@ namespace tdr {
     /// QueryDisplayConfig returned ERROR_NOT_SUPPORTED for several
     /// consecutive calls — the WDDM display API itself is wedged.
     query_display_config = 4,
+    /// The encoder's in-flight frame never signaled completion (NvEnc
+    /// encode-wait timeout) — the earliest observable symptom of a GPU
+    /// hang, minutes before the D3D11 retry ladder can exhaust.
+    encoder_stall = 5,
   };
 
   struct event_t {

--- a/src_assets/common/assets/web/components/SessionDetailsPanel.vue
+++ b/src_assets/common/assets/web/components/SessionDetailsPanel.vue
@@ -385,6 +385,7 @@ const CONNECTION_CHARTS: ChartSpec[] = [
       { key: 'client_losses',      label: 'Losses',     stroke: PAL.flare },
       { key: 'idr_requests',       label: 'IDR',        stroke: PAL.gold },
       { key: 'ref_invalidations',  label: 'Ref Inv.',   stroke: PAL.blue },
+      { key: 'gpu_resets',         label: 'GPU Reset',  stroke: PAL.violet },
     ] },
 ];
 

--- a/tools/sunshinesvc.cpp
+++ b/tools/sunshinesvc.cpp
@@ -212,6 +212,33 @@ VOID WINAPI ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
     return;
   }
 
+  // Self-configure SCM crash recovery on every start (idempotent): a
+  // GPU-driver UMD fault inside the host process (nvwgf2umx access
+  // violations during TDR recovery took it down in the field,
+  // 2026-07-26) must self-heal without user action. Restart 5 s after
+  // each of the first three failures per day; best-effort — a failure
+  // to configure never blocks service start.
+  {
+    SC_HANDLE scm = OpenSCManagerA(nullptr, nullptr, SC_MANAGER_CONNECT);
+    if (scm) {
+      SC_HANDLE svc = OpenServiceA(scm, SERVICE_NAME, SERVICE_CHANGE_CONFIG);
+      if (svc) {
+        SC_ACTION actions[3] = {
+          {SC_ACTION_RESTART, 5000},
+          {SC_ACTION_RESTART, 5000},
+          {SC_ACTION_RESTART, 5000},
+        };
+        SERVICE_FAILURE_ACTIONSA failure_actions = {};
+        failure_actions.dwResetPeriod = 24 * 60 * 60;  // seconds
+        failure_actions.cActions = ARRAYSIZE(actions);
+        failure_actions.lpsaActions = actions;
+        ChangeServiceConfig2A(svc, SERVICE_CONFIG_FAILURE_ACTIONS, &failure_actions);
+        CloseServiceHandle(svc);
+      }
+      CloseServiceHandle(scm);
+    }
+  }
+
   // Tell SCM we're starting
   service_status.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
   service_status.dwServiceSpecificExitCode = 0;


### PR DESCRIPTION
Approved plan B from the 2026-07-26 0x10E_37 crash analysis (GPU hang under Halo + DLSS FG + 4K HDR encode; nvwgf2umx AV in-process, then dxgmms2 bugcheck during pending-termination processing).

1. **Earliest TDR signal** — NvEnc encode-wait timeout records a new `tdr::source_t::encoder_stall` event (~100 ms after a hang).
2. **Blast-radius shrink** — the LuminalVGD ring reader watches `tdr::event_count()` and, on any advance, drops its cross-process shared slot textures + last-frame copy and reinits; the ring reopens against a healthy device.
3. **Self-healing service** — sunshinesvc self-configures SCM FailureActions on start (restart 5 s × 3/day), so an NVIDIA-UMD crash inside the host recovers unattended.
4. **Leak-driven recycle + telemetry** — last-session-end schedules a clean host restart when NVENC drain-leaks are on the books (15 s delay, liveness-rechecked); `gpu_resets` streams as a telemetry series and plots on the Session Details Connection chart.

Attribution note: neither dump implicates our code — this is hardening around a driver-stack failure, per the reviewed plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)