### PR TITLE
feat: HDR peak brightness (nits) slider in the VGD Control Panel

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1802,6 +1802,36 @@ editing the `conf` file in a text editor. Use the examples as reference.
     </tr>
 </table>
 
+### vgd_hdr_peak_nits
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            HDR peak brightness (nits) advertised by the LuminalVGD virtual display's EDID.<br>
+            Windows and HDR-aware games read this as the display's peak luminance; it also feeds the HDR10 metadata sent to Moonlight clients.
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}800@endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}
+            vgd_hdr_peak_nits = 1000
+            @endcode</td>
+    </tr>
+    <tr>
+        <td>Notes</td>
+        <td colspan="2">
+            Range 0–1000; values from 790 up correspond to the "HDR" zone on the Control Panel slider.<br>
+            The EDID encodes luminance on a coarse logarithmic scale (~2% steps): 800 encodes exactly, 1000 encodes as 993, and values below 51 clamp to the encodable floor.<br>
+            Applies when the virtual display is created (the next streaming session). Requires LuminalVGD driver build 15+; older drivers ignore it and use 993.
+        </td>
+    </tr>
+</table>
+
 ### max_bitrate
 
 <table>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -794,6 +794,7 @@ namespace config {
     video_t::virtual_display_mode_e::per_client,  // virtual_display_mode
     video_t::virtual_display_layout_e::exclusive,  // virtual_display_layout
     "auto",  // virtual_display_backend
+    800,  // vgd_hdr_peak_nits
 
     {
       video_t::dd_t::config_option_e::verify_only,  // configuration_option
@@ -1566,6 +1567,7 @@ namespace config {
     generic_f(vars, "virtual_display_mode", video.virtual_display_mode, virtual_display_mode_from_view);
     generic_f(vars, "virtual_display_layout", video.virtual_display_layout, virtual_display_layout_from_view);
     string_f(vars, "virtual_display_backend", video.virtual_display_backend);
+    int_between_f(vars, "vgd_hdr_peak_nits", video.vgd_hdr_peak_nits, {0, 1000});
 
     generic_f(vars, "dd_configuration_option", video.dd.configuration_option, dd::config_option_from_view);
     generic_f(vars, "dd_resolution_option", video.dd.resolution_option, dd::resolution_option_from_view);
@@ -2361,6 +2363,7 @@ namespace config {
       const auto prev_dd_snapshot_exclude_devices = video.dd.snapshot_exclude_devices;
       const auto prev_dd_dummy_plug = video.dd.wa.dummy_plug_hdr10;
       const auto prev_dd_virtual_double_refresh = video.dd.wa.virtual_double_refresh;
+      const auto prev_vgd_hdr_peak_nits = video.vgd_hdr_peak_nits;
 
       auto vars = parse_config(file_handler::read_file(sunshine.config_file.c_str()));
       for (const auto &[name, value] : command_line_overrides) {
@@ -2408,7 +2411,12 @@ namespace config {
                                      (prev_dd_activate_virtual_display != video.dd.activate_virtual_display) ||
                                      (prev_dd_snapshot_exclude_devices != video.dd.snapshot_exclude_devices) ||
                                      (prev_dd_dummy_plug != video.dd.wa.dummy_plug_hdr10) ||
-                                     (prev_dd_virtual_double_refresh != video.dd.wa.virtual_double_refresh);
+                                     (prev_dd_virtual_double_refresh != video.dd.wa.virtual_double_refresh) ||
+                                     // Nits is baked into the virtual display's EDID at
+                                     // creation — reverting cached display state makes an
+                                     // idle-time slider change take effect on the next
+                                     // session instead of whenever the display recycles.
+                                     (prev_vgd_hdr_peak_nits != video.vgd_hdr_peak_nits);
 
       // If any DD settings changed and there are no active sessions, revert to clear cached state
       if (dd_config_changed && rtsp_stream::session_count() == 0 && runtime_overrides.empty()) {

--- a/src/config.h
+++ b/src/config.h
@@ -134,6 +134,12 @@ namespace config {
     /// without a config migration.
     std::string virtual_display_backend;
 
+    /// HDR peak brightness (nits) advertised by the LuminalVGD virtual
+    /// display's EDID (CTA-861.3 max luminance). 0–1000, default 800.
+    /// Applied at monitor creation; requires driver build 15+ (older
+    /// drivers ignore it and advertise the built-in 993).
+    int vgd_hdr_peak_nits;
+
     struct dd_t {
       struct workarounds_t {
         bool dummy_plug_hdr10;  ///< Force 30 Hz and HDR for physical dummy plugs (requires VSYNC override).

--- a/src/platform/windows/virtual_display_vgd.cpp
+++ b/src/platform/windows/virtual_display_vgd.cpp
@@ -7,6 +7,7 @@
 
 #include "src/platform/windows/vgd_devnode.h"
 
+#include "src/config.h"
 #include "src/logging.h"
 
 #include <algorithm>
@@ -300,6 +301,21 @@ namespace VDISPLAY::vgd {
     req.hdr = hdr ? 1 : 0;
     if (enable_hdr && !hdr) {
       BOOST_LOG(info) << "LuminalVGD: client requested HDR but the installed driver lacks HDR10 caps; creating SDR monitor.";
+    }
+    if (hdr) {
+      // EDID peak luminance from config (proto 0.4 additive field). 0 on
+      // the wire means "driver default (993 nits)"; a slider value of 0
+      // is sent as 1 so it clamps to the CTA floor (~51 nits) instead of
+      // silently meaning "default". Pre-0.4 drivers (build ≤14) ignore
+      // the tail bytes entirely.
+      const int nits = config::video.vgd_hdr_peak_nits;
+      req.max_nits = static_cast<uint32_t>(std::max(nits, 1));
+      if (g_caps && g_caps->proto_minor < 4 && nits != 800) {
+        BOOST_LOG(info) << "LuminalVGD: vgd_hdr_peak_nits=" << nits
+                        << " requires driver build 15+ (proto 0.4); the installed driver ("
+                        << "proto " << g_caps->proto_major << '.' << g_caps->proto_minor
+                        << ") uses its built-in 993 nits.";
+      }
     }
     req.flags = 0;
     req.mode_count = 1;

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -339,6 +339,8 @@
     "virtual_display_status_state_version_incompatible": "Driver version mismatch",
     "virtual_display_status_state_watchdog_failed": "Driver watchdog failed",
     "virtual_display_status_recheck": "Re-check driver",
+    "vgd_hdr_peak_nits": "HDR peak brightness (nits)",
+    "vgd_hdr_peak_nits_desc": "Peak luminance the virtual display advertises to Windows and HDR-aware games, and the ceiling reported in HDR10 metadata to Moonlight clients. 790–1000 is the HDR zone; 800 is the default. Applies when the virtual display is created (the next streaming session) and requires LuminalVGD driver build 15 or newer.",
     "virtual_display_backend": "Virtual display driver",
     "virtual_display_backend_desc": "Selects which virtual display driver LuminalShine talks to when creating per-client virtual monitors. LuminalVGD (the first-party driver) is the only supported backend; Auto selects it when installed. If the driver is missing, run \"Reconfigure LuminalShine\" from the Start Menu (or relaunch the LuminalShine installer) to install it.",
     "virtual_display_backend_auto": "Auto (recommended) — LuminalVGD",

--- a/src_assets/common/assets/web/stores/config.ts
+++ b/src_assets/common/assets/web/stores/config.ts
@@ -175,6 +175,7 @@ const defaultGroups = [
       },
       dd_wa_virtual_double_refresh: true,
       dd_wa_dummy_plug_hdr10: false,
+      vgd_hdr_peak_nits: 800,
       max_bitrate: 0,
       minimum_fps_target: 20,
       lossless_scaling_path: '',

--- a/src_assets/common/assets/web/views/VgdControlPanelView.vue
+++ b/src_assets/common/assets/web/views/VgdControlPanelView.vue
@@ -64,6 +64,32 @@
             >
               <template v-if="item.suffix" #suffix>{{ item.suffix }}</template>
             </n-input-number>
+            <div v-else-if="item.type === 'slider'" class="w-56 sm:w-72">
+              <n-slider
+                :value="toNumber(config[item.key], Number(item.fallback ?? 0))"
+                :min="item.min ?? 0"
+                :max="item.max ?? 100"
+                :step="1"
+                :marks="item.marks"
+                @update:value="(v: number) => setOption(item.key, v)"
+              />
+              <div class="mt-1 flex items-center justify-end gap-2 text-xs opacity-80">
+                <span>
+                  {{ toNumber(config[item.key], Number(item.fallback ?? 0)) }}
+                  {{ item.suffix }}
+                </span>
+                <n-tag
+                  v-if="
+                    item.hdrZoneFrom !== undefined &&
+                    toNumber(config[item.key], Number(item.fallback ?? 0)) >= item.hdrZoneFrom
+                  "
+                  size="small"
+                  type="warning"
+                >
+                  HDR
+                </n-tag>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -87,7 +113,7 @@
 import { computed, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
-import { NAlert, NSwitch, NSelect, NInputNumber } from 'naive-ui';
+import { NAlert, NSwitch, NSelect, NInputNumber, NSlider, NTag } from 'naive-ui';
 import { useConfigStore } from '@/stores/config';
 
 const { t } = useI18n();
@@ -138,13 +164,17 @@ interface PanelItem {
   key: string;
   label: string;
   hint: string;
-  type: 'switch' | 'select' | 'number';
+  type: 'switch' | 'select' | 'number' | 'slider';
   options?: { label: string; value: string }[];
   suffix?: string;
   fallback?: string | number;
   boolEncoding?: 'string';
   min?: number;
   max?: number;
+  /// Slider tick labels ({value: label}).
+  marks?: Record<number, string>;
+  /// Values >= this render the "HDR" tag next to the readout.
+  hdrZoneFrom?: number;
 }
 
 interface PanelGroup {
@@ -273,6 +303,31 @@ const groups = computed<PanelGroup[]>(() => [
     footnote: tr(
       'vgd.modes_footnote',
       'The virtual display advertises the client-native mode automatically (up to four exact modes per monitor, millihertz-precise refresh, HDR10 when the client and driver support it).',
+    ),
+  },
+  {
+    title: tr('vgd.group_hdr', 'HDR'),
+    icon: 'fas fa-sun',
+    items: [
+      {
+        key: 'vgd_hdr_peak_nits',
+        label: tr('config.vgd_hdr_peak_nits', 'HDR peak brightness (nits)'),
+        hint: tr(
+          'vgd.hdr_peak_nits_hint',
+          'Peak luminance the virtual display advertises to Windows and HDR-aware games. Saves automatically; applies to the next streaming session.',
+        ),
+        type: 'slider',
+        fallback: 800,
+        min: 0,
+        max: 1000,
+        suffix: 'nits',
+        hdrZoneFrom: 790,
+        marks: { 790: 'HDR', 1000: '1000' },
+      },
+    ],
+    footnote: tr(
+      'vgd.hdr_footnote',
+      'Requires LuminalVGD driver build 15 or newer (older drivers use their built-in 993 nits). The EDID stores brightness on a ~2% logarithmic scale — 800 encodes exactly; 1000 encodes as 993.',
     ),
   },
 ]);


### PR DESCRIPTION
Host side of the **HDR Nits slider** (driver side: [LuminalVGD #24](https://github.com/NortheBridge/LuminalVGD/pull/24) — proto 0.4, build 15, awaiting review + signing).

## What you get

**VGD Control Panel → HDR**: the web UI'''s first slider (naive-ui `NSlider`) — 0–1000 nits, default **800**, marks at **790 ("HDR")** and 1000, live readout with an **HDR** tag whenever the value is in the 790–1000 zone. It saves through the panel'''s existing debounced auto-apply (no Save button, matching every other control there) and takes effect on the next streaming session.

## Plumbing

- New config key `vgd_hdr_peak_nits` (0–1000, default 800) across all five consistency-test files — 5/5 `ConfigConsistency` tests pass locally.
- `virtual_display_vgd.cpp` sets `req.max_nits` on HDR creates. Slider 0 sends 1 (clamps to the CTA floor ≈51 nits) rather than silently meaning "driver default". When the installed driver is pre-0.4 and the value isn'''t default, a log hint explains why it has no effect.
- `apply_config_now`: nits joins the dd-change comparison, so an idle-time slider change reverts cached display state and the next session gets the new EDID.
- Submodule pin → `da0349b` (proto 0.4 + FFI `max_nits`; also brings the vendored tree to build-15 source). The host announces `PROTO_VERSION_MINOR_REQUIRED = 3` at handshake — **build-14 drivers keep working unchanged**; with them the slider is inert (993 nits) until build 15 is signed/installed.

## Encoding notes (driver-verified)

The EDID stores luminance as an 8-bit log code (`L = 50·2^(code/32)`): **800 nits encodes exactly (code 128)**; 1000 encodes as 993 (code 138 — precisely the old hardcoded value); ~2 % steps in the HDR zone.

Rollout: mergeable now (behaves identically until build 15 is installed — the no-reboot switchover from #116 then picks the new driver up on the next service start after staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)