### PR TITLE
Forced WGC->VGD transition: no-restart backend heal + mid-session retarget

### DIFF
--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -152,6 +152,8 @@ set(PLATFORM_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/platform/windows/vgd_recovery.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/vgd_devnode.h"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/vgd_devnode.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/vgd_transition.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/vgd_transition.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/tdr_lifeboat.h"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/tdr_lifeboat.cpp"
         "${CMAKE_SOURCE_DIR}/third-party/sudovda/sudovda-ioctl.h"

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -63,6 +63,7 @@
   #include "platform/windows/render_stack_detect.h"
   #include "platform/windows/sudovda_recovery.h"
   #include "platform/windows/vgd_recovery.h"
+  #include "platform/windows/vgd_transition.h"
 #endif
 #include "cred_store/cred_store.h"
 #include "entry_handler.h"
@@ -744,6 +745,38 @@ namespace confighttp {
     if (!result.instance_id.empty()) {
       out["instance_id"] = result.instance_id;
     }
+    send_response(response, out);
+  }
+
+  /**
+   * @brief Force a WGC->VGD transition attempt now (task #61): re-attempt
+   *        the devnode ensure, re-run backend selection, and initialize
+   *        the driver status — the same sequence the periodic transition
+   *        watcher runs, kicked on demand from the VGD Control Panel.
+   *
+   * Authenticated. POST so it can't be triggered by accidental
+   * navigation. Body is ignored. The attempt runs on a background worker;
+   * the response reports only whether one was started ("started"), or why
+   * not ("already_vgd", "busy", "stack_down", "shutting_down").
+   *
+   * @api_examples{/api/state/vgd-transition| POST| {"status":true,"result":"started"}}
+   */
+  void forceVgdTransition(resp_https_t response, req_https_t request) {
+    if (!check_content_type(response, request, "application/json")) {
+      return;
+    }
+    if (!authenticate(response, request)) {
+      return;
+    }
+    print_req(request);
+
+    BOOST_LOG(info) << "WGC->VGD transition requested from the Web UI.";
+    const auto status = platf::vgd_transition::kick_now();
+
+    nlohmann::json out;
+    out["status"] = status == platf::vgd_transition::kick_status::started ||
+                    status == platf::vgd_transition::kick_status::already_vgd;
+    out["result"] = platf::vgd_transition::kick_status_name(status);
     send_response(response, out);
   }
 
@@ -2490,7 +2523,7 @@ namespace confighttp {
         }
       }
       output_tree["virtual_display_backend"] = VDISPLAY::active_backend_name();
-      output_tree["virtual_display_driver_status"] = static_cast<int>(proc::vDisplayDriverStatus);
+      output_tree["virtual_display_driver_status"] = static_cast<int>(proc::vDisplayDriverStatus.load());
       output_tree["virtual_display_driver_ready"] =
         proc::vDisplayDriverStatus == VDISPLAY::DRIVER_STATUS::OK;
       // Host identity for the Session Details panel: the LuminalShine
@@ -2545,6 +2578,15 @@ namespace confighttp {
           output_tree["vgd_handshake"] = *handshake;
         }
         output_tree["vgd_hdr10"] = VDISPLAY::vgd::driver_supports_hdr();
+      }
+      // Which capture backend the most recent display open landed on
+      // (VGD ring vs WGC vs DDA) — Troubleshooting truth for "is this
+      // stream actually on the ring", recorded by platf::display().
+      const auto capture = platf::vgd_transition::last_capture_note();
+      if (capture.sequence != 0) {
+        output_tree["capture_backend_active"] = capture.kind;
+        output_tree["capture_backend_display"] = capture.display;
+        output_tree["capture_backend_age_seconds"] = capture.age_ms / 1000;
       }
     } catch (...) {
       // Non-fatal; the UI gracefully falls back to "unknown" status.
@@ -4418,6 +4460,7 @@ namespace confighttp {
     register_api_route("^/api/health/crashdump/dismiss$", "POST", postCrashDumpDismiss);
     register_api_route("^/api/state/vdd-restart$", "POST", restartVirtualDisplayDriver);
     register_api_route("^/api/state/vdd-diagnostic$", "GET", getVirtualDisplayDiagnostic);
+    register_api_route("^/api/state/vgd-transition$", "POST", forceVgdTransition);
     register_api_route("^/api/health/render-stack$", "GET", getRenderStack);
     register_api_route("^/api/health/amd-encoder$", "GET", getAmdEncoderCaps);
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,7 @@
   #include "src/platform/windows/playnite_integration.h"
   #include "src/platform/windows/rtss_integration.h"
   #include "src/platform/windows/vgd_devnode.h"
+  #include "src/platform/windows/vgd_transition.h"
   #include "src/platform/windows/virtual_display.h"
   #include "src/platform/windows/virtual_display_cleanup.h"
 #endif
@@ -915,9 +916,21 @@ int main(int argc, char *argv[]) {
   // watchdog thread is still unwinding.
   display_helper_integration::stop_watchdog();
 
+  // Stop the detached recovery/fallback monitor threads BEFORE closing the
+  // device: closeVDisplayDevice() cannot set the sticky shutting-down flag
+  // itself (it also runs mid-process on watchdog failure), and on the
+  // LuminalVGD backend its early-return used to skip the flag entirely —
+  // a monitor waking during CRT exit then logged through destroyed
+  // Boost.Log sinks (heap fast-fail).
+  VDISPLAY::notify_shutdown();
+
   // The legacy SudoVDA watchdog thread also lives in static storage.
   // Ensure it is joined before CRT on-exit handlers destroy the thread object.
   VDISPLAY::closeVDisplayDevice();
+
+  // Bounded join of the WGC->VGD transition worker BEFORE the devnode
+  // worker below — a transition attempt may be inside a devnode ensure.
+  platf::vgd_transition::shutdown_join();
 
   // Bounded join of the background driver-rebind worker (if any) — a
   // detached worker racing static destruction is UB the crash handler

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -234,6 +234,14 @@ namespace nvhttp {
       bool allow_display_changes,
       std::optional<std::string> &pending_output_override
     ) {
+      // A new launch/resume owns virtual-display state from here on: any
+      // fallback monitor armed by an EARLIER failed launch must never fire
+      // into this session's stream. At FUNCTION entry (not inside
+      // apply_virtual_display_request) so the resume early-returns —
+      // reused display, revert-on-disconnect off — supersede too
+      // (re-verify finding: the /resume path bypassed the lambda).
+      VDISPLAY::supersede_fallback_monitors();
+
       std::optional<std::string> app_output_override;
       if (launch_session->output_name_override && !launch_session->output_name_override->empty()) {
         app_output_override = boost::algorithm::trim_copy(*launch_session->output_name_override);
@@ -378,7 +386,7 @@ namespace nvhttp {
         if (proc::vDisplayDriverStatus != VDISPLAY::DRIVER_STATUS::OK) {
           proc::initVDisplayDriver();
           if (proc::vDisplayDriverStatus != VDISPLAY::DRIVER_STATUS::OK) {
-            BOOST_LOG(warning) << "Virtual display driver unavailable (status=" << static_cast<int>(proc::vDisplayDriverStatus) << "). Continuing with best-effort virtual display creation.";
+            BOOST_LOG(warning) << "Virtual display driver unavailable (status=" << static_cast<int>(proc::vDisplayDriverStatus.load()) << "). Continuing with best-effort virtual display creation.";
           }
         }
         if (!config::video.adapter_name.empty()) {
@@ -569,6 +577,7 @@ namespace nvhttp {
           recovery_params.client_uid = display_uuid_source;
           recovery_params.client_name = client_label;
           recovery_params.hdr_profile = launch_session->hdr_profile;
+          recovery_params.enable_hdr = launch_session->enable_hdr;
           recovery_params.display_name = display_info->display_name;
           recovery_params.monitor_device_path = display_info->monitor_device_path;
           if (display_info->device_id && !display_info->device_id->empty()) {
@@ -693,6 +702,112 @@ namespace nvhttp {
           launch_session->virtual_display_device_id.clear();
           launch_session->virtual_display_ready_since.reset();
           BOOST_LOG(warning) << "Virtual display creation failed.";
+
+          // Task #61 Tier 2: the stream proceeds on a fallback display
+          // (WGC/DDA capture). Arm the fallback monitor so the live
+          // session moves onto the virtual display once the LuminalVGD
+          // driver becomes available (driver installed/staged after
+          // service start, or creation raced the background rebind).
+          VDISPLAY::VirtualDisplayRecoveryParams fallback_params;
+          fallback_params.guid = virtual_display_guid;
+          fallback_params.width = vd_width;
+          fallback_params.height = vd_height;
+          fallback_params.fps = vd_fps;
+          fallback_params.base_fps_millihz = base_vd_fps_millihz;
+          fallback_params.framegen_refresh_active = framegen_refresh_active;
+          fallback_params.client_uid = display_uuid_source;
+          fallback_params.client_name = client_label;
+          fallback_params.hdr_profile = launch_session->hdr_profile;
+          fallback_params.enable_hdr = launch_session->enable_hdr;
+          fallback_params.max_attempts = 3;
+
+          // Same "was previously active" gate as the recovery monitor
+          // (scheduled by /launch before RTSP SETUP, so sessions are 0 at
+          // schedule time), plus a never-became-active grace: a launch
+          // the client abandons must not leave a monitor that creates a
+          // zombie display hours later when the driver appears.
+          auto fb_session_was_active = std::make_shared<std::atomic<bool>>(false);
+          const auto fb_armed_at = std::chrono::steady_clock::now();
+          auto fb_session_shutting_down = [fb_session_was_active, fb_armed_at]() {
+            const bool active_now = stream::session::active_sessions.load(std::memory_order_acquire) > 0
+                                    || webrtc_stream::has_active_sessions();
+            if (active_now) {
+              fb_session_was_active->store(true, std::memory_order_release);
+              return false;
+            }
+            if (fb_session_was_active->load(std::memory_order_acquire)) {
+              return true;  // was active, has since ended
+            }
+            return std::chrono::steady_clock::now() - fb_armed_at > std::chrono::minutes(5);
+          };
+          fallback_params.should_abort = fb_session_shutting_down;
+
+          auto fallback_session = std::make_shared<rtsp_stream::launch_session_t>(
+            display_helper_integration::helpers::make_display_request_session_snapshot(*launch_session)
+          );
+          // The APPLY builder refuses while the snapshot says creation
+          // failed — rewrite it to the state the session will have once
+          // the display exists (device_id arrives in the callback).
+          fallback_session->virtual_display = true;
+          fallback_session->virtual_display_failed = false;
+          fallback_params.on_recovery_success = [fallback_session, fb_session_shutting_down](const VDISPLAY::VirtualDisplayCreationResult &result) {
+            if (fb_session_shutting_down()) {
+              BOOST_LOG(info) << "VGD fallback: skipping post-creation APPLY because no streaming sessions remain.";
+              return;
+            }
+
+            if (result.device_id && !result.device_id->empty()) {
+              fallback_session->virtual_display_device_id = *result.device_id;
+              config::set_runtime_output_name_override(fallback_session->virtual_display_device_id);
+            }
+            fallback_session->virtual_display_ready_since = result.ready_since;
+
+            constexpr int kMaxApplyAttempts = 5;
+            bool applied = false;
+            for (int attempt = 1; attempt <= kMaxApplyAttempts; ++attempt) {
+              if (fb_session_shutting_down()) {
+                BOOST_LOG(info) << "VGD fallback: aborting APPLY retries because no streaming sessions remain.";
+                return;
+              }
+
+              (void) display_helper_integration::disarm_pending_restore();
+
+              auto request = display_helper_integration::helpers::build_request_from_session(config::video, *fallback_session);
+              if (!request) {
+                BOOST_LOG(warning) << "VGD fallback: failed to build display helper request after creation (attempt "
+                                   << attempt << "/" << kMaxApplyAttempts << ").";
+                std::this_thread::sleep_for(std::chrono::milliseconds(250 + (attempt - 1) * 250));
+                continue;
+              }
+
+              if (display_helper_integration::apply(*request)) {
+                BOOST_LOG(info) << "VGD fallback: applied session display configuration onto the new virtual display.";
+                applied = true;
+                break;
+              }
+
+              BOOST_LOG(warning) << "VGD fallback: display helper apply failed (attempt "
+                                 << attempt << "/" << kMaxApplyAttempts << ").";
+              std::this_thread::sleep_for(std::chrono::milliseconds(250 + (attempt - 1) * 250));
+            }
+
+            // Final session-state check before raising switch_display —
+            // a reinit queued onto a destructing capture pipeline wedges
+            // the videoThread join (same race the recovery monitor
+            // guards against).
+            if (fb_session_shutting_down()) {
+              BOOST_LOG(info) << "VGD fallback: skipping switch_display raise because no streaming sessions remain.";
+              return;
+            }
+
+            if (mail::man) {
+              mail::man->event<int>(mail::switch_display)->raise(-1);
+            }
+            BOOST_LOG(info) << "VGD fallback: requested capture reinit to move the stream onto the virtual display"
+                            << (applied ? "." : " (apply did not succeed).");
+          };
+
+          VDISPLAY::schedule_virtual_display_fallback_monitor(fallback_params);
         }
       };
 

--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -31,6 +31,7 @@
 #include "src/logging.h"
 #include "src/platform/common.h"
 #include "src/platform/windows/tdr_lifeboat.h"
+#include "src/platform/windows/vgd_transition.h"
 #include "utf_utils.h"
 
 // Must be the last included file
@@ -1703,6 +1704,11 @@ namespace platf {
     // (POSTMORTEM-2026-07-27). Wired here (Windows platf::init) rather than
     // in main.cpp so cross-platform init stays untouched.
     tdr_lifeboat::init();
+
+    // Arm the forced WGC->VGD transition watcher (task #61): a host stuck
+    // in WGC fallback transitions onto the LuminalVGD backend once the
+    // driver becomes available, without a service restart.
+    vgd_transition::init();
 
     return co_init;
   }

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -38,6 +38,7 @@ typedef enum _D3DKMT_GPU_PREFERENCE_QUERY_STATE : DWORD {
 #include "src/display_device.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
+#include "src/platform/windows/vgd_transition.h"
 #include "src/platform/windows/virtual_display_backend.h"
 #include "src/tdr_state.h"
 #include "src/video.h"
@@ -1855,6 +1856,7 @@ namespace platf {
       // failing the stream.
       if (!user_requested_ddx && !wgc_requested && (vgd_requested || VDISPLAY::is_luminalvgd_active())) {
         if (auto disp = dxgi::display_vgd_vram_t::create(config, display_name)) {
+          vgd_transition::note_capture_backend(vgd_transition::kCaptureKindVgdRing, display_name);
           return disp;
         }
         if (vgd_requested) {
@@ -1865,24 +1867,32 @@ namespace platf {
       if (prefer_wgc_backend) {
         auto disp = dxgi::display_wgc_ipc_vram_t::create(config, display_name);
         if (disp || wgc_requested) {
+          if (disp) {
+            vgd_transition::note_capture_backend(vgd_transition::kCaptureKindWgc, display_name);
+          }
           return disp;
         }
       }
 
       auto disp = std::make_shared<dxgi::display_ddup_vram_t>();
       if (!disp->init(config, display_name)) {
+        vgd_transition::note_capture_backend(vgd_transition::kCaptureKindDda, display_name);
         return disp;
       }
     } else if (hwdevice_type == mem_type_e::system) {
       if (prefer_wgc_backend) {
         auto disp = dxgi::display_wgc_ipc_ram_t::create(config, display_name);
         if (disp || wgc_requested) {
+          if (disp) {
+            vgd_transition::note_capture_backend(vgd_transition::kCaptureKindWgc, display_name);
+          }
           return disp;
         }
       }
 
       auto disp = std::make_shared<dxgi::display_ddup_ram_t>();
       if (!disp->init(config, display_name)) {
+        vgd_transition::note_capture_backend(vgd_transition::kCaptureKindDda, display_name);
         return disp;
       }
     }

--- a/src/platform/windows/vgd_devnode.cpp
+++ b/src/platform/windows/vgd_devnode.cpp
@@ -108,6 +108,14 @@ namespace platf::vgd_devnode {
     std::atomic<bool> g_rebind_in_flight {false};
     std::atomic<bool> g_stop_requested {false};
     std::thread g_rebind_thread;
+    /// Guards g_rebind_thread the OBJECT (join/assign/detach) — the worker
+    /// body itself is coordinated by the atomics above. Needed once
+    /// ensure_retry() made the heal callable after startup: reaping a
+    /// finished worker must not race shutdown_join().
+    std::mutex g_rebind_thread_mutex;
+    /// Serializes the ensure body between the one-shot startup hook and
+    /// ensure_retry() (transition watcher worker).
+    std::mutex g_ensure_mutex;
 
     // SwDeviceCreate/SwDeviceClose are bound dynamically: MinGW toolchains
     // ship no import library (or header) for them. The exports live in
@@ -534,6 +542,20 @@ namespace platf::vgd_devnode {
     }
 
     void heal_version_mismatch() {
+      if (g_rebind_in_flight.load(std::memory_order_acquire)) {
+        return;  // a rebind is already running
+      }
+      {
+        std::lock_guard lk(g_rebind_thread_mutex);
+        if (g_rebind_thread.joinable() && !g_rebind_in_flight.load(std::memory_order_acquire)) {
+          // A previous rebind worker finished (in-flight flag cleared by
+          // its scope guard) but was never joined — assigning a new thread
+          // over a joinable one is std::terminate. Reap it first; only
+          // reachable via ensure_retry(), the startup path runs at most
+          // once.
+          g_rebind_thread.join();
+        }
+      }
       const auto bundled_pkg = platf::diag::query_bundled_vgd_package();
       if (!bundled_pkg.present || !bundled_pkg.version) {
         return;  // portable install without a bundled package — nothing to compare
@@ -571,6 +593,12 @@ namespace platf::vgd_devnode {
       BOOST_LOG(warning) << "LuminalVGD devnode: installed driver " << *installed_str
                          << " is older than the bundled " << *bundled_pkg.version
                          << " — rebinding to the new driver without a reboot (background).";
+      std::lock_guard lk(g_rebind_thread_mutex);
+      if (g_stop_requested.load(std::memory_order_acquire)) {
+        // shutdown_join() already ran (or is running) — a worker spawned
+        // now would never be joined and would race static destruction.
+        return;
+      }
       g_rebind_in_flight.store(true, std::memory_order_release);
       g_rebind_thread = std::thread(&rebind_worker, *bundled);
     }
@@ -587,7 +615,10 @@ namespace platf::vgd_devnode {
           // Nothing staged in the DriverStore: creating a DriverRequired
           // software device could never start it. Portable users run the
           // install script once, exactly as before this module existed.
-          if (bundled_driver_build()) {
+          // Once per process: ensure_retry() re-runs this body
+          // periodically while unstaged, and the warning would repeat.
+          static std::atomic<bool> warned_unstaged {false};
+          if (bundled_driver_build() && !warned_unstaged.exchange(true)) {
             BOOST_LOG(warning) << "LuminalVGD devnode: a driver package is bundled but not "
                                   "staged in the DriverStore; run drivers\\luminalvgd\\"
                                   "install.ps1 (or the installer) once to stage it.";
@@ -642,6 +673,7 @@ namespace platf::vgd_devnode {
 
   void shutdown_join() {
     g_stop_requested.store(true, std::memory_order_release);
+    std::lock_guard tlk(g_rebind_thread_mutex);
     if (!g_rebind_thread.joinable()) {
       return;
     }
@@ -669,11 +701,39 @@ namespace platf::vgd_devnode {
     static std::once_flag once;
     std::call_once(once, []() {
       try {
+        std::lock_guard lk(g_ensure_mutex);
         ensure_and_heal_once();
       } catch (...) {
         BOOST_LOG(error) << "LuminalVGD devnode: startup ensure/heal threw; continuing without it.";
       }
     });
+  }
+
+  bool ensure_retry() {
+    if (g_stop_requested.load(std::memory_order_acquire)) {
+      return false;
+    }
+    if (device_expected()) {
+      return true;  // a devnode already exists; selection keeps probing it
+    }
+    if (rebind_in_flight()) {
+      return false;
+    }
+    if (tdr::stack_down()) {
+      // PnP work against a wedged WDDM stack can hang indefinitely; the
+      // wedge needs a reboot anyway, which re-runs the startup ensure.
+      return false;
+    }
+    std::lock_guard lk(g_ensure_mutex);
+    if (device_expected()) {
+      return true;  // raced with the startup hook
+    }
+    try {
+      ensure_and_heal_once();
+    } catch (...) {
+      BOOST_LOG(error) << "LuminalVGD devnode: ensure retry threw; will try again later.";
+    }
+    return device_expected();
   }
 
 }  // namespace platf::vgd_devnode

--- a/src/platform/windows/vgd_devnode.h
+++ b/src/platform/windows/vgd_devnode.h
@@ -65,6 +65,24 @@ namespace platf::vgd_devnode {
    */
   void startup_ensure_and_heal();
 
+  /**
+   * @brief Re-attempt the devnode ensure (adopt-or-create + heal) after a
+   *        startup attempt that produced no device.
+   *
+   * The startup hook is one-shot, so a driver package STAGED AFTER the
+   * service started (installer ran while the service was up) used to be
+   * invisible until the next service restart. The forced WGC->VGD
+   * transition watcher calls this before re-running backend selection.
+   *
+   * No-op (returns true) when a device is already expected; refuses
+   * (returns false) while a rebind is in flight, during shutdown, or
+   * while the display stack is down. BLOCKING — SwDeviceCreate plus the
+   * device-started wait can take ~35 s; call from a worker thread, never
+   * from the task pool. Returns true when a device is present/expected
+   * after the call.
+   */
+  bool ensure_retry();
+
   /// A background driver rebind is currently running. Virtual-display
   /// creation refuses while true (a session started mid-rebind would
   /// have its device yanked by the recreate fallback); the client

--- a/src/platform/windows/vgd_transition.cpp
+++ b/src/platform/windows/vgd_transition.cpp
@@ -1,0 +1,292 @@
+/**
+ * @file src/platform/windows/vgd_transition.cpp
+ * @brief Forced WGC->VGD transition watcher (see vgd_transition.h).
+ *
+ * Structure mirrors the codebase's established watcher patterns: the
+ * periodic tick runs on the single-threaded task_pool and stays
+ * constant-time (one backend query + one cheap open/close probe); any
+ * blocking work — the devnode ensure can hold SwDeviceCreate plus a
+ * device-started wait for ~35 s — runs on a joinable worker thread with
+ * a bounded shutdown_join(), exactly like vgd_devnode's rebind worker.
+ */
+// platform includes
+#include <winsock2.h>
+#include <windows.h>
+
+// standard includes
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <thread>
+
+// local includes
+#include "src/globals.h"
+#include "src/logging.h"
+#include "src/platform/windows/vgd_devnode.h"
+#include "src/platform/windows/vgd_transition.h"
+#include "src/platform/windows/virtual_display_backend.h"
+#include "src/platform/windows/virtual_display_vgd.h"
+#include "src/process.h"
+#include "src/tdr_state.h"
+
+using namespace std::chrono_literals;
+
+namespace platf::vgd_transition {
+
+  namespace {
+    /// Watcher cadence. The tick is one atomic-ish backend query plus (only
+    /// while un-transitioned) one open/close probe — cheap enough for the
+    /// shared pool at this rate.
+    constexpr auto kTickInterval = 60s;
+
+    /// Devnode ensure attempts are expensive (SwDeviceCreate + started
+    /// wait, worker occupied up to ~35 s) and only ever succeed after an
+    /// installer stages the package — retry sparsely. The web UI button
+    /// bypasses this limit (explicit user intent).
+    constexpr auto kEnsureRetryEvery = 5min;
+
+    std::atomic<bool> g_stop {false};
+    std::atomic<bool> g_worker_in_flight {false};
+    std::thread g_worker;
+    /// Guards g_worker the OBJECT (join/assign/detach); the worker body is
+    /// coordinated via the atomics.
+    std::mutex g_worker_mutex;
+
+    std::chrono::steady_clock::time_point g_last_ensure_attempt {};
+    std::mutex g_ensure_stamp_mutex;
+
+    bool ensure_attempt_due() {
+      std::lock_guard lk(g_ensure_stamp_mutex);
+      const auto now = std::chrono::steady_clock::now();
+      return g_last_ensure_attempt == std::chrono::steady_clock::time_point {} ||
+             now - g_last_ensure_attempt >= kEnsureRetryEvery;
+    }
+
+    /// Stamped only AFTER a worker actually spawned with the ensure phase
+    /// enabled — a lost spawn race must not push the next automatic
+    /// attempt out another full cadence.
+    void stamp_ensure_attempt() {
+      std::lock_guard lk(g_ensure_stamp_mutex);
+      g_last_ensure_attempt = std::chrono::steady_clock::now();
+    }
+
+    /// The transition attempt. Spawn sites guarantee the backend was not
+    /// LuminalVGD just before the spawn, so reaching LUMINALVGD here IS
+    /// the WGC->VGD transition (the sentence itself is logged by backend
+    /// selection at the moment of promotion, covering every heal path —
+    /// this worker, the web UI kick, and the lazy per-query re-probe).
+    void transition_worker(bool allow_ensure) {
+      struct flight_guard_t {
+        ~flight_guard_t() {
+          g_worker_in_flight.store(false, std::memory_order_release);
+        }
+      } flight_guard;
+
+      if (g_stop.load(std::memory_order_acquire)) {
+        return;
+      }
+
+      // Phase 1: make a devnode exist, if the startup ensure couldn't.
+      if (allow_ensure && !VDISPLAY::vgd::driver_appears_installed() &&
+          !platf::vgd_devnode::device_expected()) {
+        platf::vgd_devnode::ensure_retry();
+      }
+      if (g_stop.load(std::memory_order_acquire)) {
+        return;
+      }
+      if (!VDISPLAY::vgd::driver_appears_installed()) {
+        return;  // control device still not answering — the next tick re-checks
+      }
+
+      // Phase 2: heal the backend latch (logs the transition sentence on
+      // promotion).
+      if (VDISPLAY::reselect_if_none() != VDISPLAY::BackendType::LUMINALVGD) {
+        return;
+      }
+      if (g_stop.load(std::memory_order_acquire)) {
+        return;
+      }
+
+      // Phase 3: heal the driver-status latch — nvhttp/webrtc/confighttp
+      // gate on proc::vDisplayDriverStatus, not the backend enum.
+      if (proc::vDisplayDriverStatus != VDISPLAY::DRIVER_STATUS::OK) {
+        proc::initVDisplayDriver();
+      }
+      if (proc::vDisplayDriverStatus == VDISPLAY::DRIVER_STATUS::OK) {
+        BOOST_LOG(info) << "VGD transition: driver status initialized; virtual displays are "
+                           "available without a service restart.";
+      } else {
+        BOOST_LOG(warning) << "VGD transition: backend selected but driver status init reported "
+                           << static_cast<int>(proc::vDisplayDriverStatus.load())
+                           << "; session launches will retry it.";
+      }
+    }
+
+    /// Spawn the worker if none is running. Returns true when spawned.
+    bool spawn_worker(bool allow_ensure) {
+      std::lock_guard lk(g_worker_mutex);
+      if (g_stop.load(std::memory_order_acquire)) {
+        return false;
+      }
+      if (g_worker_in_flight.exchange(true, std::memory_order_acq_rel)) {
+        return false;  // already running
+      }
+      if (g_worker.joinable()) {
+        g_worker.join();  // reap the previous (finished) attempt
+      }
+      g_worker = std::thread(&transition_worker, allow_ensure);
+      return true;
+    }
+
+    void watcher_tick() {
+      if (g_stop.load(std::memory_order_acquire)) {
+        return;  // teardown: queued ticks still run after task_pool.stop()
+      }
+      // Stack-down check FIRST: while selection is unlatched,
+      // active_backend() itself performs a device open, and any device
+      // I/O against a wedged WDDM stack can hang — on the single-threaded
+      // shared task_pool that would stall input timers process-wide
+      // (review finding).
+      if (tdr::stack_down()) {
+        task_pool.pushDelayed(&watcher_tick, kTickInterval);
+        return;
+      }
+      if (VDISPLAY::active_backend() == VDISPLAY::BackendType::LUMINALVGD) {
+        // Transitioned (by this watcher or by any lazy backend query) —
+        // the latch can never revert, so the watcher's job is done. Live
+        // WGC-fallback sessions are handled by their own fallback
+        // monitors.
+        return;
+      }
+      if (!platf::vgd_devnode::rebind_in_flight() &&
+          !g_worker_in_flight.load(std::memory_order_acquire)) {
+        const bool reachable = VDISPLAY::vgd::driver_appears_installed();
+        bool allow_ensure = false;
+        if (!reachable && !platf::vgd_devnode::device_expected()) {
+          allow_ensure = ensure_attempt_due();
+        }
+        if ((reachable || allow_ensure) && spawn_worker(allow_ensure) && allow_ensure) {
+          stamp_ensure_attempt();
+        }
+      }
+      task_pool.pushDelayed(&watcher_tick, kTickInterval);
+    }
+  }  // namespace
+
+  void init() {
+    // Deliberately NO backend query here: platf::init() also runs inside
+    // the unit-test fixture (PlatformTestSuite), and active_backend()'s
+    // first invocation performs the full devnode ensure — a real
+    // SwDeviceCreate on a driver dev box (re-verify finding). The first
+    // tick does the query on the task pool and self-disarms when the
+    // backend is already (or becomes) LuminalVGD.
+    BOOST_LOG(info) << "VGD transition watcher armed: if the host is in WGC fallback, it "
+                       "transitions to VGD Mode automatically once the LuminalVGD driver "
+                       "is available.";
+    task_pool.pushDelayed(&watcher_tick, kTickInterval);
+  }
+
+  void shutdown_join() {
+    g_stop.store(true, std::memory_order_release);
+    std::lock_guard lk(g_worker_mutex);
+    if (!g_worker.joinable()) {
+      return;
+    }
+    // Bounded: poll the in-flight flag (cleared by the worker's scope
+    // guard) for up to 2 s, then detach — same contract as
+    // vgd_devnode::shutdown_join(); a worker parked inside SwDeviceCreate
+    // or UpdateDriver must not hold shutdown past the 10 s watchdog.
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (g_worker_in_flight.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < deadline) {
+      std::this_thread::sleep_for(100ms);
+    }
+    if (!g_worker_in_flight.load(std::memory_order_acquire)) {
+      g_worker.join();
+      return;
+    }
+    BOOST_LOG(warning) << "VGD transition: shutting down with a transition attempt still in "
+                          "flight; detaching the worker.";
+    g_worker.detach();
+  }
+
+  const char *kick_status_name(kick_status status) {
+    switch (status) {
+      case kick_status::started:
+        return "started";
+      case kick_status::already_vgd:
+        return "already_vgd";
+      case kick_status::busy:
+        return "busy";
+      case kick_status::stack_down:
+        return "stack_down";
+      case kick_status::shutting_down:
+        return "shutting_down";
+    }
+    return "unknown";
+  }
+
+  kick_status kick_now() {
+    if (g_stop.load(std::memory_order_acquire)) {
+      return kick_status::shutting_down;
+    }
+    // Stack-down check BEFORE any backend query: while unlatched,
+    // active_backend() opens the device, and device I/O against a wedged
+    // WDDM stack can hang the confighttp request thread.
+    if (tdr::stack_down()) {
+      return kick_status::stack_down;
+    }
+    // This query may itself complete the transition (lazy re-probe while
+    // unlatched) — that is success, not a conflict.
+    if (VDISPLAY::active_backend() == VDISPLAY::BackendType::LUMINALVGD) {
+      return kick_status::already_vgd;
+    }
+    if (platf::vgd_devnode::rebind_in_flight() ||
+        g_worker_in_flight.load(std::memory_order_acquire)) {
+      return kick_status::busy;
+    }
+    // Explicit user intent overrides the sparse ensure cadence (the
+    // worker's ensure phase runs regardless of the stamp; stamp it so the
+    // periodic watcher doesn't immediately double-attempt).
+    if (spawn_worker(true)) {
+      stamp_ensure_attempt();
+      return kick_status::started;
+    }
+    return kick_status::busy;
+  }
+
+  // -- active-capture-backend signal ---------------------------------------
+
+  namespace {
+    std::mutex g_capture_note_mutex;
+    std::string g_capture_kind;
+    std::string g_capture_display;
+    std::chrono::steady_clock::time_point g_capture_noted_at {};
+    std::uint64_t g_capture_sequence {0};
+  }  // namespace
+
+  void note_capture_backend(const char *kind, const std::string &display) {
+    std::lock_guard lk(g_capture_note_mutex);
+    g_capture_kind = kind ? kind : "";
+    g_capture_display = display;
+    g_capture_noted_at = std::chrono::steady_clock::now();
+    ++g_capture_sequence;
+  }
+
+  capture_note last_capture_note() {
+    std::lock_guard lk(g_capture_note_mutex);
+    capture_note out;
+    out.kind = g_capture_kind;
+    out.display = g_capture_display;
+    out.sequence = g_capture_sequence;
+    out.age_ms = 0;
+    if (g_capture_sequence != 0) {
+      out.age_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                     std::chrono::steady_clock::now() - g_capture_noted_at
+      )
+                     .count();
+    }
+    return out;
+  }
+
+}  // namespace platf::vgd_transition

--- a/src/platform/windows/vgd_transition.h
+++ b/src/platform/windows/vgd_transition.h
@@ -1,0 +1,79 @@
+/**
+ * @file src/platform/windows/vgd_transition.h
+ * @brief Forced WGC->VGD transition: heals a host stuck in WGC fallback
+ *        once the LuminalVGD driver becomes available.
+ *
+ * Backend selection latches once per process, and the devnode ensure is a
+ * one-shot startup hook — so a driver installed/staged AFTER the service
+ * started left the host capturing via WGC until the next service restart
+ * (task #61). This module arms a periodic watcher that, while the backend
+ * is not LuminalVGD: re-attempts the devnode ensure (rate-limited), then
+ * re-runs backend selection and the driver-status init once the control
+ * device answers. Every completed transition logs the sentence
+ * "LuminalShine has transitioned LuminalVGD into VGD Mode".
+ *
+ * Live streams already running in WGC fallback are moved by the
+ * per-session fallback monitor (virtual_display.cpp,
+ * schedule_virtual_display_fallback_monitor), which is armed at
+ * creation-failure time and acts independently of this watcher.
+ *
+ * Also home to the active-capture-backend signal: platf::display()
+ * records which capture backend each display open landed on, so the
+ * fallback monitor can confirm the ring actually engaged and the
+ * Troubleshooting page can show WGC-vs-VGD truth (nothing else in the
+ * process records the winner).
+ */
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace platf::vgd_transition {
+
+  /// Arm the periodic watcher. Called from Windows platf::init() (after
+  /// tdr_lifeboat::init()); requires the global task_pool to be running.
+  void init();
+
+  /// Bounded stop of the transition worker. Call from main's teardown
+  /// path BEFORE platf::vgd_devnode::shutdown_join() — the worker may be
+  /// inside a devnode ensure.
+  void shutdown_join();
+
+  enum class kick_status {
+    started,        ///< a transition attempt is now running in the background
+    already_vgd,    ///< the backend is already LuminalVGD — nothing to transition
+    busy,           ///< a transition attempt or driver rebind is already in flight
+    stack_down,     ///< the display stack is down; transition deferred
+    shutting_down,  ///< the process is tearing down
+  };
+
+  const char *kick_status_name(kick_status status);
+
+  /// Kick a transition attempt immediately (web UI "Transition now"
+  /// button). The attempt itself runs on a worker thread; the returned
+  /// status says only whether one was started.
+  kick_status kick_now();
+
+  // -- active-capture-backend signal ---------------------------------------
+
+  /// Capture-backend kinds recorded by platf::display().
+  inline constexpr const char *kCaptureKindVgdRing = "vgd-ring";
+  inline constexpr const char *kCaptureKindWgc = "wgc";
+  inline constexpr const char *kCaptureKindDda = "dda";
+
+  struct capture_note {
+    std::string kind;        ///< one of the kCaptureKind* values, or empty when never noted
+    std::string display;     ///< display name the capture opened against
+    std::int64_t age_ms;     ///< milliseconds since the note was recorded
+    std::uint64_t sequence;  ///< monotonically increasing note counter (0 = never)
+  };
+
+  /// Record which capture backend a successful display open landed on.
+  /// Called by platf::display(); cheap (mutex + two string copies).
+  void note_capture_backend(const char *kind, const std::string &display);
+
+  /// Latest capture note (kind empty / sequence 0 when no capture has
+  /// been opened yet this process).
+  capture_note last_capture_note();
+
+}  // namespace platf::vgd_transition

--- a/src/platform/windows/virtual_display.cpp
+++ b/src/platform/windows/virtual_display.cpp
@@ -1,12 +1,15 @@
 #include "virtual_display.h"
 
 #include "src/config.h"
+#include "src/display_device.h"
 #include "src/globals.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
 #include "src/platform/windows/display_helper_coordinator.h"
 #include "src/platform/windows/ipc/display_settings_client.h"
 #include "src/platform/windows/misc.h"
+#include "src/platform/windows/vgd_devnode.h"
+#include "src/platform/windows/vgd_transition.h"
 #include "src/platform/windows/virtual_display_backend.h"
 #include "src/platform/windows/virtual_display_vgd.h"
 #include "src/platform/windows/sudovda_recovery.h"
@@ -2375,6 +2378,13 @@ namespace VDISPLAY {
     // The monitor checks this before any logging/work so it bails out cleanly during shutdown.
     std::atomic<bool> g_recovery_monitors_shutting_down {false};
 
+    // Fallback-monitor supersession: each launch's virtual-display
+    // processing bumps this; a fallback monitor whose recorded generation
+    // is no longer current aborts. Prevents monitors from earlier
+    // abandoned/failed launches from firing into a later session's stream
+    // (the per-guid abort registry only covers SAME-guid re-arming).
+    std::atomic<std::uint64_t> g_fallback_monitor_generation {0};
+
     std::shared_ptr<std::atomic_bool> reset_recovery_monitor_abort_flag(const uuid_util::uuid_t &guid_uuid) {
       std::lock_guard<std::mutex> lock(g_virtual_display_recovery_abort_mutex);
       auto &entry = g_virtual_display_recovery_abort[guid_uuid];
@@ -2588,7 +2598,7 @@ namespace VDISPLAY {
       proc::vDisplayDriverStatus = openVDisplayDevice();
       if (proc::vDisplayDriverStatus != DRIVER_STATUS::OK) {
         BOOST_LOG(warning) << "Virtual display recovery: failed to reopen driver (status="
-                           << static_cast<int>(proc::vDisplayDriverStatus) << ") for "
+                           << static_cast<int>(proc::vDisplayDriverStatus.load()) << ") for "
                            << state.describe_target();
         return false;
       }
@@ -2613,7 +2623,8 @@ namespace VDISPLAY {
         state.params.fps,
         state.params.guid,
         state.params.base_fps_millihz,
-        state.params.framegen_refresh_active
+        state.params.framegen_refresh_active,
+        state.params.enable_hdr
       );
       if (!recreation) {
         BOOST_LOG(warning) << "Virtual display recovery: createVirtualDisplay failed for " << state.describe_target();
@@ -2895,6 +2906,215 @@ namespace VDISPLAY {
                      << " (max_attempts=" << params.max_attempts << ").";
     std::thread monitor_thread([state = std::move(state)]() mutable {
       run_virtual_display_recovery_monitor(std::move(state));
+    });
+    monitor_thread.detach();
+  }
+
+  namespace {
+    /// Fallback flavor of the monitor loop (task #61 Tier 2): the session
+    /// is live on WGC/DDA fallback because creation failed; wait for the
+    /// driver to become usable, then run the proven recreate + APPLY +
+    /// switch_display sequence and confirm the capture reinit actually
+    /// landed before logging the transition sentence.
+    void run_virtual_display_fallback_monitor(RecoveryMonitorState state, std::uint64_t my_generation) {
+      constexpr auto kPollInterval = std::chrono::seconds(10);
+      constexpr auto kPostAttemptBackoff = std::chrono::seconds(30);
+      constexpr auto kCaptureConfirmBudget = std::chrono::seconds(15);
+      unsigned int attempts = 0;
+
+      const auto superseded = [my_generation]() {
+        return g_fallback_monitor_generation.load(std::memory_order_acquire) != my_generation;
+      };
+
+      while (true) {
+        if (g_recovery_monitors_shutting_down.load(std::memory_order_acquire)) {
+          return;
+        }
+        if (superseded()) {
+          BOOST_LOG(debug) << "VGD fallback monitor: superseded by a newer launch; exiting for "
+                           << state.describe_target();
+          return;
+        }
+        if (monitor_should_abort(state)) {
+          BOOST_LOG(debug) << "VGD fallback monitor: aborting for " << state.describe_target();
+          return;
+        }
+
+        // Driver usable = display stack alive (checked FIRST — device
+        // opens against a wedged WDDM stack can hang indefinitely), no
+        // rebind mid-flight (creation would be refused and the recreate
+        // fallback would yank the new display), the control device
+        // answers, and backend selection has promoted to LuminalVGD (the
+        // transition watcher / any lazy query heals the latch; this poll
+        // just observes it).
+        const bool driver_usable = !tdr::stack_down() &&
+                                   !platf::vgd_devnode::rebind_in_flight() &&
+                                   vgd::driver_appears_installed() &&
+                                   is_luminalvgd_active();
+        if (!driver_usable) {
+          std::this_thread::sleep_for(kPollInterval);
+          continue;
+        }
+
+        // The launch path guarantees a fed lease watchdog before any
+        // monitor session exists (initVDisplayDriver starts the ping
+        // thread); mirror that here — attempt_virtual_display_recovery
+        // only RESTARTS an existing ping thread.
+        if (proc::vDisplayDriverStatus != DRIVER_STATUS::OK) {
+          proc::initVDisplayDriver();
+          if (proc::vDisplayDriverStatus != DRIVER_STATUS::OK) {
+            std::this_thread::sleep_for(kPollInterval);
+            continue;
+          }
+        }
+
+        const auto pre_note = platf::vgd_transition::last_capture_note();
+        ++attempts;
+        if (superseded()) {
+          return;
+        }
+        if (attempt_virtual_display_recovery(state)) {
+          // on_recovery_success has run: output override retargeted,
+          // display config applied, switch_display(-1) raised. Confirm
+          // the capture reinit before claiming victory — nothing else in
+          // the process records which capture backend a stream is on.
+          // Confirmation = a capture open AGAINST THE NEW DISPLAY (by
+          // name), whatever the capture kind: with capture=wgc or a
+          // software encoder the virtual display is legitimately captured
+          // via WGC, and a kind-only check could also be satisfied by an
+          // unrelated open (encoder probe, second session).
+          bool confirmed = false;
+          std::string landed_kind;
+          const auto deadline = std::chrono::steady_clock::now() + kCaptureConfirmBudget;
+          while (std::chrono::steady_clock::now() < deadline) {
+            if (g_recovery_monitors_shutting_down.load(std::memory_order_acquire) ||
+                monitor_should_abort(state)) {
+              return;
+            }
+            // The VGD create path returns device_id only — the GDI
+            // display name exists only after the APPLY attaches the
+            // monitor to the desktop (which has happened by now, inside
+            // on_recovery_success). Resolve it lazily each pass:
+            // map_output_name turns the device id into "\\.\DISPLAYn"
+            // once the display is attached, and returns the input
+            // unchanged while it is not.
+            if ((!state.normalized_display_name || state.normalized_display_name->empty()) &&
+                state.current_device_id && !state.current_device_id->empty()) {
+              const auto mapped = display_device::map_output_name(*state.current_device_id);
+              if (!mapped.empty() && mapped != *state.current_device_id) {
+                state.normalized_display_name = normalize_display_name(mapped);
+              }
+            }
+            const auto note = platf::vgd_transition::last_capture_note();
+            if (note.sequence > pre_note.sequence) {
+              landed_kind = note.kind;
+              const bool display_known = state.normalized_display_name &&
+                                         !state.normalized_display_name->empty();
+              const bool display_matches = display_known &&
+                                           normalize_display_name(note.display) == *state.normalized_display_name;
+              // Without a resolvable display name, fall back to the ring
+              // kind as the (weaker) success signal.
+              if (display_matches ||
+                  (!display_known && note.kind == platf::vgd_transition::kCaptureKindVgdRing)) {
+                confirmed = true;
+                break;
+              }
+              // A post-raise open landed elsewhere — reinits can cascade
+              // (modeset settle), keep waiting until the budget runs out.
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+          }
+          if (confirmed) {
+            BOOST_LOG(info) << "LuminalShine has transitioned LuminalVGD into VGD Mode "
+                               "(live session retargeted onto the virtual display mid-stream; "
+                               "capture backend: "
+                            << landed_kind << ").";
+            // Parity with launch-created displays: arm the disappearance
+            // recovery monitor for the display this transition created,
+            // so a later driver hiccup mid-session still recreates it.
+            VirtualDisplayRecoveryParams recovery = state.params;
+            recovery.display_name = state.current_display_name;
+            recovery.device_id = state.current_device_id;
+            recovery.monitor_device_path = state.current_monitor_device_path;
+            const GUID recovery_guid = state.params.guid;
+            recovery.should_abort = [recovery_guid]() {
+              // Qualified: the anonymous namespace's uuid_t overload
+              // shadows the GUID one for unqualified lookup.
+              return !VDISPLAY::is_virtual_display_guid_tracked(recovery_guid);
+            };
+            schedule_virtual_display_recovery_monitor(recovery);
+          } else {
+            BOOST_LOG(warning) << "VGD fallback monitor: virtual display created and capture "
+                                  "reinit requested, but "
+                               << (landed_kind.empty() ?
+                                     "no capture re-open was observed" :
+                                     "the observed capture open ('" + landed_kind + "') did not target the new display")
+                               << " within 15 s for " << state.describe_target()
+                               << "; the stream may still be on fallback capture.";
+          }
+          return;
+        }
+
+        if (attempts >= state.params.max_attempts) {
+          BOOST_LOG(warning) << "VGD fallback monitor: giving up after " << attempts
+                             << " attempts for " << state.describe_target()
+                             << "; the session stays on fallback capture (a new launch will "
+                                "retry virtual display creation normally).";
+          return;
+        }
+        std::this_thread::sleep_for(kPostAttemptBackoff);
+      }
+    }
+  }  // namespace
+
+  void supersede_fallback_monitors() {
+    g_fallback_monitor_generation.fetch_add(1, std::memory_order_acq_rel);
+  }
+
+  void notify_shutdown() {
+    g_recovery_monitors_shutting_down.store(true, std::memory_order_release);
+    abort_all_recovery_monitors();
+  }
+
+  void schedule_virtual_display_fallback_monitor(const VirtualDisplayRecoveryParams &params) {
+    if (params.max_attempts == 0) {
+      return;
+    }
+
+    RecoveryMonitorState initial_state(params);
+    if (monitor_should_abort(initial_state)) {
+      BOOST_LOG(debug) << "VGD fallback monitor skipped for " << initial_state.describe_target()
+                       << ": already aborted before scheduling.";
+      return;
+    }
+
+    // Same abort registry as the recovery flavor: if a later launch
+    // successfully creates a display for this GUID and arms a recovery
+    // monitor, reset_recovery_monitor_abort_flag aborts this fallback
+    // monitor — the two never run concurrently for one GUID.
+    const auto guid_uuid = guid_to_uuid(params.guid);
+    const auto abort_flag = reset_recovery_monitor_abort_flag(guid_uuid);
+    VirtualDisplayRecoveryParams wrapped = params;
+    const auto external_abort = params.should_abort;
+    wrapped.should_abort = [abort_flag, external_abort]() {
+      if (abort_flag->load(std::memory_order_acquire)) {
+        return true;
+      }
+      return external_abort ? external_abort() : false;
+    };
+
+    // Becoming the CURRENT generation also supersedes every older
+    // fallback monitor, whatever guid it was armed under.
+    const auto my_generation =
+      g_fallback_monitor_generation.fetch_add(1, std::memory_order_acq_rel) + 1;
+
+    RecoveryMonitorState state(wrapped);
+    BOOST_LOG(info) << "VGD fallback monitor armed for " << state.describe_target()
+                    << ": virtual display creation failed, streaming a fallback display; the "
+                       "session transitions onto the virtual display when the LuminalVGD "
+                       "driver becomes available.";
+    std::thread monitor_thread([state = std::move(state), my_generation]() mutable {
+      run_virtual_display_fallback_monitor(std::move(state), my_generation);
     });
     monitor_thread.detach();
   }
@@ -4906,7 +5126,7 @@ VDISPLAY::ensure_display_result VDISPLAY::ensure_display() {
   if (proc::vDisplayDriverStatus != DRIVER_STATUS::OK) {
     proc::initVDisplayDriver();
     if (proc::vDisplayDriverStatus != DRIVER_STATUS::OK) {
-      BOOST_LOG(warning) << "Virtual display driver unavailable for display ensure (status=" << static_cast<int>(proc::vDisplayDriverStatus) << "). Continuing with best-effort ensure.";
+      BOOST_LOG(warning) << "Virtual display driver unavailable for display ensure (status=" << static_cast<int>(proc::vDisplayDriverStatus.load()) << "). Continuing with best-effort ensure.";
     }
   }
 

--- a/src/platform/windows/virtual_display.h
+++ b/src/platform/windows/virtual_display.h
@@ -61,6 +61,10 @@ namespace VDISPLAY {
     uint32_t fps;
     uint32_t base_fps_millihz = 0;
     bool framegen_refresh_active = false;
+    /// Recreate the monitor with the session's negotiated dynamic range —
+    /// without this an HDR session's display came back SDR and churned
+    /// format-change reinits.
+    bool enable_hdr = false;
     std::string client_uid;
     std::string client_name;
     std::optional<std::string> hdr_profile;
@@ -99,6 +103,36 @@ namespace VDISPLAY {
   bool removeVirtualDisplay(const GUID &guid);
   bool removeAllVirtualDisplays();
   void schedule_virtual_display_recovery_monitor(const VirtualDisplayRecoveryParams &params);
+
+  /// Watch a session whose virtual-display creation FAILED (it is
+  /// streaming a physical display over WGC/DDA fallback) and move it onto
+  /// the VGD backend once the LuminalVGD driver becomes available: polls
+  /// driver reachability, then runs the same recreate + APPLY +
+  /// switch_display sequence the recovery monitor uses, confirming the
+  /// capture reinit before logging the WGC->VGD transition sentence.
+  /// Armed from the creation-failure branches (nvhttp / webrtc_stream);
+  /// unlike the recovery flavor no present-active display is required at
+  /// schedule time — the display never existed.
+  void schedule_virtual_display_fallback_monitor(const VirtualDisplayRecoveryParams &params);
+
+  /// Invalidate every armed fallback monitor. Called at the top of each
+  /// launch's virtual-display processing (nvhttp / webrtc) so a stale
+  /// monitor from an earlier abandoned/failed launch can never fire into
+  /// a NEWER session's stream — only the most recent launch's monitor
+  /// survives (review finding: the session gate is process-global, so an
+  /// unrelated live session kept abandoned monitors alive indefinitely).
+  void supersede_fallback_monitors();
+
+  /// Process-teardown signal for ALL detached monitor threads (recovery +
+  /// fallback): sets the sticky shutting-down flag and aborts the monitor
+  /// registry. Call from main's teardown BEFORE closeVDisplayDevice() —
+  /// closeVDisplayDevice() itself cannot set the sticky flag because it
+  /// is also invoked mid-run (watchdog-failure path), and on the
+  /// LuminalVGD backend its early-return skipped the flag entirely
+  /// (review finding: monitors logged through destroyed Boost.Log sinks
+  /// at CRT exit).
+  void notify_shutdown();
+
   bool is_virtual_display_guid_tracked(const GUID &guid);
 
   std::optional<std::string> resolveVirtualDisplayDeviceId(const std::wstring &display_name);

--- a/src/platform/windows/virtual_display_backend.cpp
+++ b/src/platform/windows/virtual_display_backend.cpp
@@ -13,6 +13,7 @@
 #include "src/config.h"
 #include "src/logging.h"
 #include "src/platform/windows/vgd_devnode.h"
+#include "src/platform/windows/vgd_transition.h"
 #include "src/platform/windows/virtual_display.h"
 #include "src/platform/windows/virtual_display_vgd.h"
 
@@ -41,6 +42,23 @@ namespace VDISPLAY {
       return b;
     }
 
+    // Selection returned NONE at least once this process — the host was in
+    // WGC fallback. A later promotion to LUMINALVGD is then a genuine
+    // WGC->VGD transition and logs the transition sentence (a first-ever
+    // selection that lands on LuminalVGD is normal startup, not a
+    // transition).
+    std::atomic<bool> &was_in_wgc_fallback() {
+      static std::atomic<bool> b {false};
+      return b;
+    }
+
+  }  // namespace
+
+  namespace {
+    /// Selection body; caller holds selection_mutex(). Shared by
+    /// select_backend() (first-query path) and reselect_if_none() (the
+    /// forced WGC->VGD transition path, which clears the latch first).
+    BackendType select_backend_locked();
   }  // namespace
 
   BackendType select_backend() {
@@ -48,59 +66,106 @@ namespace VDISPLAY {
     if (selection_initialized().load(std::memory_order_acquire)) {
       return selected_backend().load(std::memory_order_acquire);
     }
-
-    const std::string preference = config::video.virtual_display_backend;
-    if (preference == "mtt" || preference == "sudovda") {
-      // Once per process: while selection stays unlatched (fresh install,
-      // driver start in flight) this function re-runs on every backend
-      // query, and the warning would repeat each time.
-      static std::atomic<bool> warned_once {false};
-      if (!warned_once.exchange(true)) {
-        BOOST_LOG(warning) << "virtual_display_backend=" << preference
-                           << " is no longer supported (LuminalVGD is the only backend); "
-                              "falling back to auto selection.";
-      }
-    }
-
-    // Service-owned devnode: adopt a present root\luminal_vgd device or
-    // create the software device (fresh MSI installs stage the driver
-    // package only), then heal a stale binding after an upgrade — the
-    // no-reboot driver switchover. One-shot; failures degrade to the
-    // driver simply appearing not installed. MUST run before the
-    // reachability probe below or fresh installs always select NONE.
-    platf::vgd_devnode::startup_ensure_and_heal();
-
-    const bool luminalvgd_installed = vgd::driver_appears_installed();
-
-    if (!luminalvgd_installed && platf::vgd_devnode::device_expected()) {
-      // A devnode exists (adopted or just created) but the control
-      // interface is not up yet — a fresh install's driver start can
-      // outlive our waits. Do NOT latch NONE: leave selection
-      // uninitialized so the next backend query re-probes (the probe is
-      // a cheap open/close). Latching here permanently disabled virtual
-      // displays whenever driver start lost the race (review finding).
-      static std::atomic<bool> logged_once {false};
-      if (!logged_once.exchange(true)) {
-        BOOST_LOG(info) << "LuminalVGD device present/created but its control interface is "
-                           "not up yet; backend selection will retry on the next query.";
-      }
-      return BackendType::NONE;
-    }
-
-    const BackendType chosen = luminalvgd_installed ? BackendType::LUMINALVGD : BackendType::NONE;
-
-    if (chosen == BackendType::LUMINALVGD) {
-      BOOST_LOG(info) << "Virtual-display backend: LuminalVGD (first-party IddCx driver).";
-    } else {
-      BOOST_LOG(warning) << "The LuminalVGD driver is not installed/reachable; per-client "
-                            "virtual displays will not work. Install the LuminalVGD driver "
-                            "(drivers\\luminalvgd\\install.ps1 or the installer) to enable them.";
-    }
-
-    selected_backend().store(chosen, std::memory_order_release);
-    selection_initialized().store(true, std::memory_order_release);
-    return chosen;
+    return select_backend_locked();
   }
+
+  BackendType reselect_if_none() {
+    std::lock_guard lk(selection_mutex());
+    if (selection_initialized().load(std::memory_order_acquire) &&
+        selected_backend().load(std::memory_order_acquire) == BackendType::LUMINALVGD) {
+      return BackendType::LUMINALVGD;
+    }
+    // Clear a latched NONE so the selection body runs (and may latch)
+    // again. Under the mutex this is invisible to concurrent queries:
+    // they either see the old latch or the re-selection result.
+    selection_initialized().store(false, std::memory_order_release);
+    selected_backend().store(BackendType::NONE, std::memory_order_release);
+    return select_backend_locked();
+  }
+
+  namespace {
+    BackendType select_backend_locked() {
+      const std::string preference = config::video.virtual_display_backend;
+      if (preference == "mtt" || preference == "sudovda") {
+        // Once per process: while selection stays unlatched (fresh install,
+        // driver start in flight) this function re-runs on every backend
+        // query, and the warning would repeat each time.
+        static std::atomic<bool> warned_once {false};
+        if (!warned_once.exchange(true)) {
+          BOOST_LOG(warning) << "virtual_display_backend=" << preference
+                             << " is no longer supported (LuminalVGD is the only backend); "
+                                "falling back to auto selection.";
+        }
+      }
+
+      // Service-owned devnode: adopt a present root\luminal_vgd device or
+      // create the software device (fresh MSI installs stage the driver
+      // package only), then heal a stale binding after an upgrade — the
+      // no-reboot driver switchover. One-shot; failures degrade to the
+      // driver simply appearing not installed. MUST run before the
+      // reachability probe below or fresh installs always select NONE.
+      // (The forced WGC->VGD transition re-attempts a failed ensure via
+      // vgd_devnode::ensure_retry() before calling reselect_if_none().)
+      platf::vgd_devnode::startup_ensure_and_heal();
+
+      const bool luminalvgd_installed = vgd::driver_appears_installed();
+
+      if (!luminalvgd_installed && platf::vgd_devnode::device_expected()) {
+        // A devnode exists (adopted or just created) but the control
+        // interface is not up yet — a fresh install's driver start can
+        // outlive our waits. Do NOT latch NONE: leave selection
+        // uninitialized so the next backend query re-probes (the probe is
+        // a cheap open/close). Latching here permanently disabled virtual
+        // displays whenever driver start lost the race (review finding).
+        static std::atomic<bool> logged_once {false};
+        if (!logged_once.exchange(true)) {
+          BOOST_LOG(info) << "LuminalVGD device present/created but its control interface is "
+                             "not up yet; backend selection will retry on the next query.";
+        }
+        // This branch is also the NORMAL fresh-install/slow-boot driver
+        // start race — losing that race is not "living in WGC fallback".
+        // Only count it as fallback once a WGC/DDA capture actually
+        // opened this process, so the transition sentence never fires on
+        // a plain startup that merely won the race late (review finding).
+        const auto note = platf::vgd_transition::last_capture_note();
+        if (note.sequence != 0 && note.kind != platf::vgd_transition::kCaptureKindVgdRing) {
+          was_in_wgc_fallback().store(true, std::memory_order_release);
+        }
+        return BackendType::NONE;
+      }
+
+      const BackendType chosen = luminalvgd_installed ? BackendType::LUMINALVGD : BackendType::NONE;
+
+      if (chosen == BackendType::LUMINALVGD) {
+        BOOST_LOG(info) << "Virtual-display backend: LuminalVGD (first-party IddCx driver).";
+        if (was_in_wgc_fallback().exchange(false)) {
+          // The greppable transition marker (task #61): earlier selection
+          // passes returned NONE (WGC fallback), and the driver is now
+          // reachable — the host has moved onto the VGD backend without a
+          // service restart, whichever path re-ran selection (transition
+          // watcher, web UI button, or a lazy backend query).
+          BOOST_LOG(info) << "LuminalShine has transitioned LuminalVGD into VGD Mode "
+                             "(driver reachable; virtual displays available without a "
+                             "service restart).";
+        }
+      } else {
+        // Once per process: reselect_if_none() can re-run this body (the
+        // watcher/kick path), and the multi-line install instructions
+        // would otherwise repeat on every failed re-selection.
+        static std::atomic<bool> warned_not_installed {false};
+        if (!warned_not_installed.exchange(true)) {
+          BOOST_LOG(warning) << "The LuminalVGD driver is not installed/reachable; per-client "
+                                "virtual displays will not work. Install the LuminalVGD driver "
+                                "(drivers\\luminalvgd\\install.ps1 or the installer) to enable them.";
+        }
+        was_in_wgc_fallback().store(true, std::memory_order_release);
+      }
+
+      selected_backend().store(chosen, std::memory_order_release);
+      selection_initialized().store(true, std::memory_order_release);
+      return chosen;
+    }
+  }  // namespace
 
   BackendType active_backend() {
     // Lazy-initialize on first query so callers that run before any explicit

--- a/src/platform/windows/virtual_display_backend.h
+++ b/src/platform/windows/virtual_display_backend.h
@@ -36,6 +36,14 @@ namespace VDISPLAY {
   /// Idempotent: calling more than once returns the already-chosen backend.
   BackendType select_backend();
 
+  /// Re-run selection when the current result is NONE — the escape hatch
+  /// from a latched NONE (driver installed/staged AFTER the first query,
+  /// which select_backend() alone can never see). One-directional: it can
+  /// only promote NONE -> LUMINALVGD; an already-selected LUMINALVGD is
+  /// returned unchanged, so no caller can lose a working backend to a
+  /// transient probe failure. Returns the (possibly new) active backend.
+  BackendType reselect_if_none();
+
   /// Returns the active backend without re-running selection. Returns NONE
   /// before `select_backend()` has been called.
   BackendType active_backend();

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -756,7 +756,7 @@ namespace proc {
   }  // namespace
 
 #ifdef _WIN32
-  VDISPLAY::DRIVER_STATUS vDisplayDriverStatus = VDISPLAY::DRIVER_STATUS::UNKNOWN;
+  std::atomic<VDISPLAY::DRIVER_STATUS> vDisplayDriverStatus {VDISPLAY::DRIVER_STATUS::UNKNOWN};
 
   void onVDisplayWatchdogFailed() {
     vDisplayDriverStatus = VDISPLAY::DRIVER_STATUS::WATCHDOG_FAILED;

--- a/src/process.h
+++ b/src/process.h
@@ -45,7 +45,9 @@ namespace proc {
   using file_t = util::safe_ptr_v2<FILE, int, fclose>;
 
 #ifdef _WIN32
-  extern VDISPLAY::DRIVER_STATUS vDisplayDriverStatus;
+  /// Atomic: read/written from launch threads, confighttp handlers, and
+  /// the transition/fallback background workers concurrently.
+  extern std::atomic<VDISPLAY::DRIVER_STATUS> vDisplayDriverStatus;
   void initVDisplayDriver();
 #endif
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -60,10 +60,6 @@ extern "C" {
   #include <libavutil/hwcontext_d3d11va.h>
 }
 
-namespace proc {
-  extern VDISPLAY::DRIVER_STATUS vDisplayDriverStatus;
-  void initVDisplayDriver();
-}  // namespace proc
 #endif
 
 using namespace std::literals;

--- a/src/webrtc_stream.cpp
+++ b/src/webrtc_stream.cpp
@@ -216,6 +216,11 @@ namespace webrtc_stream {
         return;
       }
 
+      // A new session owns virtual-display state from here on: any
+      // fallback monitor armed by an EARLIER failed launch must never
+      // fire into this session's stream.
+      VDISPLAY::supersede_fallback_monitors();
+
       std::optional<std::string> app_output_override;
       if (session->output_name_override && !session->output_name_override->empty()) {
         app_output_override = boost::algorithm::trim_copy(*session->output_name_override);
@@ -285,7 +290,7 @@ namespace webrtc_stream {
         proc::initVDisplayDriver();
         if (proc::vDisplayDriverStatus != VDISPLAY::DRIVER_STATUS::OK) {
           BOOST_LOG(warning)
-            << "Virtual display driver unavailable (status=" << static_cast<int>(proc::vDisplayDriverStatus)
+            << "Virtual display driver unavailable (status=" << static_cast<int>(proc::vDisplayDriverStatus.load())
             << "). Continuing with best-effort virtual display creation.";
         }
       }
@@ -449,6 +454,7 @@ namespace webrtc_stream {
         recovery_params.client_uid = session->unique_id;
         recovery_params.client_name = client_label;
         recovery_params.hdr_profile = session->hdr_profile;
+        recovery_params.enable_hdr = session->enable_hdr;
         recovery_params.display_name = display_info->display_name;
         recovery_params.monitor_device_path = display_info->monitor_device_path;
         if (display_info->device_id && !display_info->device_id->empty()) {
@@ -514,6 +520,103 @@ namespace webrtc_stream {
       session->virtual_display_guid_bytes.fill(0);
       session->virtual_display_device_id.clear();
       session->virtual_display_ready_since.reset();
+
+      // Task #61 Tier 2 (WebRTC mirror of the nvhttp arming): the stream
+      // proceeds on a fallback display; move it onto the virtual display
+      // once the LuminalVGD driver becomes available.
+      VDISPLAY::VirtualDisplayRecoveryParams fallback_params;
+      fallback_params.guid = virtual_display_guid;
+      fallback_params.width = vd_width;
+      fallback_params.height = vd_height;
+      fallback_params.fps = vd_fps;
+      fallback_params.base_fps_millihz = base_vd_fps_millihz;
+      fallback_params.framegen_refresh_active = framegen_refresh_active;
+      fallback_params.client_uid = session->unique_id;
+      fallback_params.client_name = client_label;
+      fallback_params.hdr_profile = session->hdr_profile;
+      fallback_params.enable_hdr = session->enable_hdr;
+      fallback_params.max_attempts = 3;
+
+      // "Was previously active" gate plus a never-became-active grace so
+      // an abandoned start can't leave a monitor that creates a zombie
+      // display later (WebRTC flavor: only WebRTC sessions are relevant —
+      // the streaming paths are mutually exclusive).
+      auto fb_session_was_active = std::make_shared<std::atomic<bool>>(false);
+      const auto fb_armed_at = std::chrono::steady_clock::now();
+      auto fb_session_shutting_down = [fb_session_was_active, fb_armed_at]() {
+        if (webrtc_stream::has_active_sessions()) {
+          fb_session_was_active->store(true, std::memory_order_release);
+          return false;
+        }
+        if (fb_session_was_active->load(std::memory_order_acquire)) {
+          return true;  // was active, has since ended
+        }
+        return std::chrono::steady_clock::now() - fb_armed_at > std::chrono::minutes(5);
+      };
+      fallback_params.should_abort = fb_session_shutting_down;
+
+      auto fallback_session = std::make_shared<rtsp_stream::launch_session_t>(
+        display_helper_integration::helpers::make_display_request_session_snapshot(*session)
+      );
+      // The APPLY builder refuses while the snapshot says creation failed
+      // — rewrite it to the state the session will have once the display
+      // exists (device_id arrives in the callback).
+      fallback_session->virtual_display = true;
+      fallback_session->virtual_display_failed = false;
+      fallback_params.on_recovery_success = [fallback_session, fb_session_shutting_down](const VDISPLAY::VirtualDisplayCreationResult &result) {
+        if (fb_session_shutting_down()) {
+          BOOST_LOG(info) << "VGD fallback: skipping post-creation APPLY because no WebRTC sessions remain.";
+          return;
+        }
+
+        if (result.device_id && !result.device_id->empty()) {
+          fallback_session->virtual_display_device_id = *result.device_id;
+          config::set_runtime_output_name_override(fallback_session->virtual_display_device_id);
+        }
+        fallback_session->virtual_display_ready_since = result.ready_since;
+
+        constexpr int kMaxApplyAttempts = 5;
+        bool applied = false;
+        for (int attempt = 1; attempt <= kMaxApplyAttempts; ++attempt) {
+          if (fb_session_shutting_down()) {
+            BOOST_LOG(info) << "VGD fallback: aborting APPLY retries because no WebRTC sessions remain.";
+            return;
+          }
+
+          (void) display_helper_integration::disarm_pending_restore();
+
+          auto request = display_helper_integration::helpers::build_request_from_session(config::video, *fallback_session);
+          if (!request) {
+            BOOST_LOG(warning) << "VGD fallback: failed to build WebRTC display request after creation (attempt "
+                               << attempt << "/" << kMaxApplyAttempts << ").";
+            std::this_thread::sleep_for(std::chrono::milliseconds(250 + (attempt - 1) * 250));
+            continue;
+          }
+
+          if (display_helper_integration::apply(*request)) {
+            BOOST_LOG(info) << "VGD fallback: applied WebRTC display configuration onto the new virtual display.";
+            applied = true;
+            break;
+          }
+
+          BOOST_LOG(warning) << "VGD fallback: WebRTC display helper apply failed (attempt "
+                             << attempt << "/" << kMaxApplyAttempts << ").";
+          std::this_thread::sleep_for(std::chrono::milliseconds(250 + (attempt - 1) * 250));
+        }
+
+        if (fb_session_shutting_down()) {
+          BOOST_LOG(info) << "VGD fallback: skipping switch_display raise because no WebRTC sessions remain.";
+          return;
+        }
+
+        if (mail::man) {
+          mail::man->event<int>(mail::switch_display)->raise(-1);
+        }
+        BOOST_LOG(info) << "VGD fallback: requested WebRTC capture reinit to move the stream onto the virtual display"
+                        << (applied ? "." : " (apply did not succeed).");
+      };
+
+      VDISPLAY::schedule_virtual_display_fallback_monitor(fallback_params);
     }
 #endif
 

--- a/src_assets/common/assets/web/Troubleshooting.vue
+++ b/src_assets/common/assets/web/Troubleshooting.vue
@@ -127,6 +127,12 @@
                 {{ translate('troubleshooting.signing_method', 'Signature') }}:
                 {{ vgdSignatureBadge }}
               </span>
+              <span
+                class="inline-flex items-center px-2 py-0.5 rounded-md bg-dark/5 dark:bg-light/10 font-mono"
+              >
+                {{ translate('troubleshooting.luminalvgd_capture_backend', 'Capture backend') }}:
+                {{ vgdCaptureBadge }}
+              </span>
             </div>
           </div>
         </div>
@@ -914,6 +920,21 @@ const vgdDriverVersionBadge = computed(
 const vgdBundledVersionBadge = computed(() => store.metadata?.vgd_bundled_version || '—');
 const vgdBuiltBadge = computed(() => store.metadata?.vgd_driver_date || '—');
 const vgdSignatureBadge = computed(() => store.metadata?.vgd_bundled_signature || '—');
+// Which capture backend the most recent display open landed on (VGD ring vs
+// WGC vs DDA) — the field truth for "is this stream actually on the ring".
+// The note is last-writer-wins for the process lifetime, so qualify stale
+// records with their age instead of presenting them as current.
+const vgdCaptureBadge = computed(() => {
+  const kind = store.metadata?.capture_backend_active;
+  if (!kind) return '—';
+  const label = kind === 'vgd-ring' ? 'VGD ring' : kind.toUpperCase();
+  const display = store.metadata?.capture_backend_display;
+  const base = display ? `${label} (${display})` : label;
+  const age = store.metadata?.capture_backend_age_seconds;
+  if (typeof age !== 'number' || age < 300) return base;
+  const ageLabel = age < 3600 ? `${Math.round(age / 60)} min ago` : `${Math.round(age / 3600)} h ago`;
+  return `${base}, ${ageLabel}`;
+});
 
 onMounted(() => {
   void store.fetchMetadata();

--- a/src_assets/common/assets/web/stores/config.ts
+++ b/src_assets/common/assets/web/stores/config.ts
@@ -71,6 +71,9 @@ export interface MetaInfo {
   vgd_driver_date?: string;
   vgd_bundled_version?: string;
   vgd_bundled_signature?: string;
+  capture_backend_active?: string;
+  capture_backend_display?: string;
+  capture_backend_age_seconds?: number;
   active_session_count?: number;
 }
 

--- a/src_assets/common/assets/web/views/VgdControlPanelView.vue
+++ b/src_assets/common/assets/web/views/VgdControlPanelView.vue
@@ -18,6 +18,23 @@
       }}
     </n-alert>
 
+    <n-alert v-if="showTransition" type="info" :show-icon="true">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <span class="min-w-0">
+          {{
+            tr(
+              'vgd.transition_prompt',
+              'The host is not using the LuminalVGD backend (WGC fallback capture). It transitions automatically once the driver is available — or force an attempt now.',
+            )
+          }}
+        </span>
+        <n-button size="small" type="primary" :loading="transitionPending" @click="forceTransition">
+          {{ tr('vgd.transition_now', 'Transition to VGD now') }}
+        </n-button>
+      </div>
+      <p v-if="transitionResult" class="text-xs opacity-70 mt-1">{{ transitionResult }}</p>
+    </n-alert>
+
     <section
       v-for="group in groups"
       :key="group.title"
@@ -110,11 +127,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
-import { NAlert, NSwitch, NSelect, NInputNumber, NSlider, NTag } from 'naive-ui';
+import { NAlert, NButton, NSwitch, NSelect, NInputNumber, NSlider, NTag } from 'naive-ui';
 import { useConfigStore } from '@/stores/config';
+import { http } from '@/http';
 
 const { t } = useI18n();
 
@@ -135,6 +153,58 @@ const driverReady = computed(() => {
   const md = (metadata.value || {}) as { vgd_installed?: boolean };
   return Boolean(md.vgd_installed);
 });
+
+// WGC->VGD transition affordance: shown while the backend is anything but
+// LuminalVGD. The button kicks /api/state/vgd-transition (the same attempt
+// the periodic watcher runs: devnode ensure -> backend re-selection ->
+// driver-status init); the result lands in the LuminalShine log with the
+// "LuminalShine has transitioned LuminalVGD into VGD Mode" sentence.
+const showTransition = computed(() => {
+  const md = (metadata.value || {}) as { virtual_display_backend?: string };
+  return Boolean(md.virtual_display_backend) && md.virtual_display_backend !== 'luminalvgd';
+});
+const transitionPending = ref(false);
+const transitionResult = ref('');
+
+async function forceTransition(): Promise<void> {
+  transitionPending.value = true;
+  transitionResult.value = '';
+  try {
+    const r = await http.post('./api/state/vgd-transition', {}, { validateStatus: () => true });
+    const body = (r.data || {}) as { status?: boolean; result?: string };
+    const result = typeof body.result === 'string' ? body.result : '';
+    if (r.status >= 200 && r.status < 300 && body.status === true) {
+      transitionResult.value =
+        result === 'already_vgd'
+          ? tr('vgd.transition_already', 'Already on the LuminalVGD backend.')
+          : tr(
+              'vgd.transition_started',
+              'Transition attempt started — this panel refreshes as it completes.',
+            );
+    } else {
+      const reasons: Record<string, string> = {
+        busy: tr('vgd.transition_busy', 'A transition or driver rebind is already in progress.'),
+        stack_down: tr(
+          'vgd.transition_stack_down',
+          'The display stack is down (reboot required); transition deferred.',
+        ),
+        shutting_down: tr('vgd.transition_shutdown', 'The service is shutting down.'),
+      };
+      transitionResult.value =
+        reasons[result] ??
+        `${tr('vgd.transition_failed', 'Could not start a transition attempt')} (${result || `HTTP ${r.status}`}).`;
+    }
+  } catch (e: unknown) {
+    transitionResult.value = e instanceof Error ? e.message : 'Request failed';
+  } finally {
+    transitionPending.value = false;
+    // The attempt runs in the background; refresh the metadata snapshot a
+    // few times so a successful flip updates this panel unprompted.
+    [3000, 10000, 30000].forEach((delay) => {
+      setTimeout(() => void store.fetchMetadata(), delay);
+    });
+  }
+}
 
 function toNumber(value: unknown, fallback: number): number {
   const n = Number(value);

--- a/tests/unit/test_vgd_transition.cpp
+++ b/tests/unit/test_vgd_transition.cpp
@@ -1,0 +1,93 @@
+/**
+ * @file tests/unit/test_vgd_transition.cpp
+ * @brief WGC->VGD transition primitives (task #61): the active-capture
+ *        signal's note/query semantics and the kick-status naming
+ *        contract.
+ *
+ * The full transition needs a live driver and streaming session; these
+ * tests cover only pure process-local state (no device I/O, no PnP side
+ * effects) so they behave identically on CI and on driver dev boxes.
+ */
+#ifdef _WIN32
+
+  // standard includes
+  #include <chrono>
+  #include <string>
+  #include <thread>
+
+  // lib includes
+  #include <gtest/gtest.h>
+
+  // local includes
+  #include "../tests_common.h"
+  #include "src/platform/windows/vgd_transition.h"
+
+namespace {
+
+  TEST(VgdTransitionCaptureNote, RecordsKindDisplayAndBumpsSequence) {
+    const auto before = platf::vgd_transition::last_capture_note();
+    platf::vgd_transition::note_capture_backend(
+      platf::vgd_transition::kCaptureKindWgc,
+      "\\\\.\\DISPLAY7"
+    );
+    const auto after = platf::vgd_transition::last_capture_note();
+    EXPECT_EQ(after.kind, platf::vgd_transition::kCaptureKindWgc);
+    EXPECT_EQ(after.display, "\\\\.\\DISPLAY7");
+    EXPECT_EQ(after.sequence, before.sequence + 1);
+    EXPECT_GE(after.age_ms, 0);
+  }
+
+  TEST(VgdTransitionCaptureNote, SequenceIsMonotonicAcrossKinds) {
+    platf::vgd_transition::note_capture_backend(
+      platf::vgd_transition::kCaptureKindDda,
+      "\\\\.\\DISPLAY1"
+    );
+    const auto first = platf::vgd_transition::last_capture_note();
+    platf::vgd_transition::note_capture_backend(
+      platf::vgd_transition::kCaptureKindVgdRing,
+      "\\\\.\\DISPLAY274"
+    );
+    const auto second = platf::vgd_transition::last_capture_note();
+    EXPECT_GT(second.sequence, first.sequence);
+    EXPECT_EQ(second.kind, platf::vgd_transition::kCaptureKindVgdRing);
+    // The note is last-writer-wins: the DDA record is gone.
+    EXPECT_EQ(second.display, "\\\\.\\DISPLAY274");
+  }
+
+  TEST(VgdTransitionCaptureNote, AgeAdvancesBetweenQueries) {
+    platf::vgd_transition::note_capture_backend(
+      platf::vgd_transition::kCaptureKindWgc,
+      "\\\\.\\DISPLAY2"
+    );
+    const auto early = platf::vgd_transition::last_capture_note();
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    const auto late = platf::vgd_transition::last_capture_note();
+    EXPECT_EQ(late.sequence, early.sequence);
+    EXPECT_GE(late.age_ms, early.age_ms + 20);
+  }
+
+  TEST(VgdTransitionKickStatus, NamesAreStableContract) {
+    using platf::vgd_transition::kick_status;
+    using platf::vgd_transition::kick_status_name;
+    // The web UI keys its user-facing messages off these strings; renaming
+    // one silently degrades the panel to the generic failure text.
+    EXPECT_STREQ(kick_status_name(kick_status::started), "started");
+    EXPECT_STREQ(kick_status_name(kick_status::already_vgd), "already_vgd");
+    EXPECT_STREQ(kick_status_name(kick_status::busy), "busy");
+    EXPECT_STREQ(kick_status_name(kick_status::stack_down), "stack_down");
+    EXPECT_STREQ(kick_status_name(kick_status::shutting_down), "shutting_down");
+  }
+
+  // NOTE (review finding): no test here calls VDISPLAY::reselect_if_none()
+  // or active_backend(). On a dev box with the driver package staged in
+  // the DriverStore and the service stopped, backend selection performs a
+  // REAL SwDeviceCreate of root\luminal_vgd (spawning an IddCx adapter
+  // from a unit test) plus a device-started wait up to 20 s, and the
+  // unlatched driver-start race makes consecutive-call assertions flaky.
+  // Backend re-selection is covered by the field validation checklist
+  // instead (install driver after service start, grep for the transition
+  // sentence).
+
+}  // namespace
+
+#endif  // _WIN32


### PR DESCRIPTION
## What

The user-facing gap: once LuminalShine fell back to WGC capture (driver installed after service start, latched NONE backend selection, creation raced the driver rebind), **nothing ever moved it back** - only a service restart. This PR closes that gap end to end (task #61, all three approved tiers):

- **Tier 1 - backend heal.** `VDISPLAY::reselect_if_none()` escapes the previously permanent NONE latch (one-directional); `vgd_devnode::ensure_retry()` re-arms the one-shot devnode ensure so a DriverStore package staged after service start is created in-process; a new `platf::vgd_transition` watcher (60 s tick, blocking work on a bounded-join worker) runs devnode -> backend -> driver-status heals. Every genuine transition logs the greppable marker:
  **`LuminalShine has transitioned LuminalVGD into VGD Mode`**
- **Tier 2 - mid-session retarget.** A fallback monitor armed at creation-failure time (nvhttp + WebRTC) waits for the driver, recreates the virtual display to the session''s negotiated mode, re-applies the display config, raises a capture reinit, and **confirms capture landed on the new display** (new active-capture-backend signal recorded by `platf::display()`) before logging the sentence; success arms the regular disappearance-recovery monitor for parity with launch-created displays.
- **Tier 3 - UI.** `POST /api/state/vgd-transition` + "Transition to VGD now" button in the VGD Control Panel; active capture backend (VGD ring / WGC / DDA, with staleness qualifier) on Troubleshooting and `/api/metadata`.

## Review hardening (adversarial workflow, 7 confirmed findings, all fixed + independently re-verified FIXED)

- `VDISPLAY::notify_shutdown()` in main teardown: detached monitor threads finally get a teardown signal on the VGD backend (the sticky flag was only ever set in the SudoVDA branch - monitors could log through destroyed Boost.Log sinks at CRT exit).
- Stack-down checks precede every device probe (watcher tick, web-UI kick, fallback poll) - no device I/O against a wedged WDDM stack on the shared task pool.
- Generation supersede: every launch/resume (both protocols, **including the `/resume` early-return paths**) invalidates stale fallback monitors, so an abandoned launch can never hijack a later session''s stream.
- The transition sentence cannot fire on a healthy boot that merely lost the WUDFHost start race (gated on a real WGC/DDA capture having opened).
- Capture confirmation is display-name-matched (lazy `map_output_name` resolution post-APPLY) - works for `capture=wgc` and software-encoder hosts, immune to unrelated capture opens.
- `proc::vDisplayDriverStatus` is now `std::atomic` (pre-existing data race widened by the new background writers).
- Latent fix: recovery monitors now recreate HDR sessions'' displays as HDR (`VirtualDisplayRecoveryParams.enable_hdr` was missing - recovered displays came back SDR and churned format-change reinits).
- Unit tests touch no PnP paths (an earlier revision could SwDeviceCreate a real IddCx adapter from the test binary on driver dev boxes).

## Notes

- Host-side only - no driver change, no signing round. Works with installed build 14/15 drivers.
- No new config keys (no consistency-file churn). The `capture=wgc`/`ddx` veto is naturally respected - the transition heals the backend; capture choice stays downstream.
- Field check after merge: stop the LuminalShineService, uninstall the devnode, start the service (WGC fallback), install the driver mid-uptime -> the sentence should appear within ~60 s; with a live WGC stream, the mid-session variant should appear and the stream should move onto the virtual display without a reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)