### PR TITLE
fix: retry the deferred startup encoder probe (client HEVC/HDR/YUV444 warnings)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -743,7 +743,7 @@ int main(int argc, char *argv[]) {
     BOOST_LOG(warning) << "No gamepad input is available"sv;
   }
 
-  auto startup_probe = [&shutdown_event]() {
+  auto startup_probe = [&shutdown_event](bool allow_deferral) {
     if (video::has_attempted_encoder_probe()) {
       BOOST_LOG(debug) << "Startup encoder probe skipped; probe already attempted.";
       return;
@@ -754,7 +754,7 @@ int main(int argc, char *argv[]) {
     }
 
 #ifdef _WIN32
-    if (!platf::is_default_input_desktop_active()) {
+    if (allow_deferral && !platf::is_default_input_desktop_active()) {
       BOOST_LOG(info) << "Startup encoder probe deferred until the interactive desktop is ready.";
       return;
     }
@@ -815,7 +815,44 @@ int main(int argc, char *argv[]) {
 #endif
   };
 
-  startup_probe();
+  startup_probe(true);
+
+#ifdef _WIN32
+  // The deferred path above previously NEVER retried. A service started
+  // before logon — i.e. every boot — sat advertising H.264-only/SDR/4:2:0
+  // in serverinfo (active_hevc_mode/active_av1_mode stay 0 until a probe
+  // runs), so Moonlight clients warned "HEVC is unavailable", "HDR is
+  // unavailable", "YUV 4:4:4 is unavailable" at stream start, and the
+  // first launch paid the entire probe cost mid-launch (2026-07-28
+  // report, macOS clients hit hardest). Retry every 10 s until the
+  // desktop is ready; after ~2 min force one attempt anyway — a host
+  // parked at the lock screen can still probe encoder capabilities, and
+  // a failed attempt is cheap (the probe cache never trusts negatives
+  // and session prep re-probes).
+  if (!video::has_attempted_encoder_probe()) {
+    static std::function<void(bool)> s_probe_fn;
+    static std::function<void()> s_probe_retry_tick;
+    static int s_probe_retries = 0;
+    constexpr int kMaxDeferredProbeRetries = 12;
+    s_probe_fn = startup_probe;
+    s_probe_retry_tick = []() {
+      if (video::has_attempted_encoder_probe()) {
+        return;
+      }
+      ++s_probe_retries;
+      const bool force = s_probe_retries >= kMaxDeferredProbeRetries;
+      if (force) {
+        BOOST_LOG(info) << "Startup encoder probe still deferred after " << s_probe_retries
+                        << " checks; attempting it now regardless of desktop state.";
+      }
+      s_probe_fn(!force);
+      if (!video::has_attempted_encoder_probe() && !force) {
+        task_pool.pushDelayed(s_probe_retry_tick, 10s);
+      }
+    };
+    task_pool.pushDelayed(s_probe_retry_tick, 10s);
+  }
+#endif
 
   if (http::init()) {
     BOOST_LOG(fatal) << "HTTP interface failed to initialize"sv;


### PR DESCRIPTION
## The bug (field report, 2026-07-28: macOS Moonlight clients warn "HEVC is unavailable", "HDR is unavailable", "YUV 4:4:4 is unavailable" at stream start)

`startup_probe()` runs **once** at service start. Started before logon — every boot — `is_default_input_desktop_active()` is false, the probe defers, and **nothing retries it**. Until a probe runs, `video::active_hevc_mode`/`active_av1_mode` are 0 and the 4:4:4 flags unset, so `/serverinfo` (nvhttp.cpp:1794-1827) advertises `ServerCodecModeSupport` = **H.264-only / SDR / 4:2:0**. Every client poll sees that until the first session launch finally runs the probe mid-launch — after the client has already read the degraded capabilities and warned the user. That mid-launch probe is also the bulk of the first-stream launch delay (~95 s observed in the 2026-07-28 GTA session log; task #32).

Evidence: the 07:16 post-reboot log shows "Startup encoder probe deferred until the interactive desktop is ready" at 07:16:12 and **no probe ever ran** through 07:20:37, with the user actively at the desktop.

## The fix

The deferral now schedules a 10 s retry tick (task_pool) until the desktop is ready; after 12 checks (~2 min) it forces one attempt regardless — a host parked at the lock screen can still probe encoder capabilities, and a failed attempt costs little (`probe_cache_matches` never trusts negatives, and session prep re-probes exactly as before). `startup_probe` gained an `allow_deferral` parameter so the forced attempt reuses the identical probe path.

Post-fix boot sequence: service starts → deferred → desktop ready within a tick or two → probe completes at idle → `/serverinfo` advertises full HEVC/AV1/HDR/4:4:4 **before** any client streams, and the first launch skips the probe entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)