### PR TITLE
chore: bundle LuminalVGD v0.1.0-alpha.3 (build 13) in the MSI

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -341,7 +341,7 @@ jobs:
           # (github.com/NortheBridge/LuminalVGD releases). Bump on driver
           # releases. SudoVDA is gone by decision (2026-07-23) — the MSI's
           # drivers\luminalvgd\install.ps1 also removes it wherever found.
-          LUMINALVGD_VERSION: 'v0.1.0-alpha.2'
+          LUMINALVGD_VERSION: 'v0.1.0-alpha.3'
         run: |
           $ErrorActionPreference = 'Stop'
           $packageDir = Join-Path $PWD 'src_assets/windows/drivers/luminalvgd/driver-package'

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -147,7 +147,7 @@ jobs:
         # sign/install them in the coverage workflow.
         shell: pwsh
         env:
-          LUMINALVGD_VERSION: 'v0.1.0-alpha.2'
+          LUMINALVGD_VERSION: 'v0.1.0-alpha.3'
         run: |
           $ErrorActionPreference = 'Stop'
           $packageDir = Join-Path $PWD 'src_assets/windows/drivers/luminalvgd/driver-package'


### PR DESCRIPTION
Bumps the CI driver-package pin from `v0.1.0-alpha.2` to `v0.1.0-alpha.3` (Milestone 1 Update 2, DriverVer 0.1.0.13) in both `ci-windows.yml` and `coverage-windows.yml`, so the 26.08.0-beta.5 MSI bundles the new signed driver package.

The new driver carries the cold-boot display-activation fix and the I-beam cursor black-box fix. Protocol is unchanged (`proto 0.3`, handshake build 13) — no host-side changes are needed; LuminalShine's driver floor (beta.2+) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)