### PR TITLE
feat: TDR topology lifeboat - activate a physical display on GPU hang

### DIFF
--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -150,6 +150,8 @@ set(PLATFORM_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/platform/windows/virtual_display_vgd.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/vgd_recovery.h"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/vgd_recovery.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/tdr_lifeboat.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/tdr_lifeboat.cpp"
         "${CMAKE_SOURCE_DIR}/third-party/sudovda/sudovda-ioctl.h"
         "${CMAKE_SOURCE_DIR}/third-party/sudovda/sudovda.h"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/frame_limiter.h"

--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -30,6 +30,7 @@
 #include "src/config.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
+#include "src/platform/windows/tdr_lifeboat.h"
 #include "utf_utils.h"
 
 // Must be the last included file
@@ -1695,6 +1696,13 @@ namespace platf {
     if (audio_ctrl.init() == 0) {
       audio_ctrl.reset_default_device_no_wait();
     }
+
+    // Arm the TDR topology lifeboat: from here on, a detected GPU hang
+    // best-effort activates a physical display alongside the virtual one so
+    // Windows' TDR recovery always has a hardware-backed output
+    // (POSTMORTEM-2026-07-27). Wired here (Windows platf::init) rather than
+    // in main.cpp so cross-platform init stays untouched.
+    tdr_lifeboat::init();
 
     return co_init;
   }

--- a/src/platform/windows/tdr_lifeboat.cpp
+++ b/src/platform/windows/tdr_lifeboat.cpp
@@ -1,0 +1,201 @@
+/**
+ * @file src/platform/windows/tdr_lifeboat.cpp
+ * @brief Implementation of the TDR topology lifeboat (see tdr_lifeboat.h).
+ *
+ * Flow: tdr::mark_event → on_tdr_event (constant-time gate, caller's
+ * thread) → task_pool → start_attempt (logs intent, arms the 5 s watchdog)
+ * → detached worker thread → attempt_activate_physical_display (the
+ * blocking enumerate + helper APPLY round-trip).
+ *
+ * The worker runs on its own thread rather than the task pool because the
+ * pool is single-threaded and shared with input-event timers, while helper
+ * IPC against a dying display stack can block indefinitely. The watchdog
+ * task declares the attempt failed after ~5 s; a worker parked on dead IPC
+ * is abandoned (detached, rate-limited to one per cooldown window).
+ */
+#include <winsock2.h>
+
+#include "tdr_lifeboat.h"
+
+// standard includes
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+// lib includes
+#include <display_device/types.h>
+
+// local includes
+#include "src/display_helper_builder.h"
+#include "src/globals.h"
+#include "src/logging.h"
+#include "src/platform/windows/display_helper_integration.h"
+#include "src/platform/windows/virtual_display.h"
+
+namespace tdr_lifeboat {
+  namespace {
+    /// How long the lifeboat waits for the enumerate + APPLY round-trip
+    /// before declaring the attempt failed. The stack may already be too
+    /// far gone for the helper to answer — that is fine, the escalation
+    /// paths (tdr::stack_down latch, session teardown) own terminal
+    /// handling; the lifeboat just stops waiting.
+    constexpr std::chrono::seconds ATTEMPT_TIMEOUT {5};
+
+    std::mutex g_gate_mutex;
+    attempt_gate g_gate;  ///< Guarded by g_gate_mutex.
+
+    /// Shared between the detached worker thread and the watchdog task so
+    /// a hung helper call can be abandoned without joining the thread.
+    struct attempt_state_t {
+      std::atomic<bool> done {false};
+      std::atomic<bool> timed_out {false};
+    };
+
+    /// The blocking part of the attempt. Runs on a dedicated detached
+    /// thread — never on mark_event's caller and never on the (single)
+    /// task-pool thread. Must not throw.
+    void attempt_activate_physical_display(const std::shared_ptr<attempt_state_t> &state) noexcept {
+      const auto finish = [&state](bool success, const std::string &message) {
+        state->done.store(true, std::memory_order_release);
+        const char *late = state->timed_out.load(std::memory_order_acquire) ? " (late, past the watchdog deadline)" : "";
+        if (success) {
+          BOOST_LOG(warning) << "TDR lifeboat" << late << ": " << message;
+        } else {
+          BOOST_LOG(error) << "TDR lifeboat" << late << ": " << message;
+        }
+      };
+
+      try {
+        if (VDISPLAY::has_active_physical_display()) {
+          finish(true, "a physical (non-virtual) display is already active; the OS has a hardware-backed output to recover onto — nothing to do.");
+          return;
+        }
+
+        const auto devices = display_helper_integration::enumerate_devices(display_device::DeviceEnumerationDetail::Minimal);
+        if (!devices || devices->empty()) {
+          finish(false, "could not enumerate display devices; no physical display can be picked for activation.");
+          return;
+        }
+
+        // has_active_physical_display() returned false, so every physical
+        // device in the list is inactive — take the first one.
+        std::string device_id;
+        std::string device_label;
+        for (const auto &device : *devices) {
+          if (device.m_device_id.empty()) {
+            continue;
+          }
+          if (VDISPLAY::is_virtual_display_enumerated_device(device)) {
+            continue;
+          }
+          device_id = device.m_device_id;
+          device_label = device.m_friendly_name.empty() ? device.m_device_id : device.m_friendly_name;
+          break;
+        }
+        if (device_id.empty()) {
+          finish(false, "no physical display device is connected; nothing to activate.");
+          return;
+        }
+
+        BOOST_LOG(info) << "TDR lifeboat: asking the display helper to activate physical display \"" << device_label
+                        << "\" (EnsureActive — the topology is extended; the virtual display stays active so capture keeps running on it).";
+
+        display_device::SingleDisplayConfiguration config;
+        config.m_device_id = device_id;
+        config.m_device_prep = display_device::SingleDisplayConfiguration::DevicePreparation::EnsureActive;
+
+        display_helper_integration::DisplayApplyRequest request;
+        request.action = display_helper_integration::DisplayApplyAction::Apply;
+        request.configuration = config;
+
+        // display_helper_integration::apply() is the highest-level topology
+        // API in the host: it routes through the interactive helper process,
+        // which owns display-topology writes in this architecture (SYSTEM-
+        // context SetDisplayConfig is unreliable, and the helper soft-tests
+        // with SDC_VALIDATE before committing). With no session attached the
+        // call neither hard-restarts a live helper nor falls back to an
+        // in-process SetDisplayConfig.
+        if (display_helper_integration::apply(request)) {
+          finish(true, "physical display \"" + device_label + "\" activated (topology extended) — the OS now has a hardware-backed display for TDR recovery.");
+        } else {
+          finish(false, "the display helper rejected or failed activation of \"" + device_label + "\"; continuing without a lifeboat display (the escalation paths handle a failed recovery).");
+        }
+      } catch (...) {
+        try {
+          finish(false, "attempt raised an exception; giving up.");
+        } catch (...) {
+          // Nothing sane left to do — never propagate out of the worker.
+        }
+      }
+    }
+
+    /// Task-pool entry: logs intent, spawns the bounded worker. Must not
+    /// block — the shared task pool runs input timers on its single thread.
+    void start_attempt(tdr::source_t source) {
+      try {
+        BOOST_LOG(warning) << "TDR lifeboat: GPU/TDR failure detected (" << tdr::source_label(source)
+                           << "); best-effort activating a physical display alongside the virtual display so Windows'"
+                           << " TDR recovery has a hardware-backed output to recompose onto. In every observed"
+                           << " machine-wide WDDM wedge, a virtual display was the exclusive active display"
+                           << " (POSTMORTEM-2026-07-27).";
+
+        auto state = std::make_shared<attempt_state_t>();
+
+        std::thread worker([state]() {
+          attempt_activate_physical_display(state);
+        });
+        worker.detach();
+
+        task_pool.pushDelayed(
+          [state]() {
+            if (!state->done.load(std::memory_order_acquire)) {
+              state->timed_out.store(true, std::memory_order_release);
+              BOOST_LOG(error) << "TDR lifeboat: no result within " << ATTEMPT_TIMEOUT.count()
+                               << " s; giving up on this attempt. The display stack may already be dead —"
+                               << " that is expected sometimes, and the escalation paths handle it.";
+            }
+          },
+          ATTEMPT_TIMEOUT
+        );
+      } catch (...) {
+        try {
+          BOOST_LOG(error) << "TDR lifeboat: failed to start the lifeboat attempt.";
+        } catch (...) {
+        }
+      }
+    }
+
+    /// tdr:: event hook. Runs on mark_event's calling thread — often a
+    /// time-critical path such as the NvEnc encode loop — so it stays
+    /// constant time: one uncontended mutex for the gate and one task-pool
+    /// push when the gate opens. Never throws, never blocks.
+    void on_tdr_event(tdr::source_t source) noexcept {
+      try {
+        {
+          std::lock_guard<std::mutex> lk(g_gate_mutex);
+          if (!g_gate.should_attempt(source, std::chrono::steady_clock::now())) {
+            return;
+          }
+        }
+        // The gate is armed before the attempt runs, so any tdr:: event a
+        // lifeboat attempt itself provokes (e.g. enumeration failing on a
+        // dead stack) cannot re-enter and spawn another attempt.
+        task_pool.push(start_attempt, source);
+      } catch (...) {
+        // Never propagate into mark_event's caller.
+      }
+    }
+  }  // namespace
+
+  void init() {
+    tdr::set_event_hook(&on_tdr_event);
+    BOOST_LOG(info) << "TDR topology lifeboat armed: on a detected GPU hang, a physical display is activated"
+                    << " alongside the virtual display (best-effort, at most once per "
+                    << std::chrono::duration_cast<std::chrono::minutes>(ATTEMPT_COOLDOWN).count()
+                    << " min).";
+  }
+
+}  // namespace tdr_lifeboat

--- a/src/platform/windows/tdr_lifeboat.h
+++ b/src/platform/windows/tdr_lifeboat.h
@@ -1,0 +1,117 @@
+/**
+ * @file src/platform/windows/tdr_lifeboat.h
+ * @brief TDR topology lifeboat — keep a hardware-backed display available
+ *        while Windows recovers from a GPU hang.
+ *
+ * In all three machine-wide WDDM wedges observed so far (2026-05-17,
+ * 2026-07-26, 2026-07-27 — see POSTMORTEM-2026-07-27.md), an IddCx virtual
+ * display was the EXCLUSIVE active display when the GPU hung, and Windows'
+ * TDR recovery then failed, leaving every output black until a reboot. The
+ * open hypothesis is that recovery waits on the indirect display whose own
+ * presentation pipeline runs on the very GPU being reset.
+ *
+ * The lifeboat: the moment the host detects a GPU hang (the earliest signal
+ * is tdr::mark_event with source encoder_stall, ~100 ms in), best-effort
+ * activate one PHYSICAL display alongside the virtual one — extend the
+ * topology, never deactivate the virtual display capture is running on — so
+ * the OS always has a hardware-backed display to recompose onto during
+ * recovery. Even if the hypothesis is wrong, this ends the "every output is
+ * black" experience: whatever recovery does, one physical output is lit.
+ *
+ * Everything here is best-effort and bounded: if the display stack is
+ * already too far gone for the helper to act (~5 s), we log and give up —
+ * the existing escalation paths (stack_down latch, session teardown) own
+ * the terminal handling.
+ */
+#pragma once
+
+#include "src/tdr_state.h"
+
+#include <chrono>
+#include <optional>
+
+namespace tdr_lifeboat {
+
+  /// Minimum spacing between lifeboat attempts. One attempt per incident:
+  /// a single GPU hang cascades through several detectors and, on a stack
+  /// that never recovers, is re-detected on every client attempt (~33 s
+  /// apart in the 2026-07-27 field incident). Matches tdr_state's incident
+  /// window so "once per incident" and "once per cooldown" line up.
+  constexpr std::chrono::minutes ATTEMPT_COOLDOWN {5};
+
+  /**
+   * @brief Whether a tdr:: event source warrants a lifeboat attempt.
+   *
+   * Every TDR-class detection qualifies: the earlier the attempt, the more
+   * likely the display stack can still service a topology write, but even a
+   * late detector (display_stack_down) is worth one bounded try. Unknown /
+   * out-of-range values do not trigger.
+   */
+  [[nodiscard]] constexpr bool is_lifeboat_source(tdr::source_t source) noexcept {
+    switch (source) {
+      case tdr::source_t::encoder_d3d11:
+      case tdr::source_t::dd_test_d3d11:
+      case tdr::source_t::virtual_display_enumerate:
+      case tdr::source_t::query_display_config:
+      case tdr::source_t::encoder_stall:
+      case tdr::source_t::display_stack_down:
+        return true;
+    }
+    return false;
+  }
+
+  /**
+   * @brief Pure "should a lifeboat attempt run now?" decision.
+   *
+   * Combines the two gating rules — the event source must be TDR-class,
+   * and no attempt may have been armed within the cooldown window — into
+   * one testable object with the clock injected by the caller.
+   *
+   * Not thread-safe on its own; the production consumer (tdr_lifeboat.cpp)
+   * serialises access. Header-only so unit tests exercise the exact
+   * shipping logic on every platform.
+   */
+  class attempt_gate {
+  public:
+    explicit attempt_gate(std::chrono::steady_clock::duration cooldown = ATTEMPT_COOLDOWN):
+        cooldown_ {cooldown} {
+    }
+
+    /**
+     * @brief Decide whether to attempt, and arm the cooldown if so.
+     * @param source The tdr:: event source that fired.
+     * @param now Caller-supplied steady-clock timestamp.
+     * @return True exactly when `source` is lifeboat-relevant and no prior
+     *         attempt was armed within the cooldown window. A true return
+     *         arms the cooldown — the caller is expected to attempt.
+     */
+    [[nodiscard]] bool should_attempt(tdr::source_t source, std::chrono::steady_clock::time_point now) {
+      if (!is_lifeboat_source(source)) {
+        return false;
+      }
+      if (last_attempt_ && (now - *last_attempt_) < cooldown_) {
+        // Same incident, re-detected. Denials deliberately do NOT extend
+        // the cooldown: a wedge that keeps re-firing must not starve the
+        // next attempt forever.
+        return false;
+      }
+      last_attempt_ = now;
+      return true;
+    }
+
+  private:
+    std::chrono::steady_clock::duration cooldown_;
+    std::optional<std::chrono::steady_clock::time_point> last_attempt_;
+  };
+
+  /**
+   * @brief Arm the lifeboat: installs the tdr:: event hook.
+   *
+   * Call once from Windows platf::init(), after the task pool is running.
+   * The hook does a constant-time gate check on the caller's thread and
+   * posts all real work to the task pool — it never blocks mark_event's
+   * caller and never throws.
+   */
+  void init();
+
+}  // namespace tdr_lifeboat

--- a/src/platform/windows/virtual_display.cpp
+++ b/src/platform/windows/virtual_display.cpp
@@ -4797,6 +4797,14 @@ bool VDISPLAY::has_active_physical_display() {
   return false;
 }
 
+bool VDISPLAY::is_virtual_display_enumerated_device(const display_device::EnumeratedDevice &device) {
+  // Thin public wrapper over the internal (anonymous-namespace) classifier
+  // so out-of-file consumers — currently the TDR topology lifeboat — can
+  // share the exact same virtual-vs-physical decision that
+  // has_active_physical_display() uses.
+  return is_virtual_display_device(device);
+}
+
 bool VDISPLAY::should_auto_enable_virtual_display() {
   if (!isSudaVDADriverInstalled()) {
     BOOST_LOG(warning) << "Suda VDA driver not installed, not enabling virtual display.";

--- a/src/platform/windows/virtual_display.h
+++ b/src/platform/windows/virtual_display.h
@@ -19,6 +19,10 @@
 #include <ddk/d4drvif.h>
 #include <sudovda/sudovda.h>
 
+namespace display_device {
+  struct EnumeratedDevice;
+}  // namespace display_device
+
 namespace VDISPLAY {
   inline constexpr const char *SUDOVDA_VIRTUAL_DISPLAY_SELECTION = "sunshine:sudovda_virtual_display";
 
@@ -110,6 +114,15 @@ namespace VDISPLAY {
   /// SudoVDA "SMKD1CE", LuminalVGD "NBF5001") belongs to a known
   /// virtual-display driver.
   bool is_virtual_display_hardware_id(const std::string &hardware_id);
+
+  /// Backend-agnostic check whether an enumerated display device belongs to
+  /// a known virtual-display driver (LuminalVGD, SudoVDA). Works for
+  /// inactive devices too — it matches on the monitor device path /
+  /// hardware id / friendly name, not on the active display name. Thin
+  /// public wrapper over the internal classifier that
+  /// has_active_physical_display() uses; exported for the TDR topology
+  /// lifeboat (src/platform/windows/tdr_lifeboat.cpp).
+  bool is_virtual_display_enumerated_device(const display_device::EnumeratedDevice &device);
 
   std::vector<std::wstring> matchDisplay(std::wstring sMatch);
 

--- a/src/tdr_state.cpp
+++ b/src/tdr_state.cpp
@@ -44,6 +44,10 @@ namespace tdr {
     // a fresh incident.
     constexpr std::chrono::seconds kLogCooldown {30};
     constexpr std::chrono::minutes kNotifyCooldown {2};
+
+    // Observer installed via set_event_hook(). Guarded by g_mutex; copied
+    // out and invoked only after the lock is released (see mark_event).
+    std::function<void(source_t)> g_event_hook;
   }  // namespace
 
   void mark_event(source_t source, long hresult, std::string detail) {
@@ -59,8 +63,10 @@ namespace tdr {
 
     bool should_log = false;
     bool should_notify = false;
+    std::function<void(source_t)> hook_copy;
     {
       std::lock_guard<std::mutex> lk(g_mutex);
+      hook_copy = g_event_hook;
       g_last = event;
       g_count.fetch_add(1, std::memory_order_relaxed);
 
@@ -126,6 +132,18 @@ namespace tdr {
 #else
     (void) should_notify;
 #endif
+
+    // Invoked strictly after g_mutex is released so a hook may call back
+    // into tdr:: accessors. The hook contract (tdr_state.h) requires it to
+    // be non-blocking — we are on the caller's thread, which can be a
+    // time-critical path such as the NvEnc encode loop.
+    if (hook_copy) {
+      try {
+        hook_copy(source);
+      } catch (...) {
+        // A misbehaving observer must never break event recording.
+      }
+    }
   }
 
   bool recovery_recent(std::chrono::seconds within) {
@@ -189,6 +207,11 @@ namespace tdr {
   std::uint64_t incident_count() {
     std::lock_guard<std::mutex> lk(g_mutex);
     return g_incident_count;
+  }
+
+  void set_event_hook(std::function<void(source_t)> hook) {
+    std::lock_guard<std::mutex> lk(g_mutex);
+    g_event_hook = std::move(hook);
   }
 
   const char *source_label(source_t source) {

--- a/src/tdr_state.h
+++ b/src/tdr_state.h
@@ -21,6 +21,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <string>
 
@@ -162,5 +163,24 @@ namespace tdr {
 
   /// Human-readable label for `source_t` (used by logs and the Web UI).
   const char *source_label(source_t source);
+
+  /**
+   * @brief Install a process-wide observer invoked after every `mark_event`.
+   *
+   * The hook runs on the thread that called `mark_event`, after the
+   * internal lock has been released (it is never invoked under the lock,
+   * so hook implementations may call back into `tdr::` accessors freely).
+   *
+   * IMPORTANT: the hook MUST NOT block. `mark_event` is called from
+   * time-critical paths — e.g. the NvEnc encode loop detecting an encoder
+   * stall — so the hook should do the cheapest possible dispatch (a
+   * rate-limit check, a task-pool push) and post the actual work to a
+   * worker thread. Exceptions thrown by the hook are swallowed.
+   *
+   * Replaces any previously-installed hook; pass `nullptr` to remove.
+   * Intended for a single consumer wired up at process init (currently the
+   * TDR topology lifeboat, src/platform/windows/tdr_lifeboat.h).
+   */
+  void set_event_hook(std::function<void(source_t)> hook);
 
 }  // namespace tdr

--- a/tests/unit/test_tdr_lifeboat.cpp
+++ b/tests/unit/test_tdr_lifeboat.cpp
@@ -1,0 +1,108 @@
+/**
+ * @file tests/unit/test_tdr_lifeboat.cpp
+ * @brief The TDR topology lifeboat's pure attempt decision.
+ *
+ * Covers the gate that turns a stream of tdr:: detections into at most one
+ * lifeboat attempt per incident (POSTMORTEM-2026-07-27: one GPU hang was
+ * re-detected ~22 times across several subsystems — the lifeboat must fire
+ * on the first detection and stay quiet for the rest). Only the decision
+ * logic is tested here; actual topology changes go through the display
+ * helper and are exercised on real hardware, not in unit tests.
+ */
+
+// standard includes
+#include <chrono>
+
+// lib includes
+#include <gtest/gtest.h>
+
+// local includes
+#include "../tests_common.h"
+#include "src/platform/windows/tdr_lifeboat.h"
+
+namespace {
+  using namespace std::chrono_literals;
+  using std::chrono::steady_clock;
+
+  constexpr tdr::source_t kAllSources[] = {
+    tdr::source_t::encoder_d3d11,
+    tdr::source_t::dd_test_d3d11,
+    tdr::source_t::virtual_display_enumerate,
+    tdr::source_t::query_display_config,
+    tdr::source_t::encoder_stall,
+    tdr::source_t::display_stack_down,
+  };
+
+  TEST(TdrLifeboat, AnyTdrClassSourceTriggersAFreshGate) {
+    // Every detector qualifies: the earliest (encoder_stall, ~100 ms into
+    // the hang) is the most valuable, but even a late one deserves the
+    // single bounded attempt.
+    for (const auto source : kAllSources) {
+      tdr_lifeboat::attempt_gate gate;
+      EXPECT_TRUE(gate.should_attempt(source, steady_clock::now()))
+        << "source " << static_cast<int>(source) << " must trigger on a fresh gate";
+    }
+  }
+
+  TEST(TdrLifeboat, UnknownSourceValueNeverTriggers) {
+    tdr_lifeboat::attempt_gate gate;
+    EXPECT_FALSE(gate.should_attempt(static_cast<tdr::source_t>(0), steady_clock::now()));
+    EXPECT_FALSE(gate.should_attempt(static_cast<tdr::source_t>(999), steady_clock::now()));
+  }
+
+  TEST(TdrLifeboat, SecondCallWithinCooldownIsSuppressed) {
+    tdr_lifeboat::attempt_gate gate;
+    const auto t0 = steady_clock::now();
+
+    ASSERT_TRUE(gate.should_attempt(tdr::source_t::encoder_stall, t0));
+
+    // The same hang cascading through other detectors moments later, and
+    // being re-detected by the next client attempt ~33 s in.
+    EXPECT_FALSE(gate.should_attempt(tdr::source_t::encoder_d3d11, t0 + 150ms));
+    EXPECT_FALSE(gate.should_attempt(tdr::source_t::query_display_config, t0 + 33s));
+    EXPECT_FALSE(gate.should_attempt(tdr::source_t::encoder_stall, t0 + 4min + 59s));
+  }
+
+  TEST(TdrLifeboat, CallAfterCooldownIsAllowed) {
+    tdr_lifeboat::attempt_gate gate;
+    const auto t0 = steady_clock::now();
+
+    ASSERT_TRUE(gate.should_attempt(tdr::source_t::encoder_stall, t0));
+    EXPECT_TRUE(gate.should_attempt(tdr::source_t::encoder_stall, t0 + 5min))
+      << "a detection at exactly the cooldown boundary is a new incident";
+  }
+
+  TEST(TdrLifeboat, SuppressedCallsDoNotExtendTheCooldown) {
+    // A wedge that keeps re-firing (~33 s cadence in the field) must not
+    // starve the next attempt: denials leave the armed timestamp alone.
+    tdr_lifeboat::attempt_gate gate;
+    const auto t0 = steady_clock::now();
+
+    ASSERT_TRUE(gate.should_attempt(tdr::source_t::encoder_stall, t0));
+    for (auto t = t0 + 33s; t < t0 + 5min; t += 33s) {
+      EXPECT_FALSE(gate.should_attempt(tdr::source_t::encoder_d3d11, t));
+    }
+    EXPECT_TRUE(gate.should_attempt(tdr::source_t::encoder_d3d11, t0 + 5min + 1s));
+  }
+
+  TEST(TdrLifeboat, TrueReturnArmsTheCooldownImmediately) {
+    // The gate arms on the decision, not on attempt completion, so a
+    // lifeboat attempt that itself provokes tdr:: events (enumeration
+    // failing on a dead stack) cannot re-enter and spawn another attempt.
+    tdr_lifeboat::attempt_gate gate;
+    const auto t0 = steady_clock::now();
+
+    ASSERT_TRUE(gate.should_attempt(tdr::source_t::encoder_stall, t0));
+    EXPECT_FALSE(gate.should_attempt(tdr::source_t::virtual_display_enumerate, t0))
+      << "an event at the same instant must fold into the armed attempt";
+  }
+
+  TEST(TdrLifeboat, CustomCooldownIsHonored) {
+    tdr_lifeboat::attempt_gate gate {std::chrono::seconds {10}};
+    const auto t0 = steady_clock::now();
+
+    ASSERT_TRUE(gate.should_attempt(tdr::source_t::encoder_stall, t0));
+    EXPECT_FALSE(gate.should_attempt(tdr::source_t::encoder_stall, t0 + 9s));
+    EXPECT_TRUE(gate.should_attempt(tdr::source_t::encoder_stall, t0 + 10s));
+  }
+}  // namespace


### PR DESCRIPTION
## What

Best-effort "topology lifeboat" for GPU hangs: the moment the host records a TDR-class event (earliest signal: `encoder_stall`, ~100 ms into the hang), activate one **physical** display alongside the virtual one — extend the topology, never deactivate the virtual display capture is running on — so Windows always has a hardware-backed output to recompose onto during TDR recovery.

## Why

POSTMORTEM-2026-07-27.md: in **all three** observed machine-wide WDDM wedges (2026-05-17 under SudoVDA, 2026-07-26, 2026-07-27), an IddCx virtual display was the **exclusive** active display when the GPU hung, and Windows' TDR recovery then failed, blanking every output until reboot. The open hypothesis is that recovery waits on the indirect display whose own presentation pipeline runs on the GPU being reset. Even if that hypothesis is wrong, running virtual-exclusive meant no physical output was lit when the wedge hit — this change ends the "every output black" experience either way.

## How

- **`src/tdr_state.{h,cpp}`** — append-only `set_event_hook()` observer: copied under the existing mutex, invoked only **after** the lock is released, exceptions swallowed. Documented non-blocking contract (`mark_event` runs on time-critical paths such as the NvEnc encode loop). No existing behavior changed.
- **`src/platform/windows/tdr_lifeboat.{h,cpp}`** (new) —
  - Pure `attempt_gate` (header-only, unit-tested): any TDR-class source triggers; at most one attempt per 5-minute incident window (matches tdr_state's incident window); denials do not extend the cooldown; the gate arms on the decision so events provoked by the attempt itself cannot re-enter.
  - Hook does a constant-time gate check on the caller's thread, then posts to `task_pool`. The pool task logs intent and hands the blocking work to a detached worker with a 5 s watchdog — the single-threaded, input-sharing task pool is never blocked, and a helper hung on a dead stack is abandoned (logged loudly).
  - The attempt: skip if `VDISPLAY::has_active_physical_display()`; otherwise pick the first physical device from `display_helper_integration::enumerate_devices()` and dispatch `display_helper_integration::apply()` with `DevicePreparation::EnsureActive`. The helper process owns topology writes (SYSTEM-context `SetDisplayConfig` is unreliable; the helper soft-tests with `SDC_VALIDATE`), and `EnsureActive` produces an **extended** topology — the virtual display stays active, capture keeps running. With no session attached, the call neither hard-restarts a live helper nor falls back to in-process `SetDisplayConfig`.
- **`src/platform/windows/virtual_display.{h,cpp}`** — export `is_virtual_display_enumerated_device()` (thin wrapper) so the lifeboat shares the exact virtual-vs-physical classifier `has_active_physical_display()` uses.
- **Wiring** — `tdr_lifeboat::init()` called from Windows `platf::init()` (`audio.cpp`), after the task pool is running. `src/main.cpp` deliberately untouched (concurrent PR edits it).
- **`tests/unit/test_tdr_lifeboat.cpp`** — gate decision coverage: every source triggers a fresh gate; unknown values never trigger; second call within 5 min suppressed; call at/after the boundary allowed; suppressed calls don't extend the cooldown; immediate re-entry folds into the armed attempt; custom cooldown honored. No topology changes are exercised in unit tests.

## Testing

- Full local build of `sunshine` + `test_sunshine` succeeds (MinGW/UCRT64, `-DBUILD_DOCS=OFF -DSUNSHINE_PACKAGE_LUMINALVGD=OFF`); `tdr_lifeboat.cpp` compiles warning-free.
- Local test **execution** was not possible in this session: the dev box's security stack (ESET) denies launching freshly built unsigned test binaries from this shell and quarantines them on the attempt — it also ate the pre-existing `build/tests/test_sunshine.exe` in the main checkout (rebuildable artifact; see session notes). Relying on CI to run `TdrLifeboat.*` + `TdrState.*`; known pre-existing local failures (DownloadFileTests, ConfigHttpCheckAuthTest.given_disallowed_ip…, PlayniteSync_*, LocaleConsistencyTest) are unrelated.

## Field validation

The next wedge should show, within ~1 s of the `GPU TDR escalated` signature line: `TDR lifeboat: GPU/TDR failure detected (encoder stall); best-effort activating a physical display…` followed by a loud success/failure/timeout outcome line. Verification item 10 of the postmortem (a run with a physical display kept active alongside the virtual one) can now be exercised by the lifeboat itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
