### PR TITLE
fix: tray thread must observe shutdown while waiting for the shell

### DIFF
--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -242,6 +242,13 @@ namespace system_tray {
     // the 07:08 process hung in exactly this loop during service stop and
     // self-crashed via the watchdog (WER dump luminalshine.exe.18576.dmp,
     // tray thread parked in SleepEx at this line).
+    //
+    // Known residual (accepted): this covers the DEAD-shell case. A shell
+    // that is alive but HUNG passes GetShellWindow() and can then stall
+    // inside Shell_NotifyIcon (documented ~4 s SendMessageTimeout per
+    // call, a few calls per tray_init attempt) — those waits live in
+    // third-party/tray and remain shutdown-blind; the force-shutdown
+    // watchdog is the backstop for that path.
     while (GetShellWindow() == nullptr) {
       if (tray_shutdown_requested.load()) {
         return 0;
@@ -283,6 +290,12 @@ namespace system_tray {
       return 0;
     }
     if (!wait_for_default_desktop()) {
+      // false means either the 60 s timeout elapsed or shutdown was
+      // requested mid-wait — do not log a misleading timeout warning
+      // for the latter (it would pollute the next incident's evidence).
+      if (tray_shutdown_requested.load()) {
+        return 0;
+      }
       BOOST_LOG(warning) << "Timed out waiting for interactive desktop; system tray may not appear"sv;
     } else {
       BOOST_LOG(debug) << "Interactive desktop ready for tray initialization"sv;

--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -234,13 +234,30 @@ namespace system_tray {
 
     // Wait for the shell to be initialized before registering the tray icon.
     // This ensures the tray icon works reliably after a logoff/logon cycle.
+    //
+    // Must observe shutdown: when Explorer is dead, GetShellWindow() stays
+    // null indefinitely and a shutdown-blind wait here pins end_tray()'s
+    // join until the 10 s force-shutdown watchdog crashes the process. On
+    // 2026-07-28 Explorer had died of FATAL_MEMORY_EXHAUSTION at 06:42;
+    // the 07:08 process hung in exactly this loop during service stop and
+    // self-crashed via the watchdog (WER dump luminalshine.exe.18576.dmp,
+    // tray thread parked in SleepEx at this line).
     while (GetShellWindow() == nullptr) {
+      if (tray_shutdown_requested.load()) {
+        return 0;
+      }
       Sleep(1000);
     }
 
     auto wait_for_default_desktop = []() {
       constexpr int attempts = 60;
       for (int attempt = 0; attempt < attempts; ++attempt) {
+        // Same shutdown-observability contract as the shell-window wait
+        // above: this loop can hold the thread for up to 60 s, far past
+        // the 10 s shutdown watchdog.
+        if (tray_shutdown_requested.load()) {
+          return false;
+        }
         HDESK desktop = OpenInputDesktop(0, FALSE, DESKTOP_READOBJECTS | DESKTOP_ENUMERATE);
         if (desktop != nullptr) {
           auto close_desktop = util::fail_guard([desktop]() {
@@ -262,6 +279,9 @@ namespace system_tray {
       return false;
     };
 
+    if (tray_shutdown_requested.load()) {
+      return 0;
+    }
     if (!wait_for_default_desktop()) {
       BOOST_LOG(warning) << "Timed out waiting for interactive desktop; system tray may not appear"sv;
     } else {


### PR DESCRIPTION
## The defect (2026-07-28 incident, the dump in the crash bundle)

The tray thread'''s startup path waits for `GetShellWindow()` in a `Sleep(1000)` loop with no shutdown check. Explorer had died of `FATAL_MEMORY_EXHAUSTION` at 06:42, so when the 07:08 process got its stop request 3 s after starting, the tray thread was still parked in that loop — `end_tray()`'''s unbounded `join()` hung the main thread'''s shutdown, and 10 s later the force-shutdown watchdog crashed the process on purpose (`0x80000003` via `DebugBreak`). That produced a minidump + WER APPCRASH for what should have been a quiet exit — and those artifacts are exactly what the crash bundle led with, masquerading as the incident.

Symbolized proof (cdb + DWARF addr2line, `C:\evidence\crash-20260728\analysis-shine18576.log`): main thread in `util::FailGuard` cleanup → `system_tray::end_tray()` → `std::thread::join()`; tray thread in `KERNELBASE!SleepEx` ← `system_tray.cpp:237`.

## The fix

Both shutdown-blind pre-init waits — the shell-window loop and the 60 s `wait_for_default_desktop` loop (also longer than the 10 s watchdog) — now check `tray_shutdown_requested` every iteration and exit, with an early return between them. `end_tray()`'''s join now completes within ~1 s of the request. The `tray_init` retry loop already had the check; the run loop wakes via the existing condition variable.

Task #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)