### PR TITLE
fix(display-helper): escalate loudly on machine-wide display-stack wedge instead of silent polling

### DIFF
--- a/src/platform/windows/display_helper_wedge_escalation.h
+++ b/src/platform/windows/display_helper_wedge_escalation.h
@@ -1,0 +1,143 @@
+/**
+ * @file src/platform/windows/display_helper_wedge_escalation.h
+ * @brief Pure decision logic for escalating persistent machine-wide display enumeration failures.
+ */
+#pragma once
+
+// standard
+#include <chrono>
+#include <cstddef>
+
+namespace display_helper_integration {
+
+  /**
+   * @brief State machine deciding how the display helper's restore loop reacts to
+   * a sequence of display-enumeration health probes.
+   *
+   * Motivation (POSTMORTEM-2026-07-27.md, helper blocker #6): during the
+   * machine-wide WDDM wedge the interactive-desktop helper silently polled
+   * QueryDisplayConfig for 84 minutes, rejecting golden/session restore
+   * snapshots every cycle with "no valid devices available" and never telling
+   * anyone the display stack was dead.
+   *
+   * The machine consumes one sample per observation — "did display enumeration
+   * return any devices?" plus a caller-supplied timestamp — and yields one of:
+   * - Proceed: nothing notable (healthy, or a failure streak that has not yet
+   *   met the persistence threshold); run the normal restore flow.
+   * - Escalate: failures just crossed the persistence threshold (>= N
+   *   consecutive failures spanning >= the minimum duration); emit ONE loud log
+   *   (display stack dead machine-wide, reboot required) and hold the restore.
+   * - Hold: still wedged; skip snapshot re-evaluation and stay quiet.
+   * - Relog: still wedged and the re-log interval elapsed; emit the loud log
+   *   again (rate-limited), then keep holding.
+   * - RetryNow: enumeration transitioned from wedged back to succeeding;
+   *   re-attempt the held restore immediately (callers must log the attempt).
+   *
+   * Purely functional over its inputs (no clock access, no logging, no I/O) so
+   * it can be unit-tested deterministically. Not thread-safe; callers must
+   * serialize access — the helper only touches it from the restore polling
+   * thread, and successive polling threads are serialized by std::jthread joins.
+   */
+  class WedgeEscalation {
+  public:
+    using time_point = std::chrono::steady_clock::time_point;
+
+    enum class Action {
+      Proceed,  ///< Normal restore flow; nothing to report.
+      Escalate,  ///< Threshold crossed: emit the loud machine-wide-failure log, then hold.
+      Hold,  ///< Wedged: skip snapshot re-evaluation, stay quiet.
+      Relog,  ///< Wedged and the re-log interval elapsed: emit the loud log again.
+      RetryNow,  ///< Enumeration recovered from a wedge: re-attempt the held restore now.
+    };
+
+    struct Config {
+      /// Consecutive failed samples required before escalating.
+      std::size_t failure_threshold {5};
+      /// Failures must also span at least this long before escalating.
+      std::chrono::milliseconds min_failure_duration {std::chrono::seconds(60)};
+      /// While wedged, re-emit the loud log at most this often.
+      std::chrono::milliseconds relog_interval {std::chrono::minutes(10)};
+    };
+
+    WedgeEscalation() = default;
+
+    explicit WedgeEscalation(Config config):
+        config_(config) {
+    }
+
+    /**
+     * @brief Feed one enumeration health sample and get the resulting decision.
+     * @param enumeration_ok Whether display enumeration returned any devices.
+     * @param now Timestamp of the sample (monotonic).
+     */
+    [[nodiscard]] Action on_enumeration_result(bool enumeration_ok, time_point now) {
+      if (enumeration_ok) {
+        const bool was_wedged = wedged_;
+        reset();
+        return was_wedged ? Action::RetryNow : Action::Proceed;
+      }
+
+      if (consecutive_failures_ == 0) {
+        first_failure_ = now;
+      }
+      ++consecutive_failures_;
+
+      if (!wedged_) {
+        if (consecutive_failures_ >= config_.failure_threshold &&
+            (now - first_failure_) >= config_.min_failure_duration) {
+          wedged_ = true;
+          last_escalation_log_ = now;
+          return Action::Escalate;
+        }
+        return Action::Proceed;
+      }
+
+      if ((now - last_escalation_log_) >= config_.relog_interval) {
+        last_escalation_log_ = now;
+        return Action::Relog;
+      }
+      return Action::Hold;
+    }
+
+    /// True once the persistence threshold has been crossed (loud log emitted).
+    [[nodiscard]] bool wedged() const {
+      return wedged_;
+    }
+
+    /// True while a failure streak is being tracked (wedged or still counting).
+    /// Callers use this to keep probing cheaply instead of abandoning the loop.
+    [[nodiscard]] bool engaged() const {
+      return wedged_ || consecutive_failures_ > 0;
+    }
+
+    [[nodiscard]] std::size_t consecutive_failures() const {
+      return consecutive_failures_;
+    }
+
+    /// How long the current failure streak has lasted (zero when healthy).
+    [[nodiscard]] std::chrono::milliseconds failing_for(time_point now) const {
+      if (consecutive_failures_ == 0) {
+        return std::chrono::milliseconds::zero();
+      }
+      return std::chrono::duration_cast<std::chrono::milliseconds>(now - first_failure_);
+    }
+
+    [[nodiscard]] const Config &config() const {
+      return config_;
+    }
+
+    void reset() {
+      consecutive_failures_ = 0;
+      wedged_ = false;
+      first_failure_ = {};
+      last_escalation_log_ = {};
+    }
+
+  private:
+    Config config_ {};
+    std::size_t consecutive_failures_ {0};
+    bool wedged_ {false};
+    time_point first_failure_ {};
+    time_point last_escalation_log_ {};
+  };
+}  // namespace display_helper_integration

--- a/tests/unit/test_display_helper_wedge_escalation.cpp
+++ b/tests/unit/test_display_helper_wedge_escalation.cpp
@@ -1,0 +1,164 @@
+/**
+ * @file tests/unit/test_display_helper_wedge_escalation.cpp
+ * @brief Unit tests for the display helper wedge escalation state machine.
+ *
+ * Covers the decision logic added for POSTMORTEM-2026-07-27 helper blocker #6:
+ * a machine-wide WDDM wedge must escalate loudly once (then re-log at a bounded
+ * rate) instead of silently rejecting restore snapshots every poll cycle, and
+ * must trigger exactly one retry when enumeration recovers.
+ */
+#include "../tests_common.h"
+#include "src/platform/windows/display_helper_wedge_escalation.h"
+
+#include <chrono>
+
+using display_helper_integration::WedgeEscalation;
+using Action = WedgeEscalation::Action;
+using namespace std::chrono_literals;
+
+namespace {
+  WedgeEscalation::time_point at(std::chrono::milliseconds offset) {
+    return WedgeEscalation::time_point {} + offset;
+  }
+}  // namespace
+
+TEST(DisplayHelperWedgeEscalation, HealthyResultsStayQuiet) {
+  WedgeEscalation esc;
+
+  EXPECT_EQ(esc.on_enumeration_result(true, at(0s)), Action::Proceed);
+  EXPECT_EQ(esc.on_enumeration_result(true, at(10s)), Action::Proceed);
+  EXPECT_FALSE(esc.engaged());
+  EXPECT_FALSE(esc.wedged());
+  EXPECT_EQ(esc.consecutive_failures(), 0u);
+  EXPECT_EQ(esc.failing_for(at(20s)), 0ms);
+}
+
+TEST(DisplayHelperWedgeEscalation, ShortFailureStreakDoesNotEscalate) {
+  WedgeEscalation esc;
+
+  // Four failures — below the default threshold of five — even over a long span.
+  EXPECT_EQ(esc.on_enumeration_result(false, at(0s)), Action::Proceed);
+  EXPECT_EQ(esc.on_enumeration_result(false, at(60s)), Action::Proceed);
+  EXPECT_EQ(esc.on_enumeration_result(false, at(120s)), Action::Proceed);
+  EXPECT_EQ(esc.on_enumeration_result(false, at(180s)), Action::Proceed);
+
+  EXPECT_TRUE(esc.engaged());
+  EXPECT_FALSE(esc.wedged());
+  EXPECT_EQ(esc.consecutive_failures(), 4u);
+}
+
+TEST(DisplayHelperWedgeEscalation, FastFailureBurstBelowMinDurationDoesNotEscalate) {
+  WedgeEscalation esc;
+
+  // Ten rapid-fire failures within 45s: count threshold met, wall-clock gate not.
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_EQ(esc.on_enumeration_result(false, at(i * 5s)), Action::Proceed) << "sample " << i;
+  }
+
+  EXPECT_TRUE(esc.engaged());
+  EXPECT_FALSE(esc.wedged());
+  EXPECT_EQ(esc.consecutive_failures(), 10u);
+}
+
+TEST(DisplayHelperWedgeEscalation, EscalatesOnceAfterThresholdAndDuration) {
+  WedgeEscalation esc;
+
+  EXPECT_EQ(esc.on_enumeration_result(false, at(0s)), Action::Proceed);
+  EXPECT_EQ(esc.on_enumeration_result(false, at(15s)), Action::Proceed);
+  EXPECT_EQ(esc.on_enumeration_result(false, at(30s)), Action::Proceed);
+  EXPECT_EQ(esc.on_enumeration_result(false, at(45s)), Action::Proceed);
+
+  // Fifth consecutive failure, 60s after the first: both gates satisfied.
+  EXPECT_EQ(esc.on_enumeration_result(false, at(60s)), Action::Escalate);
+  EXPECT_TRUE(esc.wedged());
+  EXPECT_EQ(esc.consecutive_failures(), 5u);
+  EXPECT_EQ(esc.failing_for(at(60s)), 60000ms);
+
+  // Escalation is emitted exactly once; further failures hold quietly.
+  EXPECT_EQ(esc.on_enumeration_result(false, at(63s)), Action::Hold);
+  EXPECT_EQ(esc.on_enumeration_result(false, at(66s)), Action::Hold);
+}
+
+TEST(DisplayHelperWedgeEscalation, RelogsAtMostEveryInterval) {
+  WedgeEscalation esc;
+
+  for (int i = 0; i < 5; ++i) {
+    (void) esc.on_enumeration_result(false, at(i * 15s));  // escalates on the fifth sample (t=60s)
+  }
+  ASSERT_TRUE(esc.wedged());
+
+  // Still inside the 10-minute re-log window: quiet.
+  EXPECT_EQ(esc.on_enumeration_result(false, at(60s + 5min)), Action::Hold);
+  EXPECT_EQ(esc.on_enumeration_result(false, at(60s + 10min - 1s)), Action::Hold);
+
+  // Interval elapsed: one re-log, then quiet again until the next interval.
+  EXPECT_EQ(esc.on_enumeration_result(false, at(60s + 10min)), Action::Relog);
+  EXPECT_EQ(esc.on_enumeration_result(false, at(60s + 10min + 3s)), Action::Hold);
+  EXPECT_EQ(esc.on_enumeration_result(false, at(60s + 20min)), Action::Relog);
+}
+
+TEST(DisplayHelperWedgeEscalation, RecoveryFromWedgeRetriesExactlyOnce) {
+  WedgeEscalation esc;
+
+  for (int i = 0; i < 5; ++i) {
+    (void) esc.on_enumeration_result(false, at(i * 20s));
+  }
+  ASSERT_TRUE(esc.wedged());
+
+  // Enumeration transitions from failing to succeeding: retry the held restore now.
+  EXPECT_EQ(esc.on_enumeration_result(true, at(30min)), Action::RetryNow);
+  EXPECT_FALSE(esc.wedged());
+  EXPECT_FALSE(esc.engaged());
+  EXPECT_EQ(esc.consecutive_failures(), 0u);
+
+  // Subsequent healthy samples are ordinary.
+  EXPECT_EQ(esc.on_enumeration_result(true, at(30min + 3s)), Action::Proceed);
+}
+
+TEST(DisplayHelperWedgeEscalation, SuccessResetsFailureStreakBeforeEscalation) {
+  WedgeEscalation esc;
+
+  (void) esc.on_enumeration_result(false, at(0s));
+  (void) esc.on_enumeration_result(false, at(30s));
+  (void) esc.on_enumeration_result(false, at(60s));
+
+  // Recovery before the streak matured is NOT a wedge recovery — no forced retry.
+  EXPECT_EQ(esc.on_enumeration_result(true, at(65s)), Action::Proceed);
+  EXPECT_FALSE(esc.engaged());
+  EXPECT_EQ(esc.consecutive_failures(), 0u);
+
+  // A fresh streak must clear both gates from scratch again.
+  EXPECT_EQ(esc.on_enumeration_result(false, at(70s)), Action::Proceed);
+  EXPECT_EQ(esc.on_enumeration_result(false, at(200s)), Action::Proceed);
+  EXPECT_EQ(esc.consecutive_failures(), 2u);
+  EXPECT_EQ(esc.failing_for(at(200s)), 130000ms);
+}
+
+TEST(DisplayHelperWedgeEscalation, WedgedStatePersistsAcrossManualReset) {
+  WedgeEscalation esc;
+
+  for (int i = 0; i < 5; ++i) {
+    (void) esc.on_enumeration_result(false, at(i * 20s));
+  }
+  ASSERT_TRUE(esc.wedged());
+
+  esc.reset();
+  EXPECT_FALSE(esc.wedged());
+  EXPECT_FALSE(esc.engaged());
+  EXPECT_EQ(esc.consecutive_failures(), 0u);
+  EXPECT_EQ(esc.failing_for(at(100s)), 0ms);
+}
+
+TEST(DisplayHelperWedgeEscalation, CustomConfigIsHonored) {
+  WedgeEscalation esc(WedgeEscalation::Config {
+    .failure_threshold = 2,
+    .min_failure_duration = 5s,
+    .relog_interval = 30s,
+  });
+
+  EXPECT_EQ(esc.on_enumeration_result(false, at(0s)), Action::Proceed);
+  EXPECT_EQ(esc.on_enumeration_result(false, at(5s)), Action::Escalate);
+  EXPECT_EQ(esc.on_enumeration_result(false, at(10s)), Action::Hold);
+  EXPECT_EQ(esc.on_enumeration_result(false, at(5s + 30s)), Action::Relog);
+  EXPECT_EQ(esc.on_enumeration_result(true, at(60s)), Action::RetryNow);
+}

--- a/tools/display_settings_helper.cpp
+++ b/tools/display_settings_helper.cpp
@@ -35,6 +35,7 @@
 
 // third-party (libdisplaydevice)
   #include "src/logging.h"
+  #include "src/platform/windows/display_helper_wedge_escalation.h"
   #include "src/platform/windows/ipc/display_settings_client.h"
   #include "src/platform/windows/ipc/pipes.h"
 
@@ -2091,6 +2092,16 @@ namespace {
 
   constexpr std::chrono::milliseconds kApplyDisconnectGrace {5000};
 
+  // Orphan lifetime bound (POSTMORTEM-2026-07-27, helper blocker #6): once the
+  // service has connected at least once and then gone away, the helper must not
+  // linger forever waiting for a reconnect (previously it could persist
+  // indefinitely — e.g. with a pending restore that a machine-wide WDDM wedge
+  // makes impossible to complete). After this long without a control
+  // connection, the helper exits; the logon-time LuminalShineDisplayRestore
+  // scheduled task (armed before every APPLY, deleted only after a confirmed
+  // restore) remains the durable fallback for restoring displays afterwards.
+  constexpr std::chrono::minutes kOrphanLifetimeBound {5};
+
   class DisplayDeviceLogBridge {
   public:
     DisplayDeviceLogBridge() = default;
@@ -2393,6 +2404,14 @@ namespace {
     static constexpr size_t kGoldenFallbackCompletionThreshold = 3;
     std::atomic<size_t> restore_backoff_index {0};
     std::atomic<long long> restore_next_allowed_ms {0};
+    // Wedge escalation (POSTMORTEM-2026-07-27, helper blocker #6): tracks
+    // consecutive display-enumeration failures so a machine-wide WDDM wedge is
+    // loudly escalated once instead of silently rejecting restore snapshots
+    // every poll cycle for hours. Only touched from the restore polling thread;
+    // successive polling threads are serialized by std::jthread joins. State is
+    // deliberately kept across restore requests so a still-wedged machine stays
+    // in the quiet hold state rather than re-spamming rejection warnings.
+    display_helper_integration::WedgeEscalation wedge_escalation;
     static constexpr std::array<std::chrono::seconds, 8> kRestoreBackoffProfile {
       std::chrono::seconds(0),
       std::chrono::seconds(1),
@@ -2533,6 +2552,50 @@ namespace {
       );
       if (delay.count() > 0) {
         BOOST_LOG(info) << "Restore polling: scheduling next attempt in " << delay.count() << "s.";
+      }
+    }
+
+    /**
+     * @brief Cheap machine-wide display-stack health probe.
+     *
+     * A Minimal-detail enumeration is a single QueryDisplayConfig pass; on a
+     * wedged WDDM stack (postmortem: QDC -> ERROR_NOT_SUPPORTED) it yields zero
+     * devices. Any healthy machine with a display attached yields at least one.
+     * @return Number of display devices currently enumerable (0 == stack dead).
+     */
+    std::size_t probe_display_device_count() const {
+      try {
+        return controller.enum_all_device_ids().size();
+      } catch (...) {
+        return 0;
+      }
+    }
+
+    /// Emit the loud, unmistakable machine-wide display-stack failure line.
+    /// Rate-limited by the wedge escalator (at most once per relog_interval).
+    void log_wedge_escalation() const {
+      const auto now = std::chrono::steady_clock::now();
+      const auto failing_secs = std::chrono::duration_cast<std::chrono::seconds>(wedge_escalation.failing_for(now)).count();
+      const auto relog_minutes = std::chrono::duration_cast<std::chrono::minutes>(wedge_escalation.config().relog_interval).count();
+      BOOST_LOG(fatal) << "DISPLAY STACK UNAVAILABLE MACHINE-WIDE: display enumeration has returned zero devices for "
+                       << wedge_escalation.consecutive_failures() << " consecutive checks over " << failing_secs
+                       << "s. Display restore CANNOT proceed while the WDDM display stack is down; holding the pending"
+                          " restore and watching for display arrival instead of re-evaluating snapshots every cycle."
+                          " First try Win+Ctrl+Shift+B to restart the Windows graphics stack (free); if displays do not"
+                          " return, this machine must be REBOOTED. (This message repeats at most every "
+                       << relog_minutes << " minutes while the condition persists.)";
+    }
+
+    /// Feed one enumeration health sample into the wedge escalator after a
+    /// failed restore attempt, emitting the loud escalation log when warranted.
+    void note_restore_failure_for_wedge_escalation() {
+      using Action = display_helper_integration::WedgeEscalation::Action;
+      const auto action = wedge_escalation.on_enumeration_result(
+        probe_display_device_count() > 0,
+        std::chrono::steady_clock::now()
+      );
+      if (action == Action::Escalate || action == Action::Relog) {
+        log_wedge_escalation();
       }
     }
 
@@ -3619,6 +3682,7 @@ namespace {
           return;
         }
         self->reset_restore_backoff();
+        self->wedge_escalation.reset();
         self->retry_revert_on_topology.store(false, std::memory_order_release);
         self->exit_after_revert.store(false, std::memory_order_release);
         run_restore_cleanup("initial attempt");
@@ -3654,6 +3718,7 @@ namespace {
       }
 
       if (initial_attempted && !initial_success) {
+        self->note_restore_failure_for_wedge_escalation();
         self->register_restore_failure();
       }
 
@@ -3683,8 +3748,47 @@ namespace {
         if (cancelled()) {
           break;
         }
+
+        // Wedge escalation hold path (POSTMORTEM-2026-07-27, helper blocker #6):
+        // once display enumeration has started failing, stop re-evaluating (and
+        // rejecting) restore snapshots every cycle. Instead, cheaply re-probe
+        // enumeration — woken early by WM_DISPLAYCHANGE / device-arrival via the
+        // event pump's message loop — and only fall through to a real restore
+        // attempt when enumeration transitions from failing back to succeeding.
+        if (self->wedge_escalation.engaged()) {
+          using WedgeAction = display_helper_integration::WedgeEscalation::Action;
+          const auto device_count = self->probe_display_device_count();
+          const auto wedge_action = self->wedge_escalation.on_enumeration_result(
+            device_count > 0,
+            std::chrono::steady_clock::now()
+          );
+          if (wedge_action == WedgeAction::Escalate || wedge_action == WedgeAction::Relog) {
+            self->log_wedge_escalation();
+            continue;
+          }
+          if (wedge_action == WedgeAction::Hold) {
+            continue;
+          }
+          if (wedge_action == WedgeAction::RetryNow) {
+            BOOST_LOG(info) << "Display enumeration recovered (" << device_count
+                            << " device(s) visible after display-stack outage); re-attempting held restore now.";
+            self->reset_restore_backoff();
+            triggered = true;  // force a restore attempt this cycle
+          }
+          // WedgeAction::Proceed: streak reset by a healthy probe, or failure
+          // streak still below the escalation threshold — normal flow resumes.
+        }
+
         if (!triggered) {
           if (window_expired) {
+            if (self->wedge_escalation.engaged()) {
+              // Do not abandon the poll loop while enumeration is failing: the
+              // wedge escalator must keep observing so it can escalate loudly,
+              // re-log while the condition persists, and retry on recovery.
+              BOOST_LOG(debug) << "Restore polling: window exhausted while display enumeration is unhealthy;"
+                                  " continuing to monitor for display-stack recovery.";
+              continue;
+            }
             const char *window_label = (active_window_kind == RestoreWindow::Primary) ? "primary" : "event";
             BOOST_LOG(info) << "Restore polling: " << window_label
                             << " window exhausted; pausing attempts until next event.";
@@ -3734,6 +3838,7 @@ namespace {
             return;
           }
           self->reset_restore_backoff();
+          self->wedge_escalation.reset();
           self->retry_revert_on_topology.store(false, std::memory_order_release);
           self->exit_after_revert.store(false, std::memory_order_release);
           run_restore_cleanup("polling attempt");
@@ -3768,6 +3873,7 @@ namespace {
           return;
         }
 
+        self->note_restore_failure_for_wedge_escalation();
         self->register_restore_failure();
 
         const auto post_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -5261,6 +5367,9 @@ int main(int argc, char *argv[]) {
   state.running_flag = &running;
   auto last_connect_wait_log = std::chrono::steady_clock::time_point::min();
   constexpr auto kReconnectLogInterval = std::chrono::hours(1);
+  // Set while disconnected after having had at least one client connection;
+  // used to enforce kOrphanLifetimeBound.
+  auto orphaned_since = std::chrono::steady_clock::time_point::min();
 
   // Outer service loop: keep accepting new client sessions while running
   while (running.load(std::memory_order_acquire)) {
@@ -5289,8 +5398,27 @@ int main(int argc, char *argv[]) {
         BOOST_LOG(info) << "Waiting for Sunshine to connect to display helper IPC...";
         last_connect_wait_log = now;
       }
+      // Orphan lifetime bound: only applies after the service has connected at
+      // least once (epoch != 0) and the pipe was then lost. Startup behaviour —
+      // waiting indefinitely for the first connection — is unchanged.
+      if (state.current_connection_epoch() != 0) {
+        if (orphaned_since == std::chrono::steady_clock::time_point::min()) {
+          orphaned_since = now;
+        } else if (now - orphaned_since >= kOrphanLifetimeBound) {
+          const bool restore_pending = state.restore_requested.load(std::memory_order_acquire);
+          BOOST_LOG(warning) << "Display helper orphaned: no control connection for "
+                             << std::chrono::duration_cast<std::chrono::minutes>(kOrphanLifetimeBound).count()
+                             << " minutes after losing the service pipe"
+                             << (restore_pending ? " and the pending display restore could not complete" : "")
+                             << "; exiting instead of persisting indefinitely."
+                             << (restore_pending ? " The logon-time restore scheduled task remains armed to retry the restore." : "");
+          running.store(false, std::memory_order_release);
+          break;
+        }
+      }
       continue;
     }
+    orphaned_since = std::chrono::steady_clock::time_point::min();
 
     const auto connection_epoch = state.begin_connection_epoch();
     // Do not cancel restore polling merely because Sunshine connected. Stream start


### PR DESCRIPTION
## Why

During the 2026-07-27 WDDM collapse (`POSTMORTEM-2026-07-27.md`, helper blocker #6), the interactive-desktop display helper (`luminalshine_display_helper`) polled `QueryDisplayConfig` for **84 minutes**, rejecting golden/session restore snapshots every cycle with `no valid devices available` and never telling anyone the display stack was dead machine-wide. The restore logic itself was proven good (it succeeded at 10:41:13) — it simply could not operate, and it neither said so nor stopped re-evaluating snapshots that could not possibly apply.

## What

**New pure state machine** — `src/platform/windows/display_helper_wedge_escalation.h` (`display_helper_integration::WedgeEscalation`, header-only). It consumes one sample per observation ("did display enumeration return any devices?" + timestamp) and yields one of:

| Action | Meaning |
|---|---|
| `Proceed` | Healthy, or failure streak below threshold — normal restore flow |
| `Escalate` | >= 5 consecutive failures spanning >= 60 s — emit ONE loud log, enter hold |
| `Hold` | Wedged — skip snapshot re-evaluation, stay quiet |
| `Relog` | Wedged and >= 10 min since last loud log — emit it again |
| `RetryNow` | Enumeration transitioned failing -> succeeding — re-attempt the held restore immediately |

**Helper integration** — `tools/display_settings_helper.cpp`:

- The loud line (BOOST_LOG fatal) states the display stack is unavailable machine-wide, restore cannot proceed, suggests **Win+Ctrl+Shift+B** as the free first attempt, and says the machine must be **rebooted** otherwise. Rate-limited to once per 10 minutes.
- While wedged, the restore poll loop **holds** the pending restore instead of re-evaluating (and rejecting) snapshots every cycle: it cheaply re-probes enumeration (one `Minimal` enumeration pass), woken early by `WM_DISPLAYCHANGE`/device-arrival via the helper's existing message-only window, and only re-attempts the restore on the failing->succeeding transition. The transition retry is logged ("Display enumeration recovered (N device(s) ...); re-attempting held restore now.").
- The poll loop no longer abandons itself on window expiry while enumeration is unhealthy, so escalation/re-log/recovery detection stay armed.
- **Orphan lifetime bound (new — no such bound existed):** after the service's control pipe is lost, the helper now exits after **5 minutes** without a reconnect instead of persisting indefinitely. Applies only after at least one connection existed (startup wait unchanged). The logon-time `LuminalShineDisplayRestore` scheduled task (armed before every APPLY, deleted only after confirmed restore) remains the durable fallback.
- `--restore` mode (the scheduled-task path) is intentionally unbounded: it is the designated restore agent, and while wedged it now holds + escalates instead of silently rejecting.

**Tests** — `tests/unit/test_display_helper_wedge_escalation.cpp`: 9 deterministic tests covering threshold/duration gating (count alone or a fast burst does not escalate), one-shot escalation, 10-minute re-log rate limiting, exactly-one retry on recovery, streak reset on pre-escalation recovery, and custom config.

## Not touched

Per parallel work in flight: `src/stream.cpp`, `src/video.cpp`, `src/tdr_state.*`, and all service-side stream/session logic are untouched. Change is helper-side only (+ new header + test).

## Verification

- `ninja -C build sunshine_display_helper` — clean build (MSYS2 ucrt64, configured with `-DBUILD_DOCS=OFF -DSUNSHINE_PACKAGE_LUMINALVGD=OFF`)
- `ninja -C build test_sunshine` — clean build
- `DisplayHelperWedgeEscalation.*` — 9/9 pass
- `DisplayHelperWatchdog.* : DisplayHelperSessionDeferral.* : *DisplayDevice*` — 160/160 pass
- Full suite: pre-existing environmental failures only (DownloadFileTests needs admin, ConfigHttpCheckAuthTest disallowed-ip, PlayniteSync_*, LocaleConsistencyTest fixture drift; Logging tests pass in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)