### PR TITLE
feat: top-level crash handler — fatal log line + minidump on every crash

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -145,6 +145,8 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/state_storage.h"
         "${CMAKE_SOURCE_DIR}/src/tdr_state.cpp"
         "${CMAKE_SOURCE_DIR}/src/tdr_state.h"
+        "${CMAKE_SOURCE_DIR}/src/crash_handler.cpp"
+        "${CMAKE_SOURCE_DIR}/src/crash_handler.h"
         "${CMAKE_SOURCE_DIR}/src/amf/amf_caps.cpp"
         "${CMAKE_SOURCE_DIR}/src/amf/amf_caps.h"
         "${CMAKE_SOURCE_DIR}/src/cred_store/cred_store.h"

--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -183,6 +183,7 @@ list(PREPEND PLATFORM_LIBRARIES
         avrt
         d3d11
         D3DCompiler
+        dbghelp
         dwmapi
         dxgi
         iphlpapi

--- a/src/crash_handler.cpp
+++ b/src/crash_handler.cpp
@@ -1,0 +1,299 @@
+/**
+ * @file src/crash_handler.cpp
+ * @brief Implementation of the top-level crash handler.
+ */
+#include "crash_handler.h"
+
+#include "logging.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <cwchar>
+#include <exception>
+#include <iterator>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#ifdef _WIN32
+// clang-format off
+  #include <windows.h>
+  #include <dbghelp.h>
+// clang-format on
+
+  #include "platform/common.h"
+#endif
+
+namespace crash_handler {
+
+  std::size_t prune_dumps(const std::filesystem::path &dir, std::size_t keep) {
+    namespace fs = std::filesystem;
+
+    std::error_code ec;
+    std::vector<std::pair<fs::file_time_type, fs::path>> dumps;
+    for (const auto &entry : fs::directory_iterator {dir, ec}) {
+      std::error_code entry_ec;
+      if (!entry.is_regular_file(entry_ec) || entry.path().extension() != ".dmp") {
+        continue;
+      }
+      const auto written_at = entry.last_write_time(entry_ec);
+      if (entry_ec) {
+        continue;
+      }
+      dumps.emplace_back(written_at, entry.path());
+    }
+
+    if (dumps.size() <= keep) {
+      return 0;
+    }
+
+    // Newest first; everything past `keep` goes.
+    std::sort(dumps.begin(), dumps.end(), [](const auto &lhs, const auto &rhs) {
+      return lhs.first > rhs.first;
+    });
+
+    std::size_t removed = 0;
+    for (std::size_t i = keep; i < dumps.size(); ++i) {
+      std::error_code remove_ec;
+      if (std::filesystem::remove(dumps[i].second, remove_ec)) {
+        ++removed;
+      }
+    }
+    return removed;
+  }
+
+#ifdef _WIN32
+
+  namespace {
+    // 0xE0 (customer-defined error severity) + "LST" — the distinctive code
+    // the std::terminate handler raises so the SEH filter below writes a
+    // dump for C++-level aborts too. Grep target: a fatal log line with
+    // this code means "std::terminate escalation", not a hardware fault.
+    constexpr DWORD kTerminateExceptionCode = 0xE04C5354;
+
+    constexpr std::size_t kMaxDumps = 5;
+
+    // Everything the exception filter needs is prebuilt or statically
+    // allocated at init() time: by the time the filter runs, the heap may
+    // be corrupt and any allocation can deadlock or recurse. The filter
+    // only does swprintf into these buffers + CreateFileW + MiniDumpWriteDump.
+    constexpr std::size_t kPathCapacity = 1024;
+    wchar_t g_dump_dir[kPathCapacity] = {};
+    wchar_t g_dump_path[kPathCapacity + 64] = {};
+    wchar_t g_module_path[kPathCapacity] = {};
+    char g_dump_path_utf8[kPathCapacity * 3 + 192] = {};
+    char g_module_path_utf8[kPathCapacity * 3] = {};
+    char g_what_buffer[512] = {};
+
+    volatile LONG g_crash_in_progress = 0;
+    volatile LONG g_terminate_in_progress = 0;
+
+    /// Narrow a wide path into a static buffer for the log line. No heap.
+    const char *to_utf8(const wchar_t *src, char *dst, int dst_size) {
+      const int written = WideCharToMultiByte(CP_UTF8, 0, src, -1, dst, dst_size, nullptr, nullptr);
+      if (written <= 0) {
+        dst[0] = '\0';
+      }
+      return dst;
+    }
+
+    LONG WINAPI unhandled_exception_filter(EXCEPTION_POINTERS *exception_info) {
+      // One shot. A second faulting thread — or a fault inside this filter
+      // itself (the dump write, or Boost.Log against a corrupt heap) —
+      // goes straight through to WER instead of recursing.
+      if (InterlockedExchange(&g_crash_in_progress, 1) != 0) {
+        return EXCEPTION_CONTINUE_SEARCH;
+      }
+      if (g_dump_dir[0] == L'\0') {
+        return EXCEPTION_CONTINUE_SEARCH;
+      }
+
+      const DWORD code = exception_info->ExceptionRecord->ExceptionCode;
+      void *const fault_address = exception_info->ExceptionRecord->ExceptionAddress;
+
+      g_module_path[0] = L'\0';
+      HMODULE fault_module = nullptr;
+      if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, reinterpret_cast<LPCWSTR>(fault_address), &fault_module) && fault_module != nullptr) {
+        GetModuleFileNameW(fault_module, g_module_path, static_cast<DWORD>(std::size(g_module_path)));
+      }
+
+      SYSTEMTIME now {};
+      GetLocalTime(&now);  // local time so the filename lines up with log timestamps
+      swprintf(
+        g_dump_path,
+        std::size(g_dump_path),
+        L"%ls\\luminalshine-%04u%02u%02u-%02u%02u%02u-%lu.dmp",
+        g_dump_dir,
+        static_cast<unsigned>(now.wYear),
+        static_cast<unsigned>(now.wMonth),
+        static_cast<unsigned>(now.wDay),
+        static_cast<unsigned>(now.wHour),
+        static_cast<unsigned>(now.wMinute),
+        static_cast<unsigned>(now.wSecond),
+        static_cast<unsigned long>(GetCurrentProcessId())
+      );
+      to_utf8(g_dump_path, g_dump_path_utf8, static_cast<int>(std::size(g_dump_path_utf8)));
+      to_utf8(g_module_path, g_module_path_utf8, static_cast<int>(std::size(g_module_path_utf8)));
+
+      // The signature log line. Includes the dump path so a user pasting
+      // their log has already told us where the dump is. BOOST_LOG here is
+      // a calculated risk (it allocates), but the alternative is the exact
+      // in-log silence the 2026-07-27 postmortem documents; the dump write
+      // below is ordered after the flush so the log line survives even if
+      // MiniDumpWriteDump takes the process down.
+      BOOST_LOG(fatal) << "CRASH: unhandled exception 0x" << std::hex << code << std::dec
+                       << (code == kTerminateExceptionCode ? " (std::terminate escalation)" : "")
+                       << " at address " << fault_address
+                       << " in module " << (g_module_path_utf8[0] != '\0' ? g_module_path_utf8 : "<unknown>")
+                       << "; writing minidump to " << g_dump_path_utf8;
+      logging::log_flush();
+
+      DWORD dump_error = ERROR_SUCCESS;
+      BOOL dump_written = FALSE;
+      const HANDLE dump_file = CreateFileW(g_dump_path, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+      if (dump_file != INVALID_HANDLE_VALUE) {
+        MINIDUMP_EXCEPTION_INFORMATION dump_exception {};
+        dump_exception.ThreadId = GetCurrentThreadId();
+        dump_exception.ExceptionPointers = exception_info;
+        dump_exception.ClientPointers = FALSE;
+
+        const auto dump_type = static_cast<MINIDUMP_TYPE>(
+          MiniDumpWithIndirectlyReferencedMemory | MiniDumpWithThreadInfo | MiniDumpWithUnloadedModules
+        );
+        dump_written = MiniDumpWriteDump(
+          GetCurrentProcess(),
+          GetCurrentProcessId(),
+          dump_file,
+          dump_type,
+          &dump_exception,
+          nullptr,
+          nullptr
+        );
+        if (!dump_written) {
+          dump_error = GetLastError();
+        }
+        CloseHandle(dump_file);
+      } else {
+        dump_error = GetLastError();
+      }
+
+      if (dump_written) {
+        BOOST_LOG(fatal) << "CRASH: minidump written to " << g_dump_path_utf8;
+      } else {
+        BOOST_LOG(fatal) << "CRASH: minidump write to " << g_dump_path_utf8
+                         << " FAILED (error=" << dump_error << "); check WER CrashDumps instead";
+      }
+      logging::log_flush();
+
+      // Let the process die: hand the exception on so WER still runs and
+      // the SYSTEM-profile CrashDumps copy keeps existing as a backstop.
+      return EXCEPTION_CONTINUE_SEARCH;
+    }
+
+    [[noreturn]] void terminate_handler() {
+      // Re-entry (e.g. the logging below itself throwing) falls through to
+      // an immediate abort rather than recursing.
+      if (InterlockedExchange(&g_terminate_in_progress, 1) != 0) {
+        std::abort();
+      }
+
+      const char *description = "no active exception";
+      if (const auto active = std::current_exception()) {
+        try {
+          std::rethrow_exception(active);
+        } catch (const std::exception &e) {
+          // Copy into a static buffer: the caught object dies with this
+          // catch block, and everything past here should avoid the heap.
+          std::strncpy(g_what_buffer, e.what(), sizeof(g_what_buffer) - 1);
+          g_what_buffer[sizeof(g_what_buffer) - 1] = '\0';
+          description = g_what_buffer;
+        } catch (...) {
+          description = "non-standard exception (no what() available)";
+        }
+      }
+
+      // Teardown-safe channels first (see the early handler in main.cpp:
+      // std::terminate can fire during CRT exit-time static destruction,
+      // where Boost.Log's sinks are already gone and logging through them
+      // corrupts the heap). If BOOST_LOG below misbehaves, this trace has
+      // already left the process.
+      std::fputs("FATAL: std::terminate: ", stderr);
+      std::fputs(description, stderr);
+      std::fputc('\n', stderr);
+      std::fflush(stderr);
+      OutputDebugStringA("FATAL: std::terminate: ");
+      OutputDebugStringA(description);
+      OutputDebugStringA("\n");
+
+      BOOST_LOG(fatal) << "std::terminate called: " << description
+                       << ". Raising exception 0x" << std::hex << kTerminateExceptionCode << std::dec
+                       << " to capture a minidump.";
+      logging::log_flush();
+
+      // Route through the SEH filter above so the abort produces the same
+      // fatal log line + minidump a hardware fault would.
+      RaiseException(kTerminateExceptionCode, EXCEPTION_NONCONTINUABLE, 0, nullptr);
+
+      // Only reachable if something (a debugger, another filter) swallowed
+      // the exception. Fall back to the default abort path.
+      std::abort();
+    }
+  }  // namespace
+
+  void init() {
+    std::filesystem::path dump_dir;
+    try {
+      dump_dir = platf::appdata() / "crashdumps";
+
+      std::error_code ec;
+      std::filesystem::create_directories(dump_dir, ec);
+      if (ec) {
+        BOOST_LOG(warning) << "Crash handler: could not create dump directory " << dump_dir.string()
+                           << ": " << ec.message() << ". Minidumps will be unavailable (WER still applies).";
+        dump_dir.clear();
+      }
+    } catch (const std::exception &e) {
+      BOOST_LOG(warning) << "Crash handler: could not resolve dump directory: " << e.what()
+                         << ". Minidumps will be unavailable (WER still applies).";
+      dump_dir.clear();
+    }
+
+    if (!dump_dir.empty()) {
+      // Prune on startup rather than inside the exception filter, where
+      // directory iteration would allocate. A crash therefore leaves at
+      // most kMaxDumps + 1 dumps on disk until the next start trims back.
+      const auto removed = prune_dumps(dump_dir, kMaxDumps);
+      if (removed > 0) {
+        BOOST_LOG(debug) << "Crash handler: pruned " << removed << " old minidump(s) from " << dump_dir.string();
+      }
+
+      const std::wstring dir_w = dump_dir.wstring();
+      if (dir_w.size() < std::size(g_dump_dir)) {
+        std::wmemcpy(g_dump_dir, dir_w.c_str(), dir_w.size() + 1);
+      } else {
+        BOOST_LOG(warning) << "Crash handler: dump directory path is too long ("
+                           << dir_w.size() << " chars); minidumps will be unavailable.";
+      }
+    }
+
+    SetUnhandledExceptionFilter(unhandled_exception_filter);
+    std::set_terminate(terminate_handler);
+
+    if (g_dump_dir[0] != L'\0') {
+      BOOST_LOG(info) << "Crash handler installed; minidumps will be written to " << dump_dir.string();
+    }
+  }
+
+#else  // !_WIN32
+
+  void init() {
+    // Windows-only for now: the silent-crash incidents this exists for
+    // (POSTMORTEM-2026-07-27.md) are Windows-host crashes, and only
+    // Windows is shipped. Compiled everywhere so call sites stay short.
+  }
+
+#endif
+
+}  // namespace crash_handler

--- a/src/crash_handler.h
+++ b/src/crash_handler.h
@@ -1,0 +1,56 @@
+/**
+ * @file src/crash_handler.h
+ * @brief Top-level crash handler: last-chance fatal logging + minidump capture.
+ *
+ * Motivated by the 2026-07-27 postmortem (POSTMORTEM-2026-07-27.md,
+ * "silent host-crash bug"): ~10 abrupt luminalshine.exe terminations
+ * between 7/25 and 7/27 left no trace in our own logs — diagnosing them
+ * required WER archaeology and admin access to the SYSTEM profile's
+ * CrashDumps folder. This module makes every crash self-document:
+ *   - an unhandled SEH exception logs a fatal line (code, faulting
+ *     address, module, dump path) and writes a minidump to
+ *     `<appdata>/crashdumps/` before letting WER proceed, and
+ *   - std::terminate logs the active exception (if any) and re-raises it
+ *     as a distinctive SEH exception so the same dump path applies.
+ *
+ * The header is cross-platform; the implementation lives in
+ * crash_handler.cpp and is compiled on every platform so the API can be
+ * called unconditionally (call sites stay short). On non-Windows
+ * platforms `init()` is a no-op.
+ */
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+
+namespace crash_handler {
+
+  /**
+   * @brief Install the process-wide crash handlers (Windows only).
+   *
+   * Call once, early in main(), after logging is initialised — the
+   * handlers emit through BOOST_LOG(fatal) so a crash before logging is
+   * up would only reach WER anyway. Creates `<appdata>/crashdumps/`,
+   * prunes it to the newest dumps, prebuilds the dump directory path
+   * into a static buffer (so the exception filter itself avoids heap
+   * allocation), then installs SetUnhandledExceptionFilter and
+   * std::set_terminate.
+   */
+  void init();
+
+  /**
+   * @brief Delete the oldest `.dmp` files in @p dir until at most @p keep remain.
+   *
+   * Ordering is by last-write time (newest kept). Non-`.dmp` entries and
+   * subdirectories are ignored; a missing or unreadable directory is a
+   * no-op. Called from `init()` on every startup — deliberately *not*
+   * from the exception filter, where directory iteration would allocate.
+   * Exposed here so the unit tests can exercise it directly.
+   *
+   * @param dir Directory to prune.
+   * @param keep Number of newest dumps to keep.
+   * @return Number of files removed.
+   */
+  std::size_t prune_dumps(const std::filesystem::path &dir, std::size_t keep = 5);
+
+}  // namespace crash_handler

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 
 // local includes
 #include "confighttp.h"
+#include "crash_handler.h"
 #include "cred_store/integrity_key.h"
 #include "entry_handler.h"
 #include "globals.h"
@@ -159,6 +160,11 @@ int main(int argc, char *argv[]) {
   // the heap (observed as 0xC0000374 in ucrtbase!_free_base, masking the real
   // fault). Use only teardown-safe primitives: direct stderr writes and
   // OutputDebugString, no Boost.Log and no heap allocation of our own.
+  //
+  // This minimal handler only covers the window before logging is up
+  // (config::parse and friends). Once logging is initialised,
+  // crash_handler::init() below replaces it with the full version that
+  // also logs through Boost.Log and captures a minidump.
   std::set_terminate([]() {
     auto emit = [](const char *msg, const char *detail) noexcept {
       std::fputs(msg, stderr);
@@ -247,6 +253,14 @@ int main(int argc, char *argv[]) {
   if (!log_deinit_guard) {
     BOOST_LOG(error) << "Logging failed to initialize"sv;
   }
+
+  // Install the top-level crash handler as soon as logging is up so any
+  // crash from here on self-documents: a fatal log line naming the fault
+  // and a minidump in <appdata>/crashdumps/. Motivated by the ~10 silent
+  // luminalshine.exe terminations documented in POSTMORTEM-2026-07-27.md,
+  // which left no in-log trace at all. Supersedes the minimal pre-logging
+  // std::terminate handler installed above.
+  crash_handler::init();
 
 #ifdef _WIN32
   const auto app_user_model_id_status =

--- a/tests/unit/test_crash_handler.cpp
+++ b/tests/unit/test_crash_handler.cpp
@@ -1,0 +1,109 @@
+/**
+ * @file tests/unit/test_crash_handler.cpp
+ * @brief Test src/crash_handler.*.
+ *
+ * Only the dump-directory pruning helper is exercised here. The actual
+ * exception filter / terminate handler are deliberately NOT tested
+ * in-process: triggering them would tear the test runner down.
+ */
+#include "../tests_common.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <src/crash_handler.h>
+#include <string>
+#include <vector>
+
+namespace {
+  namespace fs = std::filesystem;
+
+  class CrashHandlerPruneTest: public testing::Test {
+  protected:
+    void SetUp() override {
+      test_dir = fs::temp_directory_path() / ("crash_handler_prune_test_" + std::to_string(::testing::UnitTest::GetInstance()->random_seed()) + "_" + std::to_string(reinterpret_cast<std::uintptr_t>(this)));
+      fs::create_directories(test_dir);
+    }
+
+    void TearDown() override {
+      std::error_code ec;
+      fs::remove_all(test_dir, ec);
+    }
+
+    /// Create a file and stamp it with a deterministic mtime, `age_rank`
+    /// seconds in the past — rank 0 is the newest. Explicit stamps avoid
+    /// flakiness from filesystem timestamp resolution.
+    fs::path make_file(const std::string &name, int age_rank) {
+      const auto path = test_dir / name;
+      std::ofstream {path} << "fake dump";
+      fs::last_write_time(path, fs::file_time_type::clock::now() - std::chrono::seconds {age_rank * 10});
+      return path;
+    }
+
+    std::vector<std::string> remaining_files() const {
+      std::vector<std::string> names;
+      for (const auto &entry : fs::directory_iterator {test_dir}) {
+        names.push_back(entry.path().filename().string());
+      }
+      std::sort(names.begin(), names.end());
+      return names;
+    }
+
+    fs::path test_dir;
+  };
+
+  TEST_F(CrashHandlerPruneTest, KeepsNewestFive) {
+    // dump-0 is the newest, dump-8 the oldest.
+    for (int i = 0; i < 9; ++i) {
+      make_file("dump-" + std::to_string(i) + ".dmp", i);
+    }
+
+    EXPECT_EQ(crash_handler::prune_dumps(test_dir, 5), 4u);
+
+    const std::vector<std::string> expected {"dump-0.dmp", "dump-1.dmp", "dump-2.dmp", "dump-3.dmp", "dump-4.dmp"};
+    EXPECT_EQ(remaining_files(), expected);
+  }
+
+  TEST_F(CrashHandlerPruneTest, NoopAtOrUnderLimit) {
+    for (int i = 0; i < 5; ++i) {
+      make_file("dump-" + std::to_string(i) + ".dmp", i);
+    }
+
+    EXPECT_EQ(crash_handler::prune_dumps(test_dir, 5), 0u);
+    EXPECT_EQ(remaining_files().size(), 5u);
+  }
+
+  TEST_F(CrashHandlerPruneTest, IgnoresNonDumpFiles) {
+    // Six dumps (one over the limit) plus two bystanders older than all
+    // of them. Only the oldest .dmp may go; the bystanders must survive
+    // and must not count toward the limit.
+    for (int i = 0; i < 6; ++i) {
+      make_file("dump-" + std::to_string(i) + ".dmp", i);
+    }
+    make_file("notes.txt", 20);
+    make_file("dump-archive.dmp.bak", 21);
+
+    EXPECT_EQ(crash_handler::prune_dumps(test_dir, 5), 1u);
+
+    const auto names = remaining_files();
+    EXPECT_EQ(names.size(), 7u);
+    EXPECT_EQ(std::count(names.begin(), names.end(), "dump-5.dmp"), 0);
+    EXPECT_EQ(std::count(names.begin(), names.end(), "notes.txt"), 1);
+    EXPECT_EQ(std::count(names.begin(), names.end(), "dump-archive.dmp.bak"), 1);
+  }
+
+  TEST_F(CrashHandlerPruneTest, MissingDirectoryIsSafe) {
+    EXPECT_EQ(crash_handler::prune_dumps(test_dir / "does_not_exist", 5), 0u);
+  }
+
+  TEST_F(CrashHandlerPruneTest, KeepZeroRemovesEverything) {
+    for (int i = 0; i < 3; ++i) {
+      make_file("dump-" + std::to_string(i) + ".dmp", i);
+    }
+
+    EXPECT_EQ(crash_handler::prune_dumps(test_dir, 0), 3u);
+    EXPECT_TRUE(remaining_files().empty());
+  }
+}  // namespace


### PR DESCRIPTION
## Why

POSTMORTEM-2026-07-27.md ("silent host-crash bug"): ~10 abrupt `luminalshine.exe` terminations between 2026-07-25 and 2026-07-27 left **no in-log trace at all**. Diagnosing them required WER archaeology and admin access to the SYSTEM profile's CrashDumps folder. After this change, every crash self-documents: a `Fatal:` log line naming the fault and pointing at a minidump we control the location and retention of.

## What

- **`src/crash_handler.{h,cpp}`** — new module, added to the `sunshine` target in `cmake/compile_definitions/common.cmake`. Compiled on all platforms with a no-op `init()` on non-Windows (same pattern as `tdr_state`).
- **SEH path**: `SetUnhandledExceptionFilter` logs `BOOST_LOG(fatal)` with the exception code, faulting address, module, and dump path, then writes a minidump (`MiniDumpWithIndirectlyReferencedMemory | MiniDumpWithThreadInfo | MiniDumpWithUnloadedModules`) to `<appdata>/crashdumps/luminalshine-<timestamp>-<pid>.dmp` via `CreateFileW` + `MiniDumpWriteDump` directly, then returns `EXCEPTION_CONTINUE_SEARCH` so WER still runs as a backstop.
  - Allocation-cautious inside the filter: dump directory prebuilt into a static buffer at `init()` time, filename formatted into static storage, module path narrowed with `WideCharToMultiByte` into static storage, `InterlockedExchange` one-shot flag against recursive/concurrent re-entry.
- **C++ abort path**: `std::set_terminate` handler logs the active exception's `what()` (rethrown from `current_exception()`), emitting through teardown-safe channels first (stderr + `OutputDebugString` — preserving the 0xC0000374 lesson documented in `main.cpp`) and then Boost.Log, and raises distinctive SEH code `0xE04C5354` ("LST") so the filter above captures a dump for these too. The minimal pre-logging terminate handler in `main.cpp` stays to cover the window before `crash_handler::init()`.
- **Retention**: `<appdata>/crashdumps/` pruned to the newest 5 dumps at every `init()`; `prune_dumps()` exposed for testing. The filter itself never iterates directories.
- **Wiring**: `crash_handler::init()` called in `main()` immediately after `logging::init`; `dbghelp` added to the Windows platform link libraries in `cmake/compile_definitions/windows.cmake`.
- The fatal log line includes the dump path, so a user pasting their log has already told us where the dump is.

## Test plan

- `ninja -C build sunshine test_sunshine` — clean build (Windows/MSYS2 ucrt64, clang/MinGW).
- `./build/tests/test_sunshine.exe --gtest_filter='CrashHandler*'` — 5/5 pass (prune keeps newest 5, no-op at/under limit, ignores non-`.dmp` files, missing dir safe, keep=0 empties).
- The live exception filter / terminate handler are deliberately not exercised in-process by the test suite.
- Known pre-existing local failures (admin-required `DownloadFileTests`/appdata-permission suites) are unrelated and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
