### PR TITLE
fix: defer NvEnc leak-reclaim restart while the display stack is down

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -637,6 +637,34 @@ namespace stream {
     deferred_stream_start_state().reset();
   }
 
+#ifdef _WIN32
+  // Post-drain-leak host restart, deferred while the display stack is
+  // down. Restarting into a wedged WDDM stack cannot reclaim anything —
+  // the 2026-07-28 incident restarted at 07:01:04 into a dead stack and
+  // the fresh process spent 5.4 minutes walking every encoder family
+  // through D3D retry ladders (web UI unreachable throughout) before
+  // idling against the same wedge. The leak only matters for the NEXT
+  // encoder init, which cannot succeed until the stack is back anyway,
+  // so the restart waits for tdr::note_stack_healthy() to clear the
+  // latch (or for the user's reboot, which recycles the process better
+  // than we can).
+  static void leak_reclaim_restart_tick() {
+    if (session::active_sessions.load(std::memory_order_acquire) > 0) {
+      BOOST_LOG(info) << "Skipping post-leak host restart; a new session is active.";
+      return;
+    }
+    if (tdr::stack_down()) {
+      BOOST_LOG(warning) << "Deferring post-leak host restart: the display stack is down "
+                            "machine-wide (reboot required) and a fresh process could not "
+                            "probe encoders anyway. Re-checking in 60s.";
+      task_pool.pushDelayed(&leak_reclaim_restart_tick, 60s);
+      return;
+    }
+    BOOST_LOG(info) << "Restarting host to reclaim leaked NVENC registrations.";
+    platf::restart();
+  }
+#endif
+
   bool apply_deferred_stream_start_actions_if_ready() {
     {
       std::lock_guard<std::mutex> lock(deferred_stream_start_mutex());
@@ -2512,14 +2540,7 @@ namespace stream {
         if (const auto leaks = nvenc::drain_leak_count(); leaks > 0) {
           BOOST_LOG(warning) << "NvEnc drain-leak events this process: " << leaks
                              << "; scheduling a clean host restart now that no sessions remain.";
-          task_pool.pushDelayed([]() {
-            if (session::active_sessions.load(std::memory_order_acquire) > 0) {
-              BOOST_LOG(info) << "Skipping post-leak host restart; a new session is active.";
-              return;
-            }
-            BOOST_LOG(info) << "Restarting host to reclaim leaked NVENC registrations.";
-            platf::restart();
-          }, 15s);
+          task_pool.pushDelayed(&leak_reclaim_restart_tick, 15s);
         }
 #endif
         // Only revert on disconnect when explicitly enabled by config.

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -650,7 +650,19 @@ namespace stream {
   // than we can).
   static void leak_reclaim_restart_tick() {
     if (session::active_sessions.load(std::memory_order_acquire) > 0) {
+      // A later RTSP session end re-arms the schedule, so a plain return
+      // is safe here.
       BOOST_LOG(info) << "Skipping post-leak host restart; a new session is active.";
+      return;
+    }
+    if (webrtc_stream::has_active_sessions()) {
+      // WebRTC sessions live outside session::active_sessions, and their
+      // teardown never re-arms this schedule (it is armed only on the
+      // RTSP last-session-end path) — so a skip here must RESCHEDULE,
+      // not return, or the reclaim is lost. Restarting through an active
+      // WebRTC stream would kill it mid-session.
+      BOOST_LOG(info) << "Deferring post-leak host restart; a WebRTC session is active. Re-checking in 60s.";
+      task_pool.pushDelayed(&leak_reclaim_restart_tick, 60s);
       return;
     }
     if (tdr::stack_down()) {


### PR DESCRIPTION
## The defect (2026-07-28 incident)

After the GPU wedge killed the GTA V session, the drain-leak policy scheduled its "clean host restart" and executed it at 07:01:04 — **into a dead display stack**. The fresh process burned 5.4 minutes of startup encoder-probe retry ladders (nvenc → quicksync → amdvce → mediafoundation → software, 20 ladders) with the web UI unreachable the whole time, then idled against the same wedge until the user rebooted blind.

## The fix

`leak_reclaim_restart_tick()` (extracted from the inline lambda) now consults `tdr::stack_down()` before restarting: latched → defer and re-check every 60 s; healthy → restart as before. Rationale: leaked NVENC registrations only constrain the *next* encoder init, which cannot succeed on a dead stack anyway — restarting early destroys diagnostic state and burns the SCM failure-action budget for zero benefit.

Pairs with #112, which fixes the latch itself (`display_config_api_healthy` false-healthy). With both: wedge → latch within one ladder (~15 s) → loud "reboot required" + deferred restart, instead of a silent restart loop.

Task #56; evidence `C:\evidence\crash-20260728\FINDINGS.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)