### PR TITLE
feat: LuminalVGD-native virtual display diagnostic and recovery

### DIFF
--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -148,6 +148,8 @@ set(PLATFORM_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/platform/windows/virtual_display_backend.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/virtual_display_vgd.h"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/virtual_display_vgd.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/vgd_recovery.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/vgd_recovery.cpp"
         "${CMAKE_SOURCE_DIR}/third-party/sudovda/sudovda-ioctl.h"
         "${CMAKE_SOURCE_DIR}/third-party/sudovda/sudovda.h"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/frame_limiter.h"

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -62,6 +62,7 @@
   #include "amf/amf_caps.h"
   #include "platform/windows/render_stack_detect.h"
   #include "platform/windows/sudovda_recovery.h"
+  #include "platform/windows/vgd_recovery.h"
 #endif
 #include "cred_store/cred_store.h"
 #include "entry_handler.h"
@@ -709,16 +710,17 @@ namespace confighttp {
 
 #ifdef _WIN32
   /**
-   * @brief Manually restart the SudoVDA virtual display driver via the
-   *        PnP disable+enable cycle. Used as a recovery escape hatch
-   *        when the auto-ladder hasn't yet fired and the user knows or
-   *        suspects the virtual display is wedged.
+   * @brief Manually restart the LuminalVGD virtual display driver: destroy
+   *        the tracked monitor sessions and recycle the control handle,
+   *        escalating to a PnP disable+enable of `root\luminal_vgd` if the
+   *        driver still doesn't answer. A recovery escape hatch for when
+   *        the virtual display is wedged.
    *
    * Authenticated. POST so it can't be triggered by accidental
    * navigation. Body is ignored. Response includes the recovery level
    * that ran and a human-readable message suitable for support tickets.
    *
-   * @api_examples{/api/state/vdd-restart| POST| {"status":true,"level":2,"message":"PnP disable+enable completed; user handle recycled.","instance_id":"ROOT\\SUDOMAKER\\SUDOVDA\\0000"}}
+   * @api_examples{/api/state/vdd-restart| POST| {"status":true,"level":1,"message":"Virtual display sessions were destroyed and the driver connection was re-established.","instance_id":"ROOT\\LUMINAL_VGD\\0000"}}
    */
   void restartVirtualDisplayDriver(resp_https_t response, req_https_t request) {
     if (!check_content_type(response, request, "application/json")) {
@@ -729,7 +731,11 @@ namespace confighttp {
     }
     print_req(request);
 
-    const auto result = platf::sudovda::manual_restart();
+    // Logged server-side: in every log from the field this endpoint had
+    // never once been invoked, and there was no way to tell whether that
+    // meant "nobody clicked" or "the click never arrived".
+    BOOST_LOG(info) << "Virtual display driver restart requested from the Web UI.";
+    const auto result = platf::vgd_recovery::manual_restart();
 
     nlohmann::json out;
     out["status"] = result.success;
@@ -750,7 +756,7 @@ namespace confighttp {
    *
    * Authenticated. GET so the Vue view can refresh it freely.
    *
-   * @api_examples{/api/state/vdd-diagnostic| GET| {"status":true,"device_present":true,"instance_id":"ROOT\\SUDOMAKER\\SUDOVDA\\0000","hardware_ids":"root\\sudomaker\\sudovda","status_string":"Healthy (DN_STARTED)","problem_code":0}}
+   * @api_examples{/api/state/vdd-diagnostic| GET| {"status":true,"driver_reachable":true,"handshake_ok":true,"driver_version":"proto 0.3 build 13","device_present":true,"instance_id":"ROOT\\LUMINAL_VGD\\0000","hardware_ids":"root\\luminal_vgd","status_string":"Healthy (DN_STARTED, driver handshake OK)","problem_code":0}}
    */
   void getVirtualDisplayDiagnostic(resp_https_t response, req_https_t request) {
     if (!authenticate(response, request)) {
@@ -758,20 +764,26 @@ namespace confighttp {
     }
     print_req(request);
 
-    const auto diag = platf::sudovda::collect_diagnostic();
+    const auto diag = platf::vgd_recovery::collect_diagnostic();
 
     nlohmann::json out;
     out["status"] = true;
+    // Driver-side truth: whether the control device answers is what
+    // actually decides if virtual displays work. The old card reported
+    // only PnP presence — of a device this product no longer installs.
+    out["driver_reachable"] = diag.driver_reachable;
+    out["handshake_ok"] = diag.handshake_ok;
+    out["driver_version"] = diag.driver_version;
+    if (diag.last_error) {
+      out["last_error"] = static_cast<std::uint64_t>(diag.last_error);
+    }
     out["device_present"] = diag.device_present;
     out["instance_id"] = diag.instance_id;
     out["hardware_ids"] = diag.hardware_ids;
     out["status_string"] = diag.status_string;
-    out["problem_code"] = diag.problem_code;
+    out["problem_code"] = static_cast<std::uint64_t>(diag.problem_code);
     if (diag.last_recovery_at) {
-      const auto secs = std::chrono::duration_cast<std::chrono::seconds>(
-        diag.last_recovery_at->time_since_epoch()
-      ).count();
-      out["last_recovery_at"] = secs;
+      out["last_recovery_at"] = diag.last_recovery_at;
     }
     out["last_recovery_level"] = static_cast<int>(diag.last_recovery_level);
     out["last_recovery_message"] = diag.last_recovery_message;

--- a/src/platform/windows/vgd_recovery.cpp
+++ b/src/platform/windows/vgd_recovery.cpp
@@ -1,0 +1,232 @@
+/**
+ * @file src/platform/windows/vgd_recovery.cpp
+ * @brief LuminalVGD diagnostics + manual recovery (see vgd_recovery.h).
+ */
+// standard includes
+#include <chrono>
+#include <mutex>
+#include <thread>
+
+// platform includes
+#include <winsock2.h>
+#include <windows.h>
+
+#include <cfgmgr32.h>
+
+// local includes
+#include "src/logging.h"
+#include "src/platform/windows/misc.h"
+#include "src/platform/windows/virtual_display.h"
+#include "src/platform/windows/virtual_display_backend.h"
+#include "src/platform/windows/virtual_display_vgd.h"
+#include "src/platform/windows/vgd_recovery.h"
+
+// The device-node helpers live in virtual_display.cpp's anonymous
+// namespace; these thin forwarders are declared alongside the SudoVDA
+// ones (see VDISPLAY::recovery_bridge there).
+namespace VDISPLAY::recovery_bridge {
+  std::optional<std::wstring> luminal_vgd_instance_id();
+  bool device_pnp_restart(const std::wstring &id);
+  bool device_is_disabled(const std::wstring &id);
+  std::string device_collect_hardware_ids(const std::wstring &id);
+}  // namespace VDISPLAY::recovery_bridge
+
+namespace platf::vgd_recovery {
+
+  namespace {
+    std::mutex g_mutex;
+    long long g_last_recovery_at {0};
+    recovery_level_t g_last_recovery_level {recovery_level_t::none};
+    std::string g_last_recovery_message;
+
+    /// Time for the device to settle after a PnP cycle before we decide
+    /// whether the handshake came back.
+    constexpr auto kPnpSettleDelay = std::chrono::milliseconds(1500);
+
+    void record_last_recovery(recovery_level_t level, const std::string &message) {
+      const auto now = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::system_clock::now().time_since_epoch()
+      ).count();
+      std::lock_guard<std::mutex> lk(g_mutex);
+      g_last_recovery_at = static_cast<long long>(now);
+      g_last_recovery_level = level;
+      g_last_recovery_message = message;
+    }
+
+    /// Close and reopen the control device, re-running the handshake.
+    bool recycle_control_handle() {
+      VDISPLAY::vgd::close_device();
+      return VDISPLAY::vgd::driver_ready();
+    }
+  }  // namespace
+
+  diagnostic_t collect_diagnostic() {
+    diagnostic_t d {};
+
+    {
+      std::lock_guard<std::mutex> lk(g_mutex);
+      d.last_recovery_at = g_last_recovery_at;
+      d.last_recovery_level = g_last_recovery_level;
+      d.last_recovery_message = g_last_recovery_message;
+    }
+
+    // Driver-side truth first: whether the control device answers is what
+    // actually determines if virtual displays work. The PnP node can look
+    // healthy while the control ACL refuses us (the 2026-07 outage), and
+    // it can look odd while streaming works fine.
+    d.driver_reachable = VDISPLAY::vgd::driver_appears_installed();
+    if (d.driver_reachable) {
+      d.handshake_ok = VDISPLAY::vgd::driver_ready();
+      if (auto version = VDISPLAY::vgd::driver_version_string(); version) {
+        d.driver_version = *version;
+      }
+    } else {
+      d.last_error = GetLastError();
+    }
+
+    auto instance = VDISPLAY::recovery_bridge::luminal_vgd_instance_id();
+    if (!instance) {
+      d.status_string = d.handshake_ok
+        ? "Driver responding, but no root\\luminal_vgd device node was found"
+        : "Not present";
+      return d;
+    }
+
+    d.device_present = true;
+    d.instance_id = platf::to_utf8(*instance);
+    d.hardware_ids = VDISPLAY::recovery_bridge::device_collect_hardware_ids(*instance);
+
+    DEVINST dev_inst = 0;
+    CONFIGRET cr = CM_Locate_DevNodeW(
+      &dev_inst,
+      const_cast<DEVINSTID_W>(instance->c_str()),
+      CM_LOCATE_DEVNODE_NORMAL
+    );
+    if (cr != CR_SUCCESS) {
+      cr = CM_Locate_DevNodeW(
+        &dev_inst,
+        const_cast<DEVINSTID_W>(instance->c_str()),
+        CM_LOCATE_DEVNODE_PHANTOM
+      );
+    }
+    if (cr == CR_SUCCESS) {
+      ULONG status = 0, problem = 0;
+      if (CM_Get_DevNode_Status(&status, &problem, dev_inst, 0) == CR_SUCCESS) {
+        d.problem_code = problem;
+        if (status & DN_HAS_PROBLEM) {
+          if (problem == CM_PROB_DISABLED) {
+            d.status_string = "Disabled (CM_PROB_DISABLED, code 22). "
+                              "Use \"Restart Virtual Display Driver\" to re-enable.";
+          } else {
+            d.status_string = "Has problem (CM_PROB code " + std::to_string(problem) + ")";
+          }
+        } else if (status & DN_STARTED) {
+          d.status_string = d.handshake_ok
+            ? "Healthy (DN_STARTED, driver handshake OK)"
+            : "Started, but the driver did not answer a handshake";
+        } else {
+          d.status_string = "Present but not started";
+        }
+      } else {
+        d.status_string = "Present (CM_Get_DevNode_Status failed)";
+      }
+    } else {
+      d.status_string = "Present (CM_Locate_DevNodeW failed, cr=" + std::to_string(cr) + ")";
+    }
+
+    return d;
+  }
+
+  recovery_result_t manual_restart(bool allow_pnp_cycle) {
+    recovery_result_t result {};
+
+    if (!VDISPLAY::is_luminalvgd_active()) {
+      result.message = "LuminalVGD is not the active virtual display backend; "
+                       "nothing to restart.";
+      BOOST_LOG(warning) << "Virtual display restart requested, but " << result.message;
+      record_last_recovery(recovery_level_t::none, result.message);
+      return result;
+    }
+
+    if (auto instance = VDISPLAY::recovery_bridge::luminal_vgd_instance_id(); instance) {
+      result.instance_id = platf::to_utf8(*instance);
+    }
+
+    // Level 1 — drop every monitor this process owns, then recycle the
+    // control handle so the next create starts from a fresh handshake.
+    // This is the level that clears the states we can actually cause:
+    // leaked sessions, a stale device binding after a driver update.
+    BOOST_LOG(info) << "LuminalVGD recovery: level 1 (destroy tracked sessions + "
+                       "recycle control handle). Active streaming sessions using a "
+                       "virtual display will end.";
+    VDISPLAY::vgd::remove_all_virtual_displays();
+    if (recycle_control_handle()) {
+      result.success = true;
+      result.level = recovery_level_t::session_reset;
+      result.message = "Virtual display sessions were destroyed and the driver "
+                       "connection was re-established.";
+      if (auto version = VDISPLAY::vgd::driver_version_string(); version) {
+        result.message += " Driver reports " + *version + ".";
+      }
+      BOOST_LOG(info) << "LuminalVGD recovery succeeded at level 1: " << result.message;
+      record_last_recovery(result.level, result.message);
+      return result;
+    }
+
+    BOOST_LOG(warning) << "LuminalVGD recovery: control handle did not come back after "
+                          "a session reset.";
+
+    if (!allow_pnp_cycle) {
+      result.message = "Virtual display sessions were destroyed, but the driver did not "
+                       "respond to a handshake afterwards.";
+      record_last_recovery(recovery_level_t::session_reset, result.message);
+      return result;
+    }
+
+    // Level 2 — PnP disable/enable of the device node. Heavier: it tears
+    // down the device for every process, so it only runs once the lighter
+    // path has demonstrably failed.
+    auto instance = VDISPLAY::recovery_bridge::luminal_vgd_instance_id();
+    if (!instance) {
+      result.message = "The LuminalVGD device (root\\luminal_vgd) is not present in the "
+                       "PnP tree. The driver may have been uninstalled — run "
+                       "\"Reconfigure LuminalShine\" from the Start Menu to reinstall it.";
+      BOOST_LOG(error) << "LuminalVGD recovery failed: " << result.message;
+      record_last_recovery(recovery_level_t::session_reset, result.message);
+      return result;
+    }
+
+    BOOST_LOG(info) << "LuminalVGD recovery: level 2 (PnP disable+enable) on instance "
+                    << result.instance_id;
+    const bool cycled = VDISPLAY::recovery_bridge::device_pnp_restart(*instance);
+    std::this_thread::sleep_for(kPnpSettleDelay);
+    result.level = recovery_level_t::pnp_restart;
+
+    if (!cycled) {
+      if (VDISPLAY::recovery_bridge::device_is_disabled(*instance)) {
+        result.message = "The PnP restart left the LuminalVGD device disabled. "
+                         "Re-enable it in Device Manager, or reboot the machine.";
+      } else {
+        result.message = "The PnP disable+enable cycle failed; the driver may be "
+                         "unresponsive. A reboot may be required.";
+      }
+      BOOST_LOG(error) << "LuminalVGD recovery failed: " << result.message;
+      record_last_recovery(result.level, result.message);
+      return result;
+    }
+
+    if (recycle_control_handle()) {
+      result.success = true;
+      result.message = "The LuminalVGD device was restarted and the driver is "
+                       "responding again.";
+      BOOST_LOG(info) << "LuminalVGD recovery succeeded at level 2.";
+    } else {
+      result.message = "The device was restarted, but the driver still does not answer "
+                       "a handshake. A reboot may be required.";
+      BOOST_LOG(error) << "LuminalVGD recovery: " << result.message;
+    }
+    record_last_recovery(result.level, result.message);
+    return result;
+  }
+
+}  // namespace platf::vgd_recovery

--- a/src/platform/windows/vgd_recovery.h
+++ b/src/platform/windows/vgd_recovery.h
@@ -1,0 +1,92 @@
+/**
+ * @file src/platform/windows/vgd_recovery.h
+ * @brief Diagnostics and manual recovery for the LuminalVGD virtual
+ *        display driver.
+ *
+ * Replaces the legacy SudoVDA equivalents (sudovda_recovery.h). Those
+ * probed `root\sudomaker\sudovda` — a device this product no longer
+ * installs and actively removes — so on every LuminalVGD host they
+ * reported "Not present" while the real driver was handshaking fine in
+ * the same process, and the recovery ladder they drove bailed on its
+ * first step. During the 2026-07-27 display-stack failure that meant the
+ * Troubleshooting page told the user their virtual display driver was
+ * missing, and offered a "Restart Virtual Display Driver" button that
+ * could not do anything.
+ *
+ * The recovery here works with what LuminalVGD actually exposes:
+ * destroying the tracked monitor sessions, recycling the control-device
+ * handle (which re-runs the handshake), and — only as a last resort —
+ * PnP-cycling the `root\luminal_vgd` device node.
+ */
+#pragma once
+
+#include <string>
+
+namespace platf::vgd_recovery {
+
+  enum class recovery_level_t : int {
+    /// Nothing ran (driver absent, or already healthy on a probe-only call).
+    none = 0,
+    /// Tracked monitor sessions destroyed and the control handle recycled;
+    /// the next create re-handshakes against a fresh device binding.
+    session_reset = 1,
+    /// The `root\luminal_vgd` device node was PnP-disabled and re-enabled.
+    pnp_restart = 2,
+  };
+
+  struct recovery_result_t {
+    bool success {false};
+    recovery_level_t level {recovery_level_t::none};
+    /// Human-readable summary, surfaced verbatim in the Web UI.
+    std::string message;
+    /// Device instance ID at the time of the call, when known.
+    std::string instance_id;
+  };
+
+  struct diagnostic_t {
+    /// The control device could be opened (driver installed and reachable).
+    bool driver_reachable {false};
+    /// A handshake succeeded and returned protocol/build info.
+    bool handshake_ok {false};
+    /// "proto <maj>.<min> build <n>" when the handshake succeeded.
+    std::string driver_version;
+    /// Win32 error from the last failing FFI call, when the driver could
+    /// not be opened. 5 (access denied) is the signature of the control
+    /// ACL refusing a non-SYSTEM caller.
+    unsigned long last_error {0};
+
+    /// The device node exists in the PnP tree.
+    bool device_present {false};
+    std::string instance_id;
+    std::string hardware_ids;
+    /// Human-readable device state ("Healthy (DN_STARTED)", "Disabled
+    /// (CM_PROB_DISABLED, code 22)", "Not present", ...).
+    std::string status_string;
+    unsigned long problem_code {0};
+
+    /// Last recovery this process ran, for support bundles. `at` is a
+    /// Unix timestamp, 0 when nothing has run.
+    long long last_recovery_at {0};
+    recovery_level_t last_recovery_level {recovery_level_t::none};
+    std::string last_recovery_message;
+  };
+
+  /// Snapshot of driver + device state for the Troubleshooting card and
+  /// the support-diagnostic copy button. Never throws.
+  diagnostic_t collect_diagnostic();
+
+  /**
+   * @brief User-initiated recovery ("Restart Virtual Display Driver").
+   *
+   * Destroys every tracked monitor session, closes and reopens the
+   * control device (re-running the handshake), and falls back to a PnP
+   * disable/enable cycle of `root\luminal_vgd` if the handshake still
+   * fails. Any active streaming session using a virtual display ends.
+   *
+   * @param allow_pnp_cycle When false, stop after the session reset —
+   *        used by automatic paths that must not yank the device out
+   *        from under an unrelated caller.
+   */
+  recovery_result_t manual_restart(bool allow_pnp_cycle = true);
+
+}  // namespace platf::vgd_recovery

--- a/src/platform/windows/virtual_display.cpp
+++ b/src/platform/windows/virtual_display.cpp
@@ -10,6 +10,7 @@
 #include "src/platform/windows/virtual_display_backend.h"
 #include "src/platform/windows/virtual_display_vgd.h"
 #include "src/platform/windows/sudovda_recovery.h"
+#include "src/platform/windows/vgd_recovery.h"
 #include "src/process.h"
 #include "src/rtsp.h"
 #include "src/state_storage.h"
@@ -90,6 +91,10 @@ namespace VDISPLAY {
     constexpr auto ENSURE_DISPLAY_RETENTION_TIMEOUT = std::chrono::minutes(3);
     constexpr std::wstring_view SUDOVDA_HARDWARE_ID = L"root\\sudomaker\\sudovda";
     constexpr std::wstring_view SUDOVDA_FRIENDLY_NAME_W = L"SudoMaker Virtual Display Adapter";
+    /// LuminalVGD's root-enumerated device (see the driver INF). The UMDF
+    /// service name is always WUDFRd, so the hardware ID is the only
+    /// reliable way to find this device node.
+    constexpr std::wstring_view LUMINAL_VGD_HARDWARE_ID = L"root\\luminal_vgd";
 
     std::atomic<bool> g_watchdog_feed_requested {false};
     std::atomic<bool> g_watchdog_stop_requested {false};
@@ -572,11 +577,19 @@ namespace VDISPLAY {
       return system_root + L"\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
     }
 
-    std::optional<std::wstring> find_sudovda_device_instance_id() {
+    /// Locate a display-class device node by hardware ID. `friendly_name`
+    /// is an optional secondary match (SudoVDA installs were seen in the
+    /// field with a rewritten hardware ID but an intact friendly name);
+    /// pass an empty view to match on the hardware ID alone.
+    std::optional<std::wstring> find_display_device_instance_id(
+      std::wstring_view hardware_id,
+      std::wstring_view friendly_name,
+      const char *what) {
       DevInfoHandle info(SetupDiGetClassDevsW(&GUID_DEVCLASS_DISPLAY, nullptr, nullptr, DIGCF_PRESENT));
       if (!info.valid()) {
         const DWORD err = GetLastError();
-        BOOST_LOG(warning) << "Failed to acquire display device info set for SudoVDA lookup (error=" << err << ")";
+        BOOST_LOG(warning) << "Failed to acquire display device info set for " << what
+                           << " lookup (error=" << err << ")";
         return std::nullopt;
       }
 
@@ -588,19 +601,20 @@ namespace VDISPLAY {
         if (!SetupDiEnumDeviceInfo(info.get(), index, &device_info)) {
           const DWORD err = GetLastError();
           if (err != ERROR_NO_MORE_ITEMS) {
-            BOOST_LOG(warning) << "SetupDiEnumDeviceInfo failed while scanning for SudoVDA (error=" << err << ")";
+            BOOST_LOG(warning) << "SetupDiEnumDeviceInfo failed while scanning for " << what
+                               << " (error=" << err << ")";
           }
           break;
         }
 
         bool matches = false;
         if (load_device_property_multi_sz(info.get(), device_info, SPDRP_HARDWAREID, hardware_ids)) {
-          matches = multi_sz_contains_ci(hardware_ids, SUDOVDA_HARDWARE_ID);
+          matches = multi_sz_contains_ci(hardware_ids, hardware_id);
         }
 
-        if (!matches) {
+        if (!matches && !friendly_name.empty()) {
           if (auto friendly = load_device_property_string(info.get(), device_info, SPDRP_FRIENDLYNAME)) {
-            matches = equals_ci(*friendly, SUDOVDA_FRIENDLY_NAME_W);
+            matches = equals_ci(*friendly, friendly_name);
           }
         }
 
@@ -614,6 +628,16 @@ namespace VDISPLAY {
       }
 
       return std::nullopt;
+    }
+
+    std::optional<std::wstring> find_sudovda_device_instance_id() {
+      return find_display_device_instance_id(SUDOVDA_HARDWARE_ID, SUDOVDA_FRIENDLY_NAME_W, "SudoVDA");
+    }
+
+    std::optional<std::wstring> find_luminal_vgd_device_instance_id() {
+      // Hardware ID only: the friendly name is user-visible and can be
+      // renamed, and there is exactly one root\luminal_vgd node.
+      return find_display_device_instance_id(LUMINAL_VGD_HARDWARE_ID, {}, "LuminalVGD");
     }
 
     /**
@@ -837,11 +861,23 @@ namespace VDISPLAY {
       return is_device_disabled(id);
     }
 
+    std::optional<std::wstring> luminal_vgd_instance_id() {
+      return find_luminal_vgd_device_instance_id();
+    }
+
+    bool device_pnp_restart(const std::wstring &id) {
+      return restart_sudovda_device(id);
+    }
+
+    bool device_is_disabled(const std::wstring &id) {
+      return is_device_disabled(id);
+    }
+
     bool sudovda_try_reenable(const std::wstring &id) {
       return try_reenable_disabled_device(id);
     }
 
-    std::string sudovda_collect_hardware_ids(const std::wstring &id) {
+    std::string device_collect_hardware_ids(const std::wstring &id) {
       DevInfoHandle dev_set(SetupDiGetClassDevsW(nullptr, nullptr, nullptr, DIGCF_ALLCLASSES));
       if (!dev_set.valid()) {
         return {};
@@ -865,6 +901,10 @@ namespace VDISPLAY {
         cursor += wcslen(cursor) + 1;
       }
       return joined;
+    }
+
+    std::string sudovda_collect_hardware_ids(const std::wstring &id) {
+      return device_collect_hardware_ids(id);
     }
   }  // namespace recovery_bridge
 
@@ -4170,18 +4210,19 @@ namespace VDISPLAY {
       // to recycle the driver. The reset itself is idempotent but the
       // close+open pair shouldn't race.
       //
-      // Escalate through the full recovery ladder: Level 1 (handle
-      // recycle) every time, Level 2 (PnP disable+enable) at most once
-      // per 5 minutes per the ladder's internal cooldown. When the WDDM
-      // stack is wedged after a TDR, Level 1 alone usually isn't enough
-      // — the user's 2026-05-17 incident exhausted three full Level-1
-      // cycles before the session aborted. Letting the ladder escalate
-      // is the actual fix.
-      const auto recovery = platf::sudovda::run_recovery_ladder(
-        platf::sudovda::recovery_level_t::pnp_restart,
-        /*force=*/false
-      );
-      BOOST_LOG(info) << "SudoVDA recovery ladder result: level="
+      // Recover against the driver that is actually installed. This used
+      // to call the SudoVDA ladder, which on a LuminalVGD host bailed on
+      // its first step ("device not present in PnP tree") every single
+      // time — so the automatic recovery path had never once run during
+      // the incidents it was written for.
+      //
+      // The PnP cycle is deliberately withheld here: this path fires from
+      // display enumeration, which can be several layers deep inside an
+      // unrelated caller, and yanking the device node out from under it
+      // is worse than reporting failure. The user-initiated restart in
+      // the Troubleshooting page still escalates that far.
+      const auto recovery = platf::vgd_recovery::manual_restart(/*allow_pnp_cycle=*/false);
+      BOOST_LOG(info) << "LuminalVGD recovery result: level="
                       << static_cast<int>(recovery.level)
                       << " success=" << (recovery.success ? "true" : "false")
                       << " — " << recovery.message;
@@ -4447,6 +4488,14 @@ namespace VDISPLAY {
     bool sudovda_is_disabled(const std::wstring &id);
     bool sudovda_try_reenable(const std::wstring &id);
     std::string sudovda_collect_hardware_ids(const std::wstring &id);
+
+    /// Same helpers pointed at the first-party driver's device node.
+    /// `device_pnp_restart` / `device_is_disabled` are hardware-agnostic
+    /// (they take an instance ID), so only the lookup differs.
+    std::optional<std::wstring> luminal_vgd_instance_id();
+    bool device_pnp_restart(const std::wstring &id);
+    bool device_is_disabled(const std::wstring &id);
+    std::string device_collect_hardware_ids(const std::wstring &id);
   }  // namespace recovery_bridge
 }  // namespace VDISPLAY
 

--- a/src_assets/common/assets/web/Troubleshooting.vue
+++ b/src_assets/common/assets/web/Troubleshooting.vue
@@ -364,20 +364,42 @@
         <div class="flex items-start justify-between gap-4 flex-wrap">
           <div class="min-w-0">
             <h2 class="text-base font-semibold text-dark dark:text-light">
-              {{ translate('troubleshooting.vdd_card_title', 'Virtual Display Driver') }}
+              {{ translate('troubleshooting.vdd_card_title', 'Virtual Display Driver (LuminalVGD)') }}
             </h2>
             <p class="text-xs opacity-70 leading-snug">
               {{
                 translate(
                   'troubleshooting.vdd_card_desc',
-                  'Manual recovery for the SudoVDA virtual display driver. Use "Restart Virtual Display Driver" to PnP-disable and re-enable the SudoVDA root device (same as right-click Disable / Enable in Device Manager, but run as SYSTEM and scoped to SudoVDA only — other devices are not touched). Active streaming sessions will be torn down. Use "Show Diagnostic" to copy SudoVDA status into a support ticket without opening Device Manager.',
+                  'Manual recovery for the LuminalVGD virtual display driver. "Restart Virtual Display Driver" destroys the tracked virtual monitors and reconnects to the driver, escalating to a device restart (same as Disable / Enable in Device Manager, scoped to LuminalVGD only) if the driver still does not respond. Active streaming sessions using a virtual display will end. Use "Show Diagnostic" to copy the driver status into a support ticket.',
                 )
               }}
             </p>
             <div v-if="vddDiag" class="mt-2 text-xs space-y-1">
               <div>
                 <span class="opacity-70"
-                  >{{ translate('troubleshooting.vdd_status', 'Status') }}:</span
+                  >{{ translate('troubleshooting.vdd_driver', 'Driver') }}:</span
+                >
+                <span class="ml-1">
+                  <template v-if="vddDiag.handshake_ok">
+                    {{ translate('troubleshooting.vdd_driver_ok', 'Responding') }}
+                    <span v-if="vddDiag.driver_version" class="font-mono"
+                      >({{ vddDiag.driver_version }})</span
+                    >
+                  </template>
+                  <template v-else-if="vddDiag.driver_reachable">
+                    {{ translate('troubleshooting.vdd_driver_no_handshake', 'Reachable, but handshake failed') }}
+                  </template>
+                  <template v-else>
+                    {{ translate('troubleshooting.vdd_driver_unreachable', 'Not reachable') }}
+                    <span v-if="vddDiag.last_error" class="font-mono"
+                      >(error {{ vddDiag.last_error }})</span
+                    >
+                  </template>
+                </span>
+              </div>
+              <div>
+                <span class="opacity-70"
+                  >{{ translate('troubleshooting.vdd_status', 'Device') }}:</span
                 >
                 <span class="ml-1">{{ vddDiag.status_string }}</span>
               </div>
@@ -1014,8 +1036,12 @@ async function refreshTdrHealth() {
   }
 }
 
-// Virtual Display Driver (SudoVDA) recovery card state.
+// Virtual Display Driver (LuminalVGD) recovery card state.
 type VddDiagnostic = {
+  driver_reachable: boolean;
+  handshake_ok: boolean;
+  driver_version: string;
+  last_error?: number;
   device_present: boolean;
   instance_id: string;
   hardware_ids: string;
@@ -1039,6 +1065,10 @@ async function refreshVddDiagnostic() {
     const body = (r.data || {}) as Partial<VddDiagnostic> & { status?: boolean };
     if (r.status >= 200 && r.status < 300 && body.status !== false) {
       vddDiag.value = {
+        driver_reachable: body.driver_reachable === true,
+        handshake_ok: body.handshake_ok === true,
+        driver_version: typeof body.driver_version === 'string' ? body.driver_version : '',
+        last_error: typeof body.last_error === 'number' ? body.last_error : undefined,
         device_present: body.device_present === true,
         instance_id: typeof body.instance_id === 'string' ? body.instance_id : '',
         hardware_ids: typeof body.hardware_ids === 'string' ? body.hardware_ids : '',
@@ -1061,8 +1091,17 @@ async function refreshVddDiagnostic() {
 
 function formatVddDiagnosticText(d: VddDiagnostic): string {
   const lines: string[] = [];
-  lines.push('SudoVDA Virtual Display Driver diagnostic');
-  lines.push('=========================================');
+  lines.push('LuminalVGD Virtual Display Driver diagnostic');
+  lines.push('============================================');
+  lines.push(
+    `Driver:          ${
+      d.handshake_ok
+        ? `responding${d.driver_version ? ` (${d.driver_version})` : ''}`
+        : d.driver_reachable
+          ? 'reachable, handshake failed'
+          : `not reachable${d.last_error ? ` (error ${d.last_error})` : ''}`
+    }`,
+  );
   lines.push(`Device present:  ${d.device_present ? 'yes' : 'no'}`);
   lines.push(`Status:          ${d.status_string}`);
   if (d.instance_id) lines.push(`Instance ID:     ${d.instance_id}`);
@@ -1071,7 +1110,7 @@ function formatVddDiagnosticText(d: VddDiagnostic): string {
   if (d.last_recovery_at) {
     const ts = new Date(d.last_recovery_at * 1000).toLocaleString();
     const levelLabel =
-      ['none', 'handle recycle', 'PnP restart'][d.last_recovery_level] ??
+      ['none', 'session reset', 'PnP restart'][d.last_recovery_level] ??
       String(d.last_recovery_level);
     lines.push(`Last recovery:   ${ts} (${levelLabel})`);
     if (d.last_recovery_message) {
@@ -1090,7 +1129,7 @@ async function showVddDiagnostic() {
       title: translate('troubleshooting.vdd_diag_error', 'Could not collect diagnostic'),
       content: translate(
         'troubleshooting.vdd_diag_error_body',
-        'The SudoVDA diagnostic endpoint did not return data. Check the LuminalShine log for details.',
+        'The virtual display diagnostic endpoint did not return data. Check the LuminalShine log for details.',
       ),
       positiveText: translate('troubleshooting.close', 'Close'),
     });
@@ -1098,7 +1137,7 @@ async function showVddDiagnostic() {
   }
   const text = formatVddDiagnosticText(d);
   dialog.info({
-    title: translate('troubleshooting.vdd_diag_title', 'SudoVDA Diagnostic'),
+    title: translate('troubleshooting.vdd_diag_title', 'LuminalVGD Diagnostic'),
     content: () =>
       h(
         'pre',
@@ -1417,7 +1456,7 @@ function confirmRestartVdd() {
     ),
     content: translate(
       'troubleshooting.vdd_restart_confirm_body',
-      'This PnP-disables and re-enables the SudoVDA virtual display device. Any active streaming session using a virtual display will be ended; the Moonlight client will need to reconnect. Other devices are not affected.',
+      'This destroys the tracked virtual monitors and reconnects to the LuminalVGD driver, restarting the device if needed. Any active streaming session using a virtual display will be ended; the Moonlight client will need to reconnect. Other devices are not affected.',
     ),
     positiveText: translate('troubleshooting.vdd_restart_yes', 'Restart driver'),
     negativeText: translate('troubleshooting.cancel', 'Cancel'),


### PR DESCRIPTION
Third beta.6 stability fix — postmortem blocker 3 (hypothesis H7, **Confirmed**: "vdd-diagnostic card is dead SudoVDA legacy; restart never executed").

## What was wrong

The Troubleshooting page's Virtual Display Driver card and the automatic QDC-wedge recovery still targeted **SudoVDA** — a driver this product no longer installs and actively removes:
- The card probed `root\sudomaker\sudovda` → **"Not present"** while LuminalVGD was handshaking fine in the same process.
- The "Restart Virtual Display Driver" button drove a ladder that bailed at "device not present in PnP tree" on its first step — it had **never once done anything useful** on a LuminalVGD host.
- The automatic QDC-wedge handler called the same inert ladder, so the auto-recovery path had never executed during the incidents it was written for.

## What this does

New `platf::vgd_recovery` module ([vgd_recovery.h](../blob/feat/vgd-native-recovery/src/platform/windows/vgd_recovery.h)):
- **`collect_diagnostic()`** reports *driver-side truth first* — control device reachable, handshake result, driver version ("proto 0.3 build 13"), last Win32 error (5 = the control-ACL refusal signature from the 2026-07 outage) — plus the `root\luminal_vgd` PnP node state (instance ID, hardware IDs, CM problem code).
- **`manual_restart()`** recovers with what LuminalVGD actually exposes: destroy tracked monitor sessions + recycle the control handle (the next open re-handshakes), escalating to a PnP disable/enable of the device node only if the handshake stays dead. The automatic QDC-wedge path uses the same routine with the PnP cycle withheld (yanking the device node from under a caller mid-enumeration is worse than reporting failure).
- `/api/state/vdd-restart` now logs server-side — field logs couldn't distinguish "nobody clicked" from "the click never arrived".
- The device-node helpers are shared via `recovery_bridge` (the SudoVDA lookup became a wrapper over a hardware-ID-parameterised finder). The legacy `platf::sudovda` ladder is now fully uncalled from production paths; its excision is tracked as the existing SudoVDA-removal task.
- Troubleshooting card retitled "Virtual Display Driver (LuminalVGD)", renders the driver-truth fields, and every SudoVDA string in the component is gone.

Stacked on #105 (merged) — this diff is only the recovery work.

## Verification
- `luminalshine.exe` + `test_sunshine` build clean; `TdrState.*` and `SimpleWebLifetime.*` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)