### PR TITLE
chore: bundle LuminalVGD v0.1.0-alpha.4 (build 14) in the MSI

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -341,7 +341,7 @@ jobs:
           # (github.com/NortheBridge/LuminalVGD releases). Bump on driver
           # releases. SudoVDA is gone by decision (2026-07-23) — the MSI's
           # drivers\luminalvgd\install.ps1 also removes it wherever found.
-          LUMINALVGD_VERSION: 'v0.1.0-alpha.3'
+          LUMINALVGD_VERSION: 'v0.1.0-alpha.4'
         run: |
           $ErrorActionPreference = 'Stop'
           $packageDir = Join-Path $PWD 'src_assets/windows/drivers/luminalvgd/driver-package'

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -147,7 +147,7 @@ jobs:
         # sign/install them in the coverage workflow.
         shell: pwsh
         env:
-          LUMINALVGD_VERSION: 'v0.1.0-alpha.3'
+          LUMINALVGD_VERSION: 'v0.1.0-alpha.4'
         run: |
           $ErrorActionPreference = 'Stop'
           $packageDir = Join-Path $PWD 'src_assets/windows/drivers/luminalvgd/driver-package'


### PR DESCRIPTION
Bumps the CI driver-package pin `v0.1.0-alpha.3` → `v0.1.0-alpha.4` in `ci-windows.yml` and `coverage-windows.yml` so the 26.08.0-beta.6 MSI bundles driver build 14 (TDR duck-out + watchdog contract — [LuminalVGD v0.1.0-alpha.4](https://github.com/NortheBridge/LuminalVGD/releases/tag/v0.1.0-alpha.4)). Protocol unchanged (`proto 0.3`, handshake build 14); pairs with the host-side topology lifeboat merged in #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)