### PR TITLE
fix: classify display failures by evidence and add a terminal stack-down state

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -656,7 +656,13 @@ namespace confighttp {
    *        the "GPU / Display Stack Health" card in the Troubleshooting
    *        view.
    *
-   * @api_examples{/api/health/tdr| GET| {"count":1,"recovery_recent":false,"last":{"at":1715990443,"source":"encoder D3D11","hresult":2289565700,"detail":"..."}}}
+   * `count` is the number of distinct incidents, not the number of times
+   * a failure was re-detected — a stack that stays broken is one incident
+   * with a growing duration, not one per client retry. `detections` keeps
+   * the raw count for support bundles. `stack_down` means the display API
+   * itself is unavailable process-wide: terminal, reboot required.
+   *
+   * @api_examples{/api/health/tdr| GET| {"count":1,"detections":22,"recovery_recent":false,"stack_down":true,"incident":{"started_at":1715990443,"last_at":1715993901,"duration_seconds":3458,"events":22,"first_source":"encoder stall","source":"display stack down","terminal":true},"last":{"at":1715990443,"source":"encoder D3D11","hresult":2289565700,"detail":"..."}}}
    */
   void getTdrHealth(resp_https_t response, req_https_t request) {
     if (!authenticate(response, request)) {
@@ -664,8 +670,29 @@ namespace confighttp {
     }
     nlohmann::json out;
     out["status"] = true;
-    out["count"] = tdr::event_count();
+    out["count"] = tdr::incident_count();
+    out["detections"] = tdr::event_count();
     out["recovery_recent"] = tdr::recovery_recent();
+    out["stack_down"] = tdr::stack_down();
+    if (auto inc = tdr::current_incident(); inc) {
+      const auto started = std::chrono::duration_cast<std::chrono::seconds>(
+        inc->started_at.time_since_epoch()
+      ).count();
+      const auto last_at = std::chrono::duration_cast<std::chrono::seconds>(
+        inc->last_at.time_since_epoch()
+      ).count();
+      nlohmann::json incident;
+      incident["started_at"] = started;
+      incident["last_at"] = last_at;
+      incident["duration_seconds"] = last_at - started;
+      incident["events"] = inc->events;
+      incident["first_source"] = tdr::source_label(inc->first_source);
+      incident["source"] = tdr::source_label(inc->last_source);
+      incident["hresult"] = inc->hresult;
+      incident["detail"] = inc->detail;
+      incident["terminal"] = inc->terminal;
+      out["incident"] = std::move(incident);
+    }
     if (auto ev = tdr::last_event(); ev) {
       const auto secs = std::chrono::duration_cast<std::chrono::seconds>(
         ev->at.time_since_epoch()

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -98,6 +98,21 @@ namespace platf::dxgi {
    */
   HRESULT D3D11ProbeDeviceHealth() noexcept;
 
+  /**
+   * @brief Is Windows' display-configuration API alive and seeing displays?
+   *
+   * The cross-check that tells a recoverable device failure apart from a
+   * dead WDDM stack. A D3D11 failure alone proves nothing about which one
+   * you have; pairing it with this does. When the stack is dead,
+   * QueryDisplayConfig fails machine-wide (typically ERROR_NOT_SUPPORTED,
+   * 50) or enumerates zero paths, in every process, until reboot.
+   *
+   * @param error_out Receives the raw Win32 status, or nullptr.
+   * @param path_count_out Receives the active path count, or nullptr.
+   * @return true when the API answered and at least one path exists.
+   */
+  bool display_config_api_healthy(LONG *error_out, UINT32 *path_count_out) noexcept;
+
   using factory1_t = util::safe_ptr<IDXGIFactory1, Release<IDXGIFactory1>>;
   using dxgi_t = util::safe_ptr<IDXGIDevice, Release<IDXGIDevice>>;
 

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -426,13 +426,52 @@ namespace platf::dxgi {
   }
 #endif
 
+  // Is Windows' display-configuration API answering, and does it see any
+  // display paths? A dead WDDM stack fails this even though every
+  // user-mode component is healthy: QueryDisplayConfig returns
+  // ERROR_NOT_SUPPORTED (or enumerates zero paths) machine-wide, in every
+  // process, until reboot.
+  //
+  // This is the cross-check that separates "the adapter is resetting,
+  // retrying will work" from "the stack is gone, retrying is pointless" —
+  // the distinction the 2026-07-27 incident spent 96 minutes failing to
+  // make. Deliberately self-contained (raw Win32, no retries): the
+  // libdisplaydevice wrapper already retries internally and discards the
+  // error code, which is exactly the information needed here.
+  bool display_config_api_healthy(LONG *error_out, UINT32 *path_count_out) noexcept {
+    UINT32 path_count = 0;
+    UINT32 mode_count = 0;
+    const LONG status = GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &path_count, &mode_count);
+    if (error_out) {
+      *error_out = status;
+    }
+    if (path_count_out) {
+      *path_count_out = path_count;
+    }
+    if (status != ERROR_SUCCESS) {
+      return false;
+    }
+    // The API answered but nothing is attached: on this machine that only
+    // happens when the stack is wedged (a headless server would not be
+    // running a streaming host with a virtual display attached).
+    return path_count > 0;
+  }
+
   // Wrapper around D3D11CreateDevice with bounded exponential-backoff
-  // retry for the post-TDR transient failure window. Retries only on
+  // retry for the post-TDR transient failure window. Retries on
   // DXGI_ERROR_UNSUPPORTED (0x887A0004) and DXGI_ERROR_DEVICE_REMOVED
-  // (0x887A0005) — the two HRESULTs the kernel returns while a NVENC /
-  // GPU TDR recovery is in flight. Other failures (E_FAIL, E_INVALIDARG,
-  // E_OUTOFMEMORY) are surfaced immediately because they mean the call
-  // itself is wrong, not that the GPU is in a transient bad state.
+  // (0x887A0005) — both are observed while a NVENC / GPU TDR recovery is
+  // in flight. Other failures (E_FAIL, E_INVALIDARG, E_OUTOFMEMORY) are
+  // surfaced immediately because they mean the call itself is wrong, not
+  // that the GPU is in a transient bad state.
+  //
+  // Note what these HRESULTs do NOT mean on their own: DXGI_ERROR_UNSUPPORTED
+  // is a capability/environment error, not a TDR signal. Treating it as
+  // proof of a GPU reset is what produced "39 TDR events" for a single
+  // failure in the field. Retrying briefly on it is still right (it does
+  // appear transiently during a real reset), but the classification of
+  // what happened is decided after the ladder, by asking the display API
+  // whether the stack is alive at all.
   //
   // Backoff schedule: 1s, 2s, 4s, 8s — capped at 4 retries (~15s total).
   // Empirically this matches NVIDIA Game Ready driver TDR recovery on
@@ -466,6 +505,21 @@ namespace platf::dxgi {
     using namespace std::chrono_literals;
     constexpr std::chrono::milliseconds backoff_schedule[] = {1000ms, 2000ms, 4000ms, 8000ms};
     constexpr int max_attempts = sizeof(backoff_schedule) / sizeof(backoff_schedule[0]) + 1;
+
+    // Already known dead: skip the ladder entirely. Otherwise every
+    // encoder candidate burns the full ~15s of sleeps re-proving it, which
+    // is how one failure became a ~66s-per-encoder loop with no exit.
+    if (tdr::stack_down()) {
+      LONG qdc_status = ERROR_SUCCESS;
+      if (!display_config_api_healthy(&qdc_status, nullptr)) {
+        BOOST_LOG(warning) << "D3D11CreateDevice (" << (call_site ? call_site : "unknown")
+                           << "): skipped — display stack is down (QueryDisplayConfig "
+                           << "status " << qdc_status << "). A reboot is required.";
+        return DXGI_ERROR_UNSUPPORTED;
+      }
+      // The stack came back while we were latched; fall through and let
+      // the normal path re-prove it (note_stack_healthy fires on success).
+    }
 
     HRESULT status = E_FAIL;
     for (int attempt = 1; attempt <= max_attempts; ++attempt) {
@@ -507,6 +561,9 @@ namespace platf::dxgi {
         feature_level,
         context);
       if (SUCCEEDED(status)) {
+        // Proof the stack is alive — clears any latched terminal state so
+        // a recovered machine resumes without needing a restart.
+        tdr::note_stack_healthy();
         if (attempt > 1) {
           BOOST_LOG(info) << "D3D11CreateDevice (" << (call_site ? call_site : "unknown")
                           << "): recovered after " << attempt << " attempts (status 0x"
@@ -523,21 +580,52 @@ namespace platf::dxgi {
         // E_INVALIDARG, etc.) or we've exhausted the backoff schedule.
         // Caller logs the final HRESULT.
         if (is_transient) {
-          // We retried for the full window and the GPU never came back —
-          // record the TDR escalation so the high-signal log line, tray
-          // toast, and session-start gate fire from one place. The
-          // call_site string ("encoder" / "DD test") drives which tdr
-          // source category we record under so the Web UI can show the
-          // user which subsystem detected it.
-          const auto src = (call_site != nullptr && std::string_view(call_site) == "encoder")
-            ? tdr::source_t::encoder_d3d11
-            : tdr::source_t::dd_test_d3d11;
+          // We retried for the full window and device creation never came
+          // back. WHY it failed decides what we tell the user, so ask the
+          // display API before naming a cause: if QueryDisplayConfig is
+          // also unavailable (or sees zero paths), the whole WDDM stack is
+          // dead and no retry ladder will ever succeed — that is terminal
+          // and needs a reboot, not another cycle. If the display API is
+          // healthy, this is a device-level problem: a genuine reset when
+          // the device was removed, otherwise an environment/capability
+          // failure that was never a TDR at all.
+          const char *const site = call_site ? call_site : "unknown";
+          LONG qdc_status = ERROR_SUCCESS;
+          UINT32 qdc_paths = 0;
+          const bool display_api_ok = display_config_api_healthy(&qdc_status, &qdc_paths);
+
           std::string detail = "D3D11CreateDevice exhausted ";
           detail += std::to_string(max_attempts);
           detail += " retries (";
-          detail += (call_site ? call_site : "unknown");
+          detail += site;
           detail += " call site)";
-          tdr::mark_event(src, static_cast<long>(status), std::move(detail));
+
+          if (!display_api_ok) {
+            detail += "; QueryDisplayConfig unavailable (status ";
+            detail += std::to_string(qdc_status);
+            detail += ", ";
+            detail += std::to_string(qdc_paths);
+            detail += " paths)";
+            tdr::mark_stack_down(static_cast<long>(status), std::move(detail));
+          } else if (status == DXGI_ERROR_DEVICE_REMOVED) {
+            // Display API alive + device removed: a real GPU reset.
+            const auto src = (std::string_view(site) == "encoder")
+              ? tdr::source_t::encoder_d3d11
+              : tdr::source_t::dd_test_d3d11;
+            tdr::mark_event(src, static_cast<long>(status), std::move(detail));
+          } else {
+            // Display API alive, device merely unsupported: this is an
+            // environment/capability failure (wrong adapter, driver not
+            // ready, no supported feature level). Log it plainly and do
+            // NOT record a TDR — a false GPU-reset verdict here refuses
+            // sessions for 30s and forces the capture ring to reinit.
+            BOOST_LOG(error) << "D3D11CreateDevice (" << site << "): failed with 0x"
+                             << util::hex(status).to_string_view()
+                             << " after " << max_attempts
+                             << " attempts, but the display stack is healthy ("
+                             << qdc_paths << " active paths). Treating as a device/"
+                             << "capability error, not a GPU reset.";
+          }
         }
         return status;
       }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -2605,6 +2605,17 @@ namespace stream {
       // ERROR_NOT_SUPPORTED, which only surfaced as a generic 10s "Hang
       // detected" fatal. Refusing the start here means Moonlight gets an
       // immediate, intelligible failure instead of a frozen-stream window.
+      // Terminal first: a dead display stack is not "recovering" and the
+      // client retrying will never help. Say so plainly rather than
+      // implying it should try again in a moment.
+      if (tdr::stack_down()) {
+        BOOST_LOG(error)
+          << "Refusing to start new streaming session: the Windows display stack is down "
+          << "(display API unavailable process-wide). This cannot be recovered from "
+          << "software — the host machine must be rebooted.";
+        return -1;
+      }
+
       if (tdr::recovery_recent()) {
         const auto last = tdr::last_event();
         BOOST_LOG(warning)
@@ -2623,18 +2634,31 @@ namespace stream {
       // (DXGI_ERROR_UNSUPPORTED) and friends on a wedged one.
       const HRESULT probe_hr = platf::dxgi::D3D11ProbeDeviceHealth();
       if (FAILED(probe_hr)) {
-        BOOST_LOG(warning)
-          << "Refusing to start new streaming session: pre-flight D3D11 health check failed (hresult=0x"
-          << std::hex << probe_hr << std::dec
-          << "). The GPU driver appears mid-recovery; the client should retry shortly.";
-        // Record so the Troubleshooting card reflects it the way a
-        // post-TDR event would, even though the encoder/QDC paths
-        // didn't fire it from inside an active stream.
-        tdr::mark_event(
-          tdr::source_t::dd_test_d3d11,
-          static_cast<long>(probe_hr),
-          "Pre-flight D3D11 health check failed at session start"
-        );
+        // Only escalate to a recorded failure when the display API
+        // corroborates it. Recording unconditionally made this probe
+        // self-feeding: its own event satisfied recovery_recent() above,
+        // so the next session was refused before the probe even ran, and
+        // the "events" counter climbed once per client attempt for as
+        // long as the machine stayed broken.
+        LONG qdc_status = ERROR_SUCCESS;
+        UINT32 qdc_paths = 0;
+        const bool display_api_ok =
+          platf::dxgi::display_config_api_healthy(&qdc_status, &qdc_paths);
+        if (!display_api_ok) {
+          std::string detail = "Pre-flight D3D11 health check failed at session start; "
+                               "QueryDisplayConfig unavailable (status ";
+          detail += std::to_string(qdc_status);
+          detail += ", ";
+          detail += std::to_string(qdc_paths);
+          detail += " paths)";
+          tdr::mark_stack_down(static_cast<long>(probe_hr), std::move(detail));
+        } else {
+          BOOST_LOG(warning)
+            << "Refusing to start new streaming session: pre-flight D3D11 health check failed (hresult=0x"
+            << std::hex << probe_hr << std::dec
+            << "), though the display stack itself is healthy (" << qdc_paths
+            << " active paths). The GPU driver may be mid-recovery; the client should retry shortly.";
+        }
         return -1;
       }
 #endif

--- a/src/tdr_state.cpp
+++ b/src/tdr_state.cpp
@@ -23,6 +23,18 @@ namespace tdr {
     std::chrono::steady_clock::time_point g_last_log_at {};
     std::chrono::steady_clock::time_point g_last_notify_at {};
 
+    std::optional<incident_t> g_incident;
+    std::chrono::steady_clock::time_point g_incident_last_steady {};
+    std::uint64_t g_incident_count {0};
+    std::atomic<bool> g_stack_down {false};
+
+    // How long an incident stays open. A dead stack is re-detected on
+    // every client attempt (~33s apart in the 2026-07-27 field incident),
+    // and those detections are the same failure, not new ones. Comfortably
+    // longer than that cadence so a persistent wedge reads as one incident
+    // with a growing duration.
+    constexpr std::chrono::minutes kIncidentWindow {5};
+
     // Cooldowns. Each TDR-class failure cascades through several call
     // sites (encoder D3D11, DD test, virtual display enumerate, ...), all
     // firing within seconds of each other. The first event in a cluster
@@ -51,6 +63,28 @@ namespace tdr {
       std::lock_guard<std::mutex> lk(g_mutex);
       g_last = event;
       g_count.fetch_add(1, std::memory_order_relaxed);
+
+      // Fold into the open incident, or open a new one after a quiet
+      // window. `terminal` is sticky for the life of the incident.
+      const bool fold = g_incident.has_value()
+        && g_incident_last_steady != clock::time_point {}
+        && (now_steady - g_incident_last_steady) < kIncidentWindow;
+      if (!fold) {
+        incident_t fresh;
+        fresh.started_at = now_system;
+        fresh.first_source = source;
+        g_incident = std::move(fresh);
+        ++g_incident_count;
+      }
+      g_incident->last_at = now_system;
+      g_incident->last_source = source;
+      g_incident->hresult = hresult;
+      g_incident->detail = detail;
+      g_incident->events += 1;
+      if (source == source_t::display_stack_down) {
+        g_incident->terminal = true;
+      }
+      g_incident_last_steady = now_steady;
 
       if (g_last_log_at == clock::time_point {} || (now_steady - g_last_log_at) >= kLogCooldown) {
         g_last_log_at = now_steady;
@@ -112,6 +146,51 @@ namespace tdr {
     return g_count.load(std::memory_order_relaxed);
   }
 
+  void mark_stack_down(long hresult, std::string detail) {
+    const bool first = !g_stack_down.exchange(true, std::memory_order_release);
+    if (first) {
+      // Loud, once, with the actual remedy — not the generic TDR line.
+      BOOST_LOG(error) << "Display stack down: " << detail
+                       << " (hresult=0x" << std::hex << hresult << std::dec
+                       << "). Windows' display API is unavailable process-wide, "
+                       << "which no user-mode recovery can clear — the machine "
+                       << "must be rebooted. New sessions will be refused until "
+                       << "the display stack returns.";
+    }
+    // Still recorded as an event so the incident (and the ring/telemetry
+    // consumers watching event_count) see it; mark_event handles the
+    // rate-limited logging and the tray toast.
+    mark_event(source_t::display_stack_down, hresult, std::move(detail));
+  }
+
+  bool stack_down() {
+    return g_stack_down.load(std::memory_order_acquire);
+  }
+
+  void note_stack_healthy() {
+    if (!g_stack_down.exchange(false, std::memory_order_release)) {
+      return;  // nothing was latched — cheap no-op on the hot success path
+    }
+    BOOST_LOG(info) << "Display stack recovered: Windows is enumerating displays "
+                    << "and D3D11 device creation succeeds again. Resuming normal "
+                    << "session handling.";
+    std::lock_guard<std::mutex> lk(g_mutex);
+    if (g_incident) {
+      // Close the incident so a later failure reads as a new one.
+      g_incident_last_steady = std::chrono::steady_clock::time_point {};
+    }
+  }
+
+  std::optional<incident_t> current_incident() {
+    std::lock_guard<std::mutex> lk(g_mutex);
+    return g_incident;
+  }
+
+  std::uint64_t incident_count() {
+    std::lock_guard<std::mutex> lk(g_mutex);
+    return g_incident_count;
+  }
+
   const char *source_label(source_t source) {
     switch (source) {
       case source_t::encoder_d3d11:
@@ -124,6 +203,8 @@ namespace tdr {
         return "QueryDisplayConfig";
       case source_t::encoder_stall:
         return "encoder stall";
+      case source_t::display_stack_down:
+        return "display stack down";
     }
     return "unknown";
   }

--- a/src/tdr_state.h
+++ b/src/tdr_state.h
@@ -42,6 +42,11 @@ namespace tdr {
     /// encode-wait timeout) — the earliest observable symptom of a GPU
     /// hang, minutes before the D3D11 retry ladder can exhaust.
     encoder_stall = 5,
+    /// The WDDM display stack is dead machine-wide: D3D11 device creation
+    /// fails AND QueryDisplayConfig reports the display API unavailable /
+    /// zero paths. Recovery is not possible from user mode — only a
+    /// reboot clears it. Terminal; see `stack_down()`.
+    display_stack_down = 6,
   };
 
   struct event_t {
@@ -49,6 +54,28 @@ namespace tdr {
     source_t source;
     long hresult;  ///< Native HRESULT or 0 if not applicable.
     std::string detail;  ///< Free-text context (call_site, attempt count, etc.).
+  };
+
+  /**
+   * @brief One failure incident: a cluster of events, not a raw count.
+   *
+   * A single GPU hang cascades through several detectors and, on a stack
+   * that never recovers, is re-detected on every client attempt. Counting
+   * detections told the user "39 TDR events" for what was one failure.
+   * Events within the incident window fold into the incident that is
+   * already open; the first event after a quiet window opens a new one.
+   */
+  struct incident_t {
+    std::chrono::system_clock::time_point started_at;
+    std::chrono::system_clock::time_point last_at;
+    std::uint64_t events {0};  ///< Detections folded into this incident.
+    source_t first_source;  ///< What detected it first (closest to the cause).
+    source_t last_source;
+    long hresult {0};
+    std::string detail;
+    /// The display stack was confirmed dead (D3D11 + QueryDisplayConfig
+    /// both failing). User-visible remedy is a reboot.
+    bool terminal {false};
   };
 
   /**
@@ -86,7 +113,52 @@ namespace tdr {
   std::optional<event_t> last_event();
 
   /// Total recorded events since process start.
+  ///
+  /// This is a raw detection count and is deliberately NOT what the Web UI
+  /// shows — it exists so in-process consumers can watch for "something
+  /// changed" edges (the LuminalVGD ring drops its shared textures when
+  /// this advances, and the per-session `gpu_resets` telemetry series is
+  /// its delta). Use `incident_count()` / `current_incident()` for
+  /// anything a human reads.
   std::uint64_t event_count();
+
+  /**
+   * @brief Record a confirmed machine-wide display-stack failure.
+   *
+   * Called when a D3D11 device creation failure is corroborated by
+   * QueryDisplayConfig reporting the display API unavailable or zero
+   * paths — i.e. the failure is below every user-mode component and no
+   * amount of retrying will fix it. Latches `stack_down()` until
+   * `note_stack_healthy()` observes the stack working again, so the
+   * retry ladders can stop instead of re-detecting the same corpse every
+   * ~33 seconds.
+   */
+  void mark_stack_down(long hresult, std::string detail);
+
+  /**
+   * @brief Whether the display stack is currently known to be dead.
+   *
+   * Latched by `mark_stack_down`, cleared by `note_stack_healthy`. Call
+   * sites use this to fail fast and loudly (with "reboot required")
+   * instead of burning the backoff ladder per encoder, per attempt.
+   */
+  bool stack_down();
+
+  /**
+   * @brief Report that the display stack was just observed working.
+   *
+   * Clears the terminal latch (a successful D3D11 device creation or a
+   * healthy QueryDisplayConfig proves the stack came back — e.g. the GPU
+   * driver recovered on its own, or the user reset it). Cheap and safe to
+   * call on every success path; it is a no-op when nothing is latched.
+   */
+  void note_stack_healthy();
+
+  /// The incident currently open (or the last one, if it has closed).
+  std::optional<incident_t> current_incident();
+
+  /// Number of distinct incidents since process start.
+  std::uint64_t incident_count();
 
   /// Human-readable label for `source_t` (used by logs and the Web UI).
   const char *source_label(source_t source);

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -37,6 +37,7 @@ extern "C" {
 #include "nvenc/nvenc_base.h"
 #include "platform/common.h"
 #include "sync.h"
+#include "tdr_state.h"
 #include "video.h"
 #include "webrtc_stream.h"
 #ifdef _WIN32
@@ -3668,6 +3669,18 @@ namespace video {
       encoder_probe_attempted.store(true, std::memory_order_release);
       BOOST_LOG(debug) << "Encoder probe skipped (cached success).";
       return 0;
+    }
+
+    // A dead display stack fails every encoder identically, and each
+    // candidate costs ~15 s of D3D11 backoff to re-prove it — ~66 s per
+    // probe pass, re-armed on every client attempt. Bail immediately with
+    // the real diagnosis instead of grinding through the list.
+    if (tdr::stack_down()) {
+      BOOST_LOG(error) << "Skipping encoder probe: the Windows display stack is down "
+                          "(display API unavailable process-wide). No encoder can be "
+                          "initialised until the host machine is rebooted."sv;
+      update_probe_cache(cache_key, false, false, false, false, false, false);
+      return -1;
     }
 
     if (!allow_encoder_probing()) {

--- a/src_assets/common/assets/web/Troubleshooting.vue
+++ b/src_assets/common/assets/web/Troubleshooting.vue
@@ -236,20 +236,61 @@
               {{
                 translate(
                   'troubleshooting.tdr_card_desc',
-                  'Tracks NVIDIA GPU TDR (Timeout Detection and Recovery) events and WDDM display-stack failures that LuminalShine detected. A TDR can end an active stream and momentarily wedge SudoVDA; the active session is refused while recovery is in progress so the client gets a quick failure instead of a frozen stream.',
+                  'Tracks GPU resets (TDR — Timeout Detection and Recovery) and Windows display-stack failures that LuminalShine detected. A GPU reset can end an active stream; new sessions are refused briefly while the driver recovers, so the client gets a quick failure instead of a frozen stream. Repeated detections of the same unresolved failure are grouped into one incident.',
                 )
               }}
             </p>
+            <div
+              v-if="tdrStackDown"
+              class="mt-3 rounded-md border border-error/40 bg-error/10 px-3 py-2 text-xs"
+            >
+              <div class="flex items-center gap-2 font-semibold text-error">
+                <i class="fas fa-circle-exclamation" />
+                {{
+                  translate('troubleshooting.tdr_stack_down_title', 'Display stack down — reboot required')
+                }}
+              </div>
+              <p class="mt-1 opacity-90">
+                {{
+                  translate(
+                    'troubleshooting.tdr_stack_down_body',
+                    "Windows' display API is unavailable for every program on this machine, so no display can be configured or captured. This happens when the graphics driver fails to recover from a GPU reset. Nothing LuminalShine (or any other application) can do will clear it — restart the host machine. Streaming will keep being refused until then.",
+                  )
+                }}
+              </p>
+            </div>
             <div class="mt-2 flex flex-wrap items-center gap-2 text-xs">
               <span
                 class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-dark/5 dark:bg-light/10"
               >
                 <i class="fas fa-bolt" />
-                {{ translate('troubleshooting.tdr_count_label', 'Events since process start') }}:
+                {{ translate('troubleshooting.tdr_count_label', 'Incidents since process start') }}:
                 <strong>{{ tdrCount }}</strong>
               </span>
               <span
-                v-if="tdrRecoveryRecent"
+                v-if="tdrIncidentDurationDisplay"
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-dark/5 dark:bg-light/10"
+              >
+                <i class="fas fa-clock" />
+                {{ translate('troubleshooting.tdr_incident_duration', 'Latest incident lasted') }}:
+                <strong>{{ tdrIncidentDurationDisplay }}</strong>
+              </span>
+              <span
+                v-if="tdrIncident && tdrIncident.events > 1"
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-dark/5 dark:bg-light/10"
+                :title="
+                  translate(
+                    'troubleshooting.tdr_detections_hint',
+                    'How many times the same unresolved failure was re-detected.',
+                  )
+                "
+              >
+                <i class="fas fa-repeat" />
+                {{ translate('troubleshooting.tdr_detections', 'Detections') }}:
+                <strong>{{ tdrIncident.events }}</strong>
+              </span>
+              <span
+                v-if="tdrRecoveryRecent && !tdrStackDown"
                 class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-warning/15 text-warning"
               >
                 <i class="fas fa-triangle-exclamation" />
@@ -887,10 +928,33 @@ type TdrLast = {
   hresult: number;
   detail: string;
 };
+type TdrIncident = {
+  started_at: number;
+  last_at: number;
+  duration_seconds: number;
+  events: number;
+  first_source: string;
+  source: string;
+  terminal: boolean;
+};
 const tdrCount = ref(0);
 const tdrRecoveryRecent = ref(false);
+const tdrStackDown = ref(false);
+const tdrIncident = ref<TdrIncident | null>(null);
 const tdrLast = ref<TdrLast | null>(null);
 const tdrRefreshing = ref(false);
+
+const tdrIncidentDurationDisplay = computed(() => {
+  const inc = tdrIncident.value;
+  if (!inc || inc.duration_seconds <= 0) return '';
+  const total = Math.round(inc.duration_seconds);
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const seconds = total % 60;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+});
 
 const tdrLastAtDisplay = computed(() => {
   if (!tdrLast.value) return '';
@@ -915,6 +979,22 @@ async function refreshTdrHealth() {
     if (r.status >= 200 && r.status < 300) {
       tdrCount.value = typeof body.count === 'number' ? body.count : 0;
       tdrRecoveryRecent.value = body.recovery_recent === true;
+      tdrStackDown.value = body.stack_down === true;
+      const incident = body.incident as Partial<TdrIncident> | undefined;
+      if (incident && typeof incident.started_at === 'number') {
+        tdrIncident.value = {
+          started_at: incident.started_at,
+          last_at: typeof incident.last_at === 'number' ? incident.last_at : incident.started_at,
+          duration_seconds:
+            typeof incident.duration_seconds === 'number' ? incident.duration_seconds : 0,
+          events: typeof incident.events === 'number' ? incident.events : 0,
+          first_source: typeof incident.first_source === 'string' ? incident.first_source : '',
+          source: typeof incident.source === 'string' ? incident.source : '',
+          terminal: incident.terminal === true,
+        };
+      } else {
+        tdrIncident.value = null;
+      }
       const last = body.last as Partial<TdrLast> | undefined;
       if (last && typeof last.at === 'number' && typeof last.source === 'string') {
         tdrLast.value = {

--- a/tests/unit/test_tdr_state.cpp
+++ b/tests/unit/test_tdr_state.cpp
@@ -1,0 +1,107 @@
+/**
+ * @file tests/unit/test_tdr_state.cpp
+ * @brief Incident grouping and terminal-state behaviour of tdr::.
+ *
+ * Regression coverage for the 2026-07-27 incident (POSTMORTEM-2026-07-27.md):
+ * one GPU failure that Windows never recovered from was re-detected ~22
+ * times and reported to the user as "39 TDR events", with no terminal
+ * state to stop the retry ladders. Detections of an unresolved failure
+ * must fold into a single incident, and a confirmed dead display stack
+ * must latch until the stack is observed working again.
+ */
+
+// standard includes
+#include <chrono>
+
+// lib includes
+#include <gtest/gtest.h>
+
+// local includes
+#include "../tests_common.h"
+#include "src/tdr_state.h"
+
+namespace {
+  class TdrState: public ::testing::Test {
+  protected:
+    void SetUp() override {
+      // Process-wide singleton with no reset API by design (a real
+      // incident must survive everything except a restart). Tests take
+      // the state as they find it and assert on deltas.
+      baseline_incidents = tdr::incident_count();
+      baseline_events = tdr::event_count();
+      tdr::note_stack_healthy();
+    }
+
+    void TearDown() override {
+      tdr::note_stack_healthy();
+    }
+
+    std::uint64_t baseline_incidents {0};
+    std::uint64_t baseline_events {0};
+  };
+
+  TEST_F(TdrState, RepeatedDetectionsFoldIntoOneIncident) {
+    tdr::mark_event(tdr::source_t::encoder_stall, 0, "encode wait timeout");
+    const auto after_first = tdr::incident_count();
+    EXPECT_EQ(after_first, baseline_incidents + 1);
+
+    // The same unresolved failure, re-detected by other subsystems and by
+    // later client attempts. These are not new incidents.
+    tdr::mark_event(tdr::source_t::encoder_d3d11, 0x887A0004, "retry ladder exhausted");
+    tdr::mark_event(tdr::source_t::dd_test_d3d11, 0x887A0004, "retry ladder exhausted");
+    tdr::mark_event(tdr::source_t::query_display_config, 0, "QDC unavailable");
+
+    EXPECT_EQ(tdr::incident_count(), after_first)
+      << "re-detections must not open new incidents";
+    EXPECT_EQ(tdr::event_count(), baseline_events + 4)
+      << "raw detection count still advances for the ring/telemetry consumers";
+
+    const auto incident = tdr::current_incident();
+    ASSERT_TRUE(incident.has_value());
+    EXPECT_EQ(incident->events, 4u);
+    // The first detector is the one closest to the cause, and is kept
+    // distinct from whatever detected it most recently.
+    EXPECT_EQ(incident->first_source, tdr::source_t::encoder_stall);
+    EXPECT_EQ(incident->last_source, tdr::source_t::query_display_config);
+    EXPECT_FALSE(incident->terminal) << "nothing confirmed the stack was dead";
+  }
+
+  TEST_F(TdrState, StackDownLatchesAndMarksIncidentTerminal) {
+    EXPECT_FALSE(tdr::stack_down());
+
+    tdr::mark_stack_down(0x887A0004, "QueryDisplayConfig unavailable (status 50, 0 paths)");
+
+    EXPECT_TRUE(tdr::stack_down())
+      << "a confirmed dead stack must latch so retry ladders can stop";
+    const auto incident = tdr::current_incident();
+    ASSERT_TRUE(incident.has_value());
+    EXPECT_TRUE(incident->terminal);
+    EXPECT_EQ(incident->last_source, tdr::source_t::display_stack_down);
+  }
+
+  TEST_F(TdrState, StackHealthyClearsTheLatch) {
+    tdr::mark_stack_down(0x887A0004, "QueryDisplayConfig unavailable");
+    ASSERT_TRUE(tdr::stack_down());
+
+    // The driver recovered on its own, or the user reset it: a successful
+    // device creation proves the stack is back and must not require a
+    // service restart to act on.
+    tdr::note_stack_healthy();
+    EXPECT_FALSE(tdr::stack_down());
+
+    // And a failure after recovery reads as a new incident, not a
+    // continuation of the one that was closed.
+    const auto before = tdr::incident_count();
+    tdr::mark_event(tdr::source_t::encoder_stall, 0, "fresh failure after recovery");
+    EXPECT_EQ(tdr::incident_count(), before + 1);
+  }
+
+  TEST_F(TdrState, SourceLabelCoversEveryEnumerator) {
+    // A missing label silently renders as "unknown" in the Web UI.
+    for (int i = 1; i <= 6; ++i) {
+      const auto src = static_cast<tdr::source_t>(i);
+      EXPECT_STRNE(tdr::source_label(src), "unknown")
+        << "source_t value " << i << " has no label";
+    }
+  }
+}  // namespace


### PR DESCRIPTION
Second beta.6 stability fix — postmortem blockers 1 and 2 (`POSTMORTEM-2026-07-27.md`).

## What was wrong

One GPU hang with failed OS recovery was re-detected for 96 minutes on 7/27:
- `0x887A0004` (`DXGI_ERROR_UNSUPPORTED`) was unconditionally classified as "GPU TDR recovery suspected" ([display_base.cpp:518](../blob/main/src/platform/windows/display_base.cpp#L518) was the single load-bearing line).
- Each of the 5 encoder candidates burned the full ~15 s D3D11 backoff ladder per probe pass (~66 s/encoder), re-armed on every client attempt, with no exit condition.
- The pre-flight session gate recorded its own probe failures as TDR events, feeding the 30 s `recovery_recent()` window that refused the *next* session — self-sustaining forever on a dead stack.
- The health card counted detections: **"39 TDR events"** for one failure.

## What this does

**Evidence-based classification.** After the retry ladder exhausts, a raw `GetDisplayConfigBufferSizes` probe (deliberately not the libdisplaydevice wrapper, which retries internally and discards the error) decides the verdict:
- Display API dead / zero paths → **terminal `display stack down`** state: latched, loud, "reboot required" in the log, the session refusal, and the web UI.
- Display API healthy + `DEVICE_REMOVED` → a real GPU reset (recorded as before).
- Display API healthy + `UNSUPPORTED` → an environment/capability error — logged plainly, **never** recorded as TDR (a false verdict here also forced the LuminalVGD ring to drop its shared textures mid-stream via the `event_count()` watcher).

**Bounded behaviour while terminal.** The D3D11 ladder returns immediately instead of sleeping through its schedule; `probe_encoders_impl` refuses to grind the candidate list; `rtsp_stream::start` tells the client the host needs a reboot. Any successful device creation calls `note_stack_healthy()` — recovery never needs a service restart.

**Incidents, not counters.** `tdr::` now groups detections into incidents (start, duration, first/last source, terminal flag; 5-minute fold window). `/api/health/tdr` reports `count` = incidents, `detections` = raw, `stack_down`, and an `incident` object. The raw `event_count()` and its consumers (ring reinit trigger, `gpu_resets` telemetry series) are semantically unchanged. The Troubleshooting card shows incidents + duration + a prominent red "Display stack down — reboot required" banner.

## Verification

- `luminalshine.exe` + `test_sunshine` build clean.
- New `TdrState` unit tests: detection folding, terminal latch + clear, new-incident-after-recovery, label completeness — all pass, plus the SimpleWebLifetime stress test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)