### PR TITLE
fix: eliminate pairing use-after-free and serialize HTTP connection I/O

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,11 @@ test_sunshine.log
 # LuminalVGD signed driver-package: packaging input dropped in from a
 # LuminalVGD release (or a local signed build) - never committed.
 src_assets/windows/drivers/luminalvgd/driver-package/
+
+# Runtime state written into the working directory when the test binary
+# (or a dev run) is launched from the repo root. Contains session tokens
+# and credential material - never committed.
+luminalshine_state.json
+luminalshine_state.json.bak
+sunshine_state.json
+sunshine_state.json.bak

--- a/.gitmodules
+++ b/.gitmodules
@@ -65,9 +65,13 @@
 	path = third-party/nvapi-open-source-sdk
 	url = https://github.com/NVIDIA/nvapi.git
 	branch = main
+# NortheBridge fork of the LizardByte-infrastructure fork. Carries the
+# per-connection I/O serialization fix (NortheBridge/Simple-Web-Server#1)
+# for the response/connection lifetime hazards found during the
+# 2026-07-27 crash investigation. Rebase onto upstream when it moves.
 [submodule "third-party/Simple-Web-Server"]
 	path = third-party/Simple-Web-Server
-	url = https://github.com/LizardByte-infrastructure/Simple-Web-Server.git
+	url = https://github.com/NortheBridge/Simple-Web-Server.git
 	branch = master
 [submodule "third-party/TPCircularBuffer"]
 	path = third-party/TPCircularBuffer

--- a/docs/web-server-replacement.md
+++ b/docs/web-server-replacement.md
@@ -1,0 +1,66 @@
+# Replacing Simple-Web-Server — evaluation and recommendation
+
+Status: recommendation only (2026-07-27). Not scheduled for beta.6 — the beta.6
+fix hardens the vendored Simple-Web-Server in place (NortheBridge fork). This
+document is the follow-up plan for retiring it.
+
+## Why replace it
+
+The 2026-07-27 crash analysis (`POSTMORTEM-2026-07-27.md`; dump
+`luminalshine.exe.52192.dmp`) traced the nightly host death to a
+session-lifetime race inside Simple-Web-Server's HTTPS server: two independent
+write-submission paths per response (`send()` queue vs `send_on_delete`), an
+unsynchronized keep-alive streambuf hand-off, and no strand serialization of
+per-connection state. The library is a ~900-line header maintained sporadically
+(our submodule is a LizardByte infrastructure fork); its design predates
+asio strands-by-default, and every LuminalShine feature that holds a response
+across threads (SSE ICE streaming, task_pool handlers) fights the model.
+
+## What confighttp/nvhttp actually need
+
+- HTTPS (OpenSSL; our own certs), HTTP/1.1 keep-alive; TLS client-cert
+  verification on the nvhttp GameStream plane.
+- REST routing with regex/param paths (~120 routes), large static/SPA serving
+  with range requests, cookie/session + token auth middleware.
+- Server-Sent Events (ICE candidate stream) and long-held responses written
+  from non-server threads — the thing that must be first-class.
+- WebSocket: not currently used (WebRTC signaling is REST+SSE), but keep the
+  door open.
+- Windows/clang(MinGW, `--fms-extensions`)/CMake build; no MSVC-only code;
+  header-only or trivially-linkable strongly preferred (our CI builds cold).
+- Low idle overhead — the host is a always-on SYSTEM service; a thread-per-core
+  event loop or single-threaded io model both fine.
+
+## Candidates
+
+| Library | Model | TLS | Fit notes |
+|---|---|---|---|
+| **Boost.Beast** | asio, low-level HTTP/WS primitives | via asio::ssl | Already ship Boost + asio + OpenSSL — zero new deps, no new build risk on clang/MinGW. No router/middleware: we build a thin server layer (routing table, session mgmt) ourselves — which we already effectively own today, scattered through confighttp. Strand-per-connection is idiomatic. WebSocket built in. Most work, most control, least dependency risk. |
+| **Drogon** | own event loop (trantor), full framework | OpenSSL | Fastest full-featured option (routing, filters/middleware, WS, SSE-able chunked responses, static files). C++17, CMake, actively maintained; MinGW builds are supported but less exercised than MSVC/Linux — needs a spike. Brings its own event loop next to our asio usage (two reactor stacks in-process). |
+| **Crow** | header-only, asio-based | via asio::ssl | Familiar Flask-like API, header-only, middleware, WS. Maintained community fork (CrowCpp). asio-based so it composes with our stack. Weaker SSE story (manual chunked writes); route performance fine at our scale. |
+| **cpp-httplib** | header-only, thread-per-connection blocking | OpenSSL | Simplest possible integration; SSE supported via content providers. But thread-per-connection + blocking model is a regression for an always-on service with long-held SSE streams (thread per open stream), and its Windows TLS cert-verification paths need care. Good for tools, not for the host. |
+| **uWebSockets** | own event loop (uSockets), WS-first | BoringSSL/OpenSSL | Exceptional performance, but C-ish API, BoringSSL preference, and MinGW support is rough; HTTP feature set (routing/static/middleware) is thin. Overkill for a config UI, wrong shape for our TLS client-cert needs. |
+| Pistache / Oat++ / RESTinio | various | various | Pistache is Linux-only (out). Oat++ is full-featured but brings a large opinionated object model and its own async runtime. RESTinio is asio-based and decent but smaller community than Crow/Drogon; SSE workable via chunked writes. None beat the top three for us. |
+
+## Recommendation
+
+1. **First choice: Boost.Beast** with a small in-repo server layer
+   (`src/httpd/`): connection class = one strand + one SSL stream + explicit
+   state machine; router lifted from confighttp's existing regex table; SSE as
+   a first-class "streaming response" object that marshals writes onto the
+   connection strand (the exact bug class we just fixed becomes structurally
+   impossible). Zero new dependencies, full control of session lifetime, and
+   both confighttp and nvhttp (client-cert plane) can migrate onto the same
+   layer incrementally — route by route — while Simple-Web-Server keeps
+   serving the unmigrated routes during the transition.
+2. **Second choice: Crow (CrowCpp)** if we prefer not to own a server layer:
+   header-only, asio-composable, small diff for the 80% of routes that are
+   plain JSON REST. SSE and client-cert verification need custom work anyway,
+   which narrows its advantage over Beast.
+3. Drogon is the best "batteries included" framework but the second event loop
+   and MinGW risk make it a spike-first option, not a default.
+
+Suggested sequencing (post-Milestone 1): spike Beast connection layer behind a
+compile flag, port `/api/health/*` + static serving first, then the auth
+middleware, then SSE, then nvhttp last (client-cert plane needs the most care).
+Delete the Simple-Web-Server submodule at the end.

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -739,6 +739,13 @@ namespace nvhttp {
   };
 
   // uniqueID, session
+  //
+  // Mutated from three threads: the HTTPS and HTTP nvhttp server threads
+  // (both expose /pair on their own io_context) and the confighttp thread
+  // (nvhttp::pin() when the user submits the PIN form). Every access must
+  // hold map_id_sess_mutex — concurrent emplace/erase/rehash against a
+  // lookup corrupts the heap.
+  std::mutex map_id_sess_mutex;
   std::unordered_map<std::string, pair_session_t> map_id_sess;
   client_t client_root;
   std::atomic<uint32_t> session_id_counter;
@@ -1613,6 +1620,11 @@ namespace nvhttp {
 
     auto uniqID {get_arg(args, "uniqueid")};
 
+    // Held for the whole pairing phase: every branch below either inserts,
+    // looks up, or (via fail_pair) erases the session record, and the two
+    // server threads plus the Web UI's pin() run this concurrently.
+    std::lock_guard<std::mutex> sess_lock {map_id_sess_mutex};
+
     args_t::const_iterator it;
     if (it = args.find("phrase"); it != std::end(args)) {
       if (it->second == "getservercert"sv) {
@@ -1673,6 +1685,7 @@ namespace nvhttp {
 
   bool pin(std::string pin, std::string name) {
     pt::ptree tree;
+    std::lock_guard<std::mutex> sess_lock {map_id_sess_mutex};
     if (map_id_sess.empty()) {
       return false;
     }
@@ -1696,15 +1709,26 @@ namespace nvhttp {
       return false;
     }
 
-    auto &sess = std::begin(map_id_sess)->second;
-    getservercert(sess, tree, pin);
+    // Take our own reference to the pending response and clear the stored
+    // one BEFORE running the pairing phase: getservercert() rejects an
+    // out-of-order call (e.g. a double-submitted PIN form, or a retry
+    // against a session left in a non-NONE phase) via fail_pair() ->
+    // remove_session(), which erases this very map entry and destroys
+    // `sess`. Everything below used to run on the freed node — a heap
+    // write-after-free plus a call through a dangling response pointer.
+    auto sess_it = std::begin(map_id_sess);
+    auto &sess = sess_it->second;
+    auto async_response = std::move(sess.async_insert_pin.response);
+    sess.async_insert_pin.response = std::decay_t<decltype(async_response.left())>();
     sess.client.name = name;
+
+    getservercert(sess, tree, pin);
+    // `sess` and `sess_it` may be dangling from here on — do not touch them.
 
     // response to the request for pin
     std::ostringstream data;
     pt::write_xml(data, tree);
 
-    auto &async_response = sess.async_insert_pin.response;
     if (async_response.has_left() && async_response.left()) {
       async_response.left()->write(data.str());
     } else if (async_response.has_right() && async_response.right()) {
@@ -1713,8 +1737,6 @@ namespace nvhttp {
       return false;
     }
 
-    // reset async_response
-    async_response = std::decay_t<decltype(async_response.left())>();
     // response to the current request
     return true;
   }

--- a/tests/unit/test_simpleweb_lifetime.cpp
+++ b/tests/unit/test_simpleweb_lifetime.cpp
@@ -1,0 +1,151 @@
+/**
+ * @file tests/unit/test_simpleweb_lifetime.cpp
+ * @brief Stress test for Simple-Web-Server connection/response lifetime.
+ *
+ * Regression coverage for the 2026-07-27 crash class (POSTMORTEM-2026-07-27.md,
+ * dump luminalshine.exe.52192.dmp): responses held, written, and dropped on
+ * non-server threads (the SSE ICE-stream pattern) while clients run keep-alive
+ * request loops and disconnect early. Before the NortheBridge fork patch,
+ * Response::send() and Response::send_on_delete() could start two concurrent
+ * async_write chains on one socket and the keep-alive streambuf hand-off was
+ * not serialized with in-flight operations — corrupting the heap or scanning a
+ * dangling request streambuf. The patched fork serializes every per-connection
+ * operation on the connection strand and routes all writes through one queue.
+ *
+ * The test uses the plain-HTTP server instantiation: the raced code all lives
+ * in ServerBase, shared with the HTTPS instantiation used in production, and
+ * plain HTTP avoids certificate fixtures.
+ */
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <Simple-Web-Server/client_http.hpp>
+#include <Simple-Web-Server/server_http.hpp>
+
+#include <gtest/gtest.h>
+
+#include "../tests_common.h"
+
+namespace {
+  using HttpServer = SimpleWeb::Server<SimpleWeb::HTTP>;
+  using HttpClient = SimpleWeb::Client<SimpleWeb::HTTP>;
+
+  class SimpleWebLifetime: public ::testing::Test {
+  protected:
+    void SetUp() override {
+      server = std::make_unique<HttpServer>();
+      server->config.port = 0;  // OS-assigned
+      server->config.thread_pool_size = 2;  // exercise the strands, not just one runner
+      server->config.timeout_request = 1;  // aggressive timeouts: exercise timer vs read races
+      server->config.timeout_content = 2;
+
+      server->resource["^/ping$"]["GET"] = [](std::shared_ptr<HttpServer::Response> response, std::shared_ptr<HttpServer::Request>) {
+        response->write("pong");
+      };
+
+      // The SSE-shaped hazard: hold the response on a detached thread, stream
+      // a few events with explicit send(), then drop the response there so
+      // send_on_delete fires on a foreign thread — historically overlapping
+      // the still-draining send queue.
+      server->resource["^/sse$"]["GET"] = [this](std::shared_ptr<HttpServer::Response> response, std::shared_ptr<HttpServer::Request>) {
+        std::thread([this, response]() mutable {
+          response->close_connection_after_response = true;
+          response->write({{"Content-Type", "text/event-stream"}, {"Cache-Control", "no-cache"}});
+          for (int i = 0; i < 5 && !stopping.load(); ++i) {
+            *response << "data: tick " << i << "\n\n";
+            response->send();
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          }
+          // Dropped here, possibly with sends still queued.
+        }).detach();
+      };
+
+      server_thread = std::thread([this]() {
+        server->start([this](unsigned short p) {
+          port.store(p);
+        });
+      });
+      while (port.load() == 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+      }
+    }
+
+    void TearDown() override {
+      stopping.store(true);
+      // Give detached SSE threads a beat to drop their responses first.
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      server->stop();
+      if (server_thread.joinable()) {
+        server_thread.join();
+      }
+    }
+
+    std::unique_ptr<HttpServer> server;
+    std::thread server_thread;
+    std::atomic<unsigned short> port {0};
+    std::atomic<bool> stopping {false};
+  };
+
+  TEST_F(SimpleWebLifetime, KeepAliveAndForeignThreadSseStress) {
+    constexpr int kClientThreads = 4;
+    constexpr auto kDuration = std::chrono::seconds(3);
+
+    std::atomic<int> ok {0};
+    std::atomic<int> requests {0};
+    std::vector<std::thread> clients;
+    const auto deadline = std::chrono::steady_clock::now() + kDuration;
+    const std::string host = "127.0.0.1:" + std::to_string(port.load());
+
+    clients.reserve(kClientThreads);
+    for (int t = 0; t < kClientThreads; ++t) {
+      clients.emplace_back([&, t]() {
+        while (std::chrono::steady_clock::now() < deadline) {
+          try {
+            HttpClient client(host);
+            // Keep-alive loop on one connection: each cycle runs the
+            // response-complete → streambuf-steal → re-read hand-off.
+            for (int i = 0; i < 8; ++i) {
+              auto r = client.request("GET", "/ping");
+              requests.fetch_add(1);
+              if (r->content.string() == "pong") {
+                ok.fetch_add(1);
+              }
+            }
+            // Odd threads also open an SSE stream and abandon it early,
+            // forcing server-side response drops with writes in flight.
+            if (t % 2 == 1) {
+              try {
+                client.request("GET", "/sse");
+                requests.fetch_add(1);
+              } catch (...) {
+                // Early disconnects / timeouts are expected here.
+              }
+            }
+          } catch (...) {
+            // Connection-level errors (timeouts, resets) are acceptable;
+            // the assertion is that the server survives and keeps serving.
+          }
+        }
+      });
+    }
+    for (auto &c : clients) {
+      c.join();
+    }
+
+    // The server must have survived the stress window and served real
+    // traffic. If the old race fires, the process crashes outright (AV /
+    // heap corruption), so reaching this point with traffic served is the
+    // regression signal.
+    EXPECT_GT(requests.load(), 0);
+    EXPECT_GT(ok.load(), 0);
+
+    // And it must still be alive and serving afterwards.
+    HttpClient after(host);
+    auto r = after.request("GET", "/ping");
+    EXPECT_EQ(r->content.string(), "pong");
+  }
+}  // namespace


### PR DESCRIPTION
First of the beta.6 stability fixes. Closes the crash class that killed the host ~10 times between 7/25 and 7/27.

## The bug the dumps actually pointed at

Dump analysis (`C:\evidence\wedge-20260727`, dump `luminalshine.exe.52192.dmp`) put the 03:59:32 crash on the confighttp HTTPS thread inside an asio `read_until` scanning a request streambuf that read as `0xffffffffffffffff`. The read op's own state was provably alive, so the faulting thread was a **victim of heap corruption**, not its source — and the two `0xc0000374` heap-corruption crashes on 7/25 independently prove a corrupting writer exists in this process.

The writer is `nvhttp::pin()`:

```cpp
auto &sess = std::begin(map_id_sess)->second;
getservercert(sess, tree, pin);   // may fail_pair() -> remove_session() -> erase(sess.client.uniqueID)
sess.client.name = name;          // <-- write to freed node
auto &async_response = sess.async_insert_pin.response;  // <-- read from freed node
async_response.left()->write(...);                      // <-- call through it
```

`getservercert()` rejects an out-of-order call by erasing the session. Reaching it is easy: a successful `getservercert` leaves the session in the map with `last_phase = GETSERVERCERT`, so a **double-submitted PIN form** — or a retry against an abandoned pairing attempt — makes the second call take the fail path and free the record mid-function. The heap write lands in whatever allocation reuses that node.

**Fix:** move the stored response out and set the client name *before* the phase runs; never touch the record afterwards.

## Second defect: `map_id_sess` had no lock

It is mutated from three threads — the HTTPS and HTTP nvhttp server threads (each serves `/pair` on its own io_context) and the confighttp thread via `pin()`. Concurrent `emplace`/`erase`/rehash against a lookup is its own heap-corruption source. Now guarded by a mutex held across each pairing phase. The response write happens after the lock releases (the fail-guard outlives the lock guard by declaration order).

## Third: the library hazard the investigation started from

The vendored `Simple-Web-Server` submodule moves to the **NortheBridge fork** carrying NortheBridge/Simple-Web-Server#1:
- `send_on_delete` now shares the ordered `send_queue` with `send()` — a Response dropped with sends outstanding can no longer start a second concurrent composed write on one SSL stream.
- Every per-connection operation binds to the connection strand: read initiation and completion, content/chunked reads, **write completions** (previously unbound — the keep-alive streambuf hand-off ran un-serialized at any pool size > 1), the timeout timer, and the TLS handshake.
- `close_connection_after_response` is atomic.

This makes the SSE pattern in `/api/webrtc/.../ice/stream` — response held, written, and dropped on a detached thread — safe by construction rather than by luck.

## Verification

- `luminalshine.exe` and `test_sunshine` build clean.
- New `SimpleWebLifetime.KeepAliveAndForeignThreadSseStress`: 4 client threads × 3s of keep-alive request loops plus SSE streams abandoned early, `thread_pool_size=2`, 1s/2s timeouts — passes.
- Full suite run before/after: the 5 pre-existing failures (`ConfigHttpCheckAuthTest.given_disallowed_ip_address...`, `PlayniteSync_*`) reproduce identically on an unmodified baseline build, so they are not from this change. `DownloadFileTests` cannot run locally (needs write access to `C:\ProgramData\LuminalShine\config`).

## Also here

- `docs/web-server-replacement.md` — evaluation of replacements for Simple-Web-Server (recommendation: Boost.Beast with a thin in-repo server layer; Crow as the lighter-touch alternative). Not scheduled for beta.6.
- Repo-root runtime state files written by test runs are gitignored — they contain session tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)