### PR TITLE
chore: bump bundled LuminalVGD to v0.1.0-alpha.5 (build 15)

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -341,7 +341,7 @@ jobs:
           # (github.com/NortheBridge/LuminalVGD releases). Bump on driver
           # releases. SudoVDA is gone by decision (2026-07-23) — the MSI's
           # drivers\luminalvgd\install.ps1 also removes it wherever found.
-          LUMINALVGD_VERSION: 'v0.1.0-alpha.4'
+          LUMINALVGD_VERSION: 'v0.1.0-alpha.5'
         run: |
           $ErrorActionPreference = 'Stop'
           $packageDir = Join-Path $PWD 'src_assets/windows/drivers/luminalvgd/driver-package'

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -147,7 +147,7 @@ jobs:
         # sign/install them in the coverage workflow.
         shell: pwsh
         env:
-          LUMINALVGD_VERSION: 'v0.1.0-alpha.4'
+          LUMINALVGD_VERSION: 'v0.1.0-alpha.5'
         run: |
           $ErrorActionPreference = 'Stop'
           $packageDir = Join-Path $PWD 'src_assets/windows/drivers/luminalvgd/driver-package'


### PR DESCRIPTION
Pin bump for 26.08.0-beta.7: the MSI/portable bundles driver **build 15** ([v0.1.0-alpha.5](https://github.com/NortheBridge/LuminalVGD/releases/tag/v0.1.0-alpha.5), proto 0.4 — configurable HDR peak nits), signed and released at user direction. Pairs with #118 (the Control Panel nits slider).

🤖 Generated with [Claude Code](https://claude.com/claude-code)