### PR TITLE
Stop a 100 ms encode-wait timeout from declaring a GPU reset

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #include "logging.h"
 #include "main.h"
 #include "nvhttp.h"
+#include "nvenc/nvenc_base.h"
 #include "process.h"
 #include "rtsp.h"
 #include "session_monitor_client.h"
@@ -909,6 +910,9 @@ int main(int argc, char *argv[]) {
   // logging through Boost.Log after the sinks are torn down during CRT exit.
   stream::notify_shutdown();
   webrtc_stream::notify_shutdown();
+  // An encode stalled against the OS-scale wait deadline must abandon it
+  // now rather than hold teardown until the force-shutdown watchdog fires.
+  nvenc::notify_shutdown();
 
 #ifdef _WIN32
   // Full process shutdown cannot leave the paused-session watchdog running.

--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -20,7 +20,9 @@
 #include <algorithm>
 #include <atomic>
 #include <format>
+#include <mutex>
 #include <optional>
+#include <vector>
 
 // Make sure we check backwards compatibility when bumping the Video Codec SDK version
 // Things to look out for:
@@ -146,6 +148,15 @@ namespace nvenc {
     /// schedule a clean host restart before the bounded registered-
     /// resource pool (~64 on consumer cards) exhausts.
     std::atomic<std::uint64_t> g_drain_leak_count {0};
+
+    /// Repeated-stall circuit breaker state. Process-wide: a wedged GPU
+    /// affects every session, and a per-encoder counter would reset on the
+    /// teardown/rebuild that a stall itself provokes. Guarded by a plain
+    /// mutex — this is touched only on the (rare) full-deadline path.
+    constexpr int kBreakerStallThreshold = 3;
+    constexpr auto kBreakerWindow = std::chrono::seconds(60);
+    std::mutex g_stall_breaker_mutex;
+    std::vector<std::chrono::steady_clock::time_point> g_recent_hard_stalls;
   }  // namespace
 
   std::uint64_t drain_leak_count() {
@@ -185,15 +196,18 @@ namespace nvenc {
     encoder_params.buffer_format = buffer_format;
     encoder_params.rfi = true;
 
-    // Cache the per-session encode-wait timeout. Read once here; the
-    // per-frame wait below in encode_frame consults the cached value
-    // every frame instead of the global config so it cannot race a
-    // settings change mid-session, and so the timeout reflects whatever
-    // render-stack-aware tuning the caller applied at session start
-    // (e.g. 250 ms for DLSS-FG + AV1 + 4K HDR vs the 100 ms baseline).
-    // Clamp to >=10 ms so a misconfigured 0 doesn't busy-loop the
-    // encoder thread on every frame.
-    encoder_state.encode_wait_timeout_ms = std::max<uint32_t>(10, config.encode_wait_timeout_ms);
+    // Cache the per-session encode-wait parameters. Read once here; the
+    // per-frame wait below in encode_frame consults the cached values
+    // every frame instead of the global config so they cannot race a
+    // settings change mid-session, and so they reflect whatever
+    // OS-anchored deadline the caller derived at session start (see
+    // encode_wait_deadline_from_tdr). Clamp to >=10 ms so a misconfigured
+    // 0 doesn't busy-loop the encoder thread on every frame.
+    encoder_state.encode_wait_poll_slice_ms = std::max<uint32_t>(10, config.encode_wait_poll_slice_ms);
+    encoder_state.encode_wait_timeout_ms =
+      std::max(encoder_state.encode_wait_poll_slice_ms, config.encode_wait_timeout_ms);
+    encoder_state.encode_stall_warn_ms = config.encode_stall_warn_ms;
+    encoder_state.warned_slow_encode_wait = false;
 
     selected_api_version = 0;
 
@@ -843,8 +857,9 @@ namespace nvenc {
     // heap validator several minutes later in an unrelated allocation.
     //
     // Bounded at 2500ms because Windows TDR detection itself is ~2s
-    // (TdrDelay default) and TdrDdiDelay-driven recovery extends to ~7s.
-    // 2500ms unblocks before the kernel has finished a real TDR recovery
+    // (TdrDelay default) and the full detect+unwind span reaches ~7s
+    // (TdrDelay 2s + TdrDdiDelay 5s — the 7s figure is the SUM, not
+    // TdrDdiDelay alone). 2500ms unblocks before the kernel has finished a real TDR recovery
     // — but waiting longer would back up subsequent teardowns on the
     // shared serialized teardown worker (encoder_teardown_queue in
     // video.cpp), which runs sessions one at a time off the encode
@@ -854,8 +869,8 @@ namespace nvenc {
     // exit reclaims the leak; a session reinit does not.
     if (encoder && async_event_handle && encoder_state.has_pending_async) {
       // 2500 because Windows TDR detection itself is ~2s (TdrDelay default)
-      // and TdrDdiDelay-driven recovery extends to ~7s. 2500 unblocks
-      // before the kernel has finished a real TDR recovery — but waiting
+      // and the full detect+unwind span reaches ~7s (TdrDelay + TdrDdiDelay).
+      // 2500 unblocks before the kernel has finished a real TDR recovery — but waiting
       // longer would back up subsequent teardowns on the shared serialized
       // teardown worker (encoder_teardown_queue in video.cpp). See the
       // leak path below.
@@ -1025,7 +1040,7 @@ namespace nvenc {
     lock_bitstream.outputBitstream = output_bitstream;
     lock_bitstream.doNotWait = async_event_handle ? 1 : 0;
 
-    if (async_event_handle && !wait_for_async_event(encoder_state.encode_wait_timeout_ms)) {
+    if (async_event_handle && !wait_for_encode_completion()) {
       // Capture diagnostic context on the timeout. The previous one-line
       // log gave no signal about whether this was a transient bubble or
       // the start of a TDR — and the line printed two lines before the
@@ -1052,18 +1067,65 @@ namespace nvenc {
                       << " resolution=" << encoder_params.width << "x" << encoder_params.height
                       << " buffer_format=" << static_cast<int>(encoder_params.buffer_format)
                       << " force_idr=" << (force_idr ? "true" : "false")
-                      << ". A long since_last_encode (>200ms) typically indicates GPU TDR is in progress; "
-                         "the encoder will tear down and the D3D11 retry path (D3D11CreateDeviceWithRecovery) will pick up.";
+                      << ". The wait ran the full " << encoder_state.encode_wait_timeout_ms
+                      << " ms deadline; whether this is a GPU fault is decided by the device, not by elapsed time.";
       BOOST_LOG(error) << "NvEnc: frame " << frame_index << " encode wait timeout";
-      // Record the stall as a TDR-class event immediately: this is the
-      // earliest observable symptom of a GPU hang, and downstream holders
-      // of shared GPU allocations (the LuminalVGD ring reader) key their
-      // release-before-recovery behavior off tdr::event_count().
-      tdr::mark_event(
-        tdr::source_t::encoder_stall,
-        0,
-        "NvEnc encode-wait timeout, frame=" + std::to_string(frame_index)
-      );
+
+      // CORROBORATION GATE. Elapsed wait time is neither necessary nor
+      // sufficient evidence of a GPU hang, so it may not by itself produce
+      // a TDR verdict — that verdict is expensive (it terminates the live
+      // session, makes the LuminalVGD ring reader drop every shared
+      // texture, refuses reconnects for ~30 s and triggers a lifeboat
+      // topology write). Five field escalations were examined and all five
+      // were false: stalls of 100-105 ms, hresult=0x0, gpu_resets=0 in
+      // telemetry, and not one nvlddmkm/dxgkrnl/4101 event in the System
+      // log. Only the device's own GetDeviceRemovedReason may promote a
+      // stall, with a repeated-stall circuit breaker as the fallback for
+      // backends that cannot answer (or a machine with TdrLevel=0, where
+      // the device never reports removal because the OS never resets it).
+      std::uint32_t removed_reason = 0;
+      const bool corroborated = device_lost(removed_reason);
+      const bool breaker_tripped = note_hard_stall_and_check_breaker();
+
+      if (corroborated || breaker_tripped) {
+        if (corroborated) {
+          BOOST_LOG(error) << "NvEnc: treating the stall as a GPU fault — the device reports removal [0x"sv
+                           << util::hex(removed_reason).to_string_view() << "]."sv;
+        } else {
+          BOOST_LOG(error) << "NvEnc: treating the stall as a GPU fault — repeated hard stalls tripped "
+                              "the circuit breaker (the device itself reported no fault).";
+        }
+        tdr::mark_event(
+          tdr::source_t::encoder_stall,
+          removed_reason,
+          "NvEnc encode-wait timeout, frame=" + std::to_string(frame_index) +
+            (corroborated ? " (device removed)" : " (repeated stalls)")
+        );
+      } else {
+        // Not a GPU fault. The empty return below still fails this encode,
+        // and video.cpp treats a failed encode as fatal for the session
+        // (encode_nvenc -> -1 -> the encode thread returns / raises
+        // shutdown). That teardown is deliberate and load-bearing: it runs
+        // destroy_encoder, whose async drain resolves the deferred unmap of
+        // pending_mapped_resource. Letting the session limp on with a
+        // still-mapped resource would leak NVENC mappings and expose the
+        // stale-completion-signal hazard reset_async_event exists to
+        // prevent.
+        //
+        // What this branch changes is the BLAST RADIUS, not the session:
+        // no tdr::mark_event means no machine-wide "WDDM stack failure"
+        // verdict, so the LuminalVGD ring reader keeps its shared textures,
+        // reconnects are not refused for ~30 s, the topology lifeboat does
+        // not fire, and the drain-leak counter does not march toward a host
+        // restart. Combined with the OS-anchored deadline this path should
+        // now be nearly unreachable — every observed false escalation
+        // stalled 100-105 ms against what is now a >= 3 s deadline.
+        BOOST_LOG(warning) << "NvEnc: the device reports no fault, so frame " << frame_index
+                           << " was a slow frame rather than a GPU reset. Failing this encode "
+                              "(the session restarts) but NOT recording a GPU-reset event. "
+                              "Windows does not consider a GPU hung until TdrDelay, and no "
+                              "device-removed code was returned.";
+      }
       // The GPU may still complete this picture's encode later and write
       // into output_bitstream / read from the registered input texture.
       // Flag so destroy_encoder knows to drain the completion event before
@@ -1174,6 +1236,52 @@ namespace nvenc {
       }
     }
 
+    return true;
+  }
+
+  bool nvenc_base::wait_for_encode_completion() {
+    const auto slice = std::max<uint32_t>(10, encoder_state.encode_wait_poll_slice_ms);
+    const auto deadline_ms = std::max(slice, encoder_state.encode_wait_timeout_ms);
+    const auto started = std::chrono::steady_clock::now();
+
+    while (true) {
+      if (wait_for_async_event(slice)) {
+        return true;
+      }
+
+      const auto waited_ms = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - started).count()
+      );
+
+      // Soft threshold: telemetry only, once per session. Never escalates
+      // and never ends the stream — a slow frame is a slow frame.
+      if (!encoder_state.warned_slow_encode_wait && waited_ms >= encoder_state.encode_stall_warn_ms) {
+        encoder_state.warned_slow_encode_wait = true;
+        BOOST_LOG(warning) << "NvEnc: an encode has been waiting " << waited_ms
+                           << " ms (soft threshold " << encoder_state.encode_stall_warn_ms
+                           << " ms). This is reported once per session and is not treated as a fault; "
+                              "it usually means the GPU is saturated by the foreground game.";
+      }
+
+      if (waited_ms >= deadline_ms) {
+        return false;
+      }
+    }
+  }
+
+  bool nvenc_base::note_hard_stall_and_check_breaker() {
+    const auto now = std::chrono::steady_clock::now();
+    std::lock_guard lk(g_stall_breaker_mutex);
+    std::erase_if(g_recent_hard_stalls, [&](const auto &t) {
+      return now - t > kBreakerWindow;
+    });
+    g_recent_hard_stalls.push_back(now);
+    if (static_cast<int>(g_recent_hard_stalls.size()) < kBreakerStallThreshold) {
+      return false;
+    }
+    // Tripped: clear so the next escalation needs a fresh run of stalls
+    // rather than firing on every subsequent frame.
+    g_recent_hard_stalls.clear();
     return true;
   }
 

--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -22,6 +22,7 @@
 #include <format>
 #include <mutex>
 #include <optional>
+#include <thread>
 #include <vector>
 
 // Make sure we check backwards compatibility when bumping the Video Codec SDK version
@@ -157,7 +158,16 @@ namespace nvenc {
     constexpr auto kBreakerWindow = std::chrono::seconds(60);
     std::mutex g_stall_breaker_mutex;
     std::vector<std::chrono::steady_clock::time_point> g_recent_hard_stalls;
+
+    /// Set by nvenc::notify_shutdown() from main's teardown so an encode
+    /// stalled against the OS-scale deadline abandons the wait promptly
+    /// instead of racing the force-shutdown watchdog.
+    std::atomic<bool> g_shutdown_requested {false};
   }  // namespace
+
+  void notify_shutdown() {
+    g_shutdown_requested.store(true, std::memory_order_release);
+  }
 
   std::uint64_t drain_leak_count() {
     return g_drain_leak_count.load(std::memory_order_relaxed);
@@ -195,19 +205,6 @@ namespace nvenc {
     encoder_params.height = client_config.height;
     encoder_params.buffer_format = buffer_format;
     encoder_params.rfi = true;
-
-    // Cache the per-session encode-wait parameters. Read once here; the
-    // per-frame wait below in encode_frame consults the cached values
-    // every frame instead of the global config so they cannot race a
-    // settings change mid-session, and so they reflect whatever
-    // OS-anchored deadline the caller derived at session start (see
-    // encode_wait_deadline_from_tdr). Clamp to >=10 ms so a misconfigured
-    // 0 doesn't busy-loop the encoder thread on every frame.
-    encoder_state.encode_wait_poll_slice_ms = std::max<uint32_t>(10, config.encode_wait_poll_slice_ms);
-    encoder_state.encode_wait_timeout_ms =
-      std::max(encoder_state.encode_wait_poll_slice_ms, config.encode_wait_timeout_ms);
-    encoder_state.encode_stall_warn_ms = config.encode_stall_warn_ms;
-    encoder_state.warned_slow_encode_wait = false;
 
     selected_api_version = 0;
 
@@ -838,7 +835,32 @@ namespace nvenc {
                       << quality_preset_string_from_guid(init_params.presetGUID) << extra;
     }
 
+    // Fresh per-session state. NOTE the ordering: this wipes the whole
+    // struct back to its in-class defaults, so anything derived from
+    // `config` MUST be applied AFTER it. An earlier revision cached the
+    // encode-wait parameters near the top of this function and had them
+    // silently erased here, which made the OS-anchored deadline dead code
+    // (review finding) — the same trap that defeated the old 250 ms
+    // render-stack bump.
     encoder_state = {};
+
+    // Cache the per-session encode-wait parameters. The per-frame wait
+    // consults these cached values rather than the global config so they
+    // cannot race a settings change mid-session, and so they reflect the
+    // OS-anchored deadline the caller derived at session start (see
+    // encode_wait_deadline_from_tdr). Clamp the slice to >=10 ms so a
+    // misconfigured 0 cannot busy-loop the encode thread, and keep the
+    // deadline at least one slice long so the loop always waits once.
+    encoder_state.encode_wait_poll_slice_ms = std::max<uint32_t>(10, config.encode_wait_poll_slice_ms);
+    encoder_state.encode_wait_timeout_ms =
+      std::max(encoder_state.encode_wait_poll_slice_ms, config.encode_wait_timeout_ms);
+    encoder_state.encode_stall_warn_ms = config.encode_stall_warn_ms;
+
+    BOOST_LOG(info) << "NvEnc: encode-wait deadline " << encoder_state.encode_wait_timeout_ms
+                    << " ms (polled every " << encoder_state.encode_wait_poll_slice_ms
+                    << " ms, soft warning at " << encoder_state.encode_stall_warn_ms
+                    << " ms); a GPU-reset verdict additionally requires the device to report removal.";
+
     fail_guard.disable();
     return true;
   }
@@ -1040,7 +1062,11 @@ namespace nvenc {
     lock_bitstream.outputBitstream = output_bitstream;
     lock_bitstream.doNotWait = async_event_handle ? 1 : 0;
 
-    if (async_event_handle && !wait_for_encode_completion()) {
+    std::uint32_t wait_removed_reason = 0;
+    const auto wait_result = async_event_handle ?
+                               wait_for_encode_completion(wait_removed_reason) :
+                               encode_wait_result::completed;
+    if (wait_result != encode_wait_result::completed) {
       // Capture diagnostic context on the timeout. The previous one-line
       // log gave no signal about whether this was a transient bubble or
       // the start of a TDR — and the line printed two lines before the
@@ -1083,9 +1109,25 @@ namespace nvenc {
       // stall, with a repeated-stall circuit breaker as the fallback for
       // backends that cannot answer (or a machine with TdrLevel=0, where
       // the device never reports removal because the OS never resets it).
-      std::uint32_t removed_reason = 0;
-      const bool corroborated = device_lost(removed_reason);
-      const bool breaker_tripped = note_hard_stall_and_check_breaker();
+      // Shutdown: not a fault at all. Say nothing, escalate nothing — the
+      // process is going away and the teardown path handles the rest.
+      if (wait_result == encode_wait_result::aborted) {
+        BOOST_LOG(info) << "NvEnc: abandoning the wait for frame " << frame_index
+                        << " because the host is shutting down.";
+        encoder_state.has_pending_async = true;
+        return {};
+      }
+
+      std::uint32_t removed_reason = wait_removed_reason;
+      // device_lost was already observed mid-wait for the fast path; only
+      // re-ask when the deadline elapsed without a verdict.
+      const bool corroborated = wait_result == encode_wait_result::device_lost ||
+                                device_lost(removed_reason);
+      // Only charge the breaker for UNCORROBORATED stalls. A corroborated
+      // fault already escalates on its own, and counting it here would let
+      // real faults push the breaker toward tripping on later benign
+      // stalls (review finding).
+      const bool breaker_tripped = !corroborated && note_hard_stall_and_check_breaker();
 
       if (corroborated || breaker_tripped) {
         if (corroborated) {
@@ -1239,19 +1281,37 @@ namespace nvenc {
     return true;
   }
 
-  bool nvenc_base::wait_for_encode_completion() {
+  nvenc_base::encode_wait_result nvenc_base::wait_for_encode_completion(std::uint32_t &out_reason) {
+    out_reason = 0;
     const auto slice = std::max<uint32_t>(10, encoder_state.encode_wait_poll_slice_ms);
     const auto deadline_ms = std::max(slice, encoder_state.encode_wait_timeout_ms);
     const auto started = std::chrono::steady_clock::now();
 
     while (true) {
+      const auto slice_started = std::chrono::steady_clock::now();
       if (wait_for_async_event(slice)) {
-        return true;
+        return encode_wait_result::completed;
       }
 
+      const auto now = std::chrono::steady_clock::now();
       const auto waited_ms = static_cast<uint64_t>(
-        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - started).count()
+        std::chrono::duration_cast<std::chrono::milliseconds>(now - started).count()
       );
+
+      // Real faults are caught HERE, within one slice — not after the full
+      // deadline. This is what keeps the TDR lifeboat's reaction window and
+      // the ring reader's release-before-recovery behaviour as prompt as
+      // the old 100 ms timeout made them, while still being patient with a
+      // merely-slow frame.
+      if (device_lost(out_reason)) {
+        return encode_wait_result::device_lost;
+      }
+
+      // Teardown must not wait out an OS-scale deadline: the force-shutdown
+      // watchdog would fire first.
+      if (g_shutdown_requested.load(std::memory_order_acquire)) {
+        return encode_wait_result::aborted;
+      }
 
       // Soft threshold: telemetry only, once per session. Never escalates
       // and never ends the stream — a slow frame is a slow frame.
@@ -1264,7 +1324,17 @@ namespace nvenc {
       }
 
       if (waited_ms >= deadline_ms) {
-        return false;
+        return encode_wait_result::timed_out;
+      }
+
+      // Defensive: if the wait returned false WITHOUT consuming its slice
+      // (a broken/closed event handle makes WaitForSingleObject fail
+      // immediately), this loop would spin the encode thread at 100% for
+      // the whole deadline. Sleep out the remainder of the slice instead.
+      const auto slice_elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(now - slice_started);
+      if (slice_elapsed < std::chrono::milliseconds(slice) / 2) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(slice) - slice_elapsed);
       }
     }
   }

--- a/src/nvenc/nvenc_base.h
+++ b/src/nvenc/nvenc_base.h
@@ -126,7 +126,57 @@ namespace nvenc {
     virtual void reset_async_event() {
     }
 
+    /**
+     * @brief Authoritative device-loss check — the corroboration gate for
+     *        the encode-wait timeout.
+     *
+     * An elapsed encode wait is neither necessary nor sufficient evidence
+     * of a GPU hang: a healthy but deeply-queued GPU can legitimately take
+     * seconds, and a real TDR surfaces as device-removed regardless of how
+     * long we waited. Only the device's own verdict may promote a stall to
+     * a TDR-class event, so the timeout path consults this before calling
+     * tdr::mark_event.
+     *
+     * Default is "no opinion", which never corroborates — a backend that
+     * cannot ask its device must not be able to declare the GPU dead.
+     *
+     * @param out_reason Receives the platform failure code when available
+     *                   (HRESULT bits on Windows), 0 otherwise.
+     * @return true only when the device positively reports removal/reset.
+     */
+    virtual bool device_lost(std::uint32_t &out_reason) {
+      out_reason = 0;
+      return false;
+    }
+
     bool nvenc_failed(NVENCSTATUS status);
+
+    /**
+     * @brief Wait for the async completion event, sliced.
+     *
+     * Polls `wait_for_async_event` in `encode_wait_poll_slice_ms` slices
+     * up to the `encode_wait_timeout_ms` deadline, logging once per
+     * session when a wait crosses `encode_stall_warn_ms`. Slicing is what
+     * lets the deadline be OS-scale (seconds) without the encode thread
+     * becoming unresponsive for that long, and it costs nothing on a
+     * healthy frame — the event returns immediately on signal, so a normal
+     * frame is still one syscall.
+     *
+     * @return true when the encode completed, false when the deadline
+     *         elapsed (the caller then applies the corroboration gate).
+     */
+    bool wait_for_encode_completion();
+
+    /**
+     * @brief Record a hard (full-deadline) stall and report whether the
+     *        repeated-stall circuit breaker has tripped.
+     *
+     * Process-wide, since a wedged GPU affects every session. Exists so a
+     * genuinely hung device still escalates on backends that cannot answer
+     * `device_lost` — and on machines with TdrLevel=0, where the OS never
+     * resets the GPU so the device never reports removal at all.
+     */
+    bool note_hard_stall_and_check_breaker();
 
     const NV_ENC_DEVICE_TYPE device_type;
 
@@ -179,12 +229,18 @@ namespace nvenc {
       // the event signal, so there's no in-flight work to wait for and the
       // drain would just stall for the full timeout on every shutdown).
       bool has_pending_async = false;
-      // Cached at create_encoder time from nvenc_config.encode_wait_timeout_ms.
-      // Per-session immutable: deliberately NOT re-snapshotted mid-stream
-      // because the foreground render workload doesn't reclassify in <1s
-      // and re-evaluating each frame would just add jitter while paying
-      // ~10ms per snapshot for nothing.
-      uint32_t encode_wait_timeout_ms = 100;
+      // Cached at create_encoder time from the matching nvenc_config
+      // fields. Per-session immutable: these are derived from the machine's
+      // OS configuration (see encode_wait_deadline_from_tdr), which only
+      // changes on reboot, so re-reading mid-session could not observe a
+      // different value anyway.
+      uint32_t encode_wait_timeout_ms = 7000;
+      uint32_t encode_wait_poll_slice_ms = 100;
+      uint32_t encode_stall_warn_ms = 500;
+      // Set once per session the first time a wait crosses the soft
+      // threshold, so the warning is one line per session rather than one
+      // per slow frame on a chronically-loaded machine.
+      bool warned_slow_encode_wait = false;
       // Set whenever nvEncMapInputResource succeeds; cleared when the
       // matching nvEncUnmapInputResource succeeds. On the encode-wait
       // timeout path encode_frame deliberately does NOT unmap (the GPU

--- a/src/nvenc/nvenc_base.h
+++ b/src/nvenc/nvenc_base.h
@@ -151,21 +151,37 @@ namespace nvenc {
 
     bool nvenc_failed(NVENCSTATUS status);
 
+    /// Outcome of the sliced encode-completion wait.
+    enum class encode_wait_result {
+      completed,  ///< The GPU signalled; the bitstream is ready.
+      device_lost,  ///< The device reported removal mid-wait — a real fault, detected within one slice.
+      aborted,  ///< Process teardown asked us to stop waiting.
+      timed_out,  ///< The full deadline elapsed with no verdict from the device.
+    };
+
     /**
-     * @brief Wait for the async completion event, sliced.
+     * @brief Wait for the async completion event, sliced, doing real work
+     *        per slice.
      *
-     * Polls `wait_for_async_event` in `encode_wait_poll_slice_ms` slices
-     * up to the `encode_wait_timeout_ms` deadline, logging once per
-     * session when a wait crosses `encode_stall_warn_ms`. Slicing is what
-     * lets the deadline be OS-scale (seconds) without the encode thread
-     * becoming unresponsive for that long, and it costs nothing on a
-     * healthy frame — the event returns immediately on signal, so a normal
-     * frame is still one syscall.
+     * Slicing is what lets the deadline be OS-scale (seconds) without the
+     * encode thread becoming unresponsive for that long — but only because
+     * each slice boundary is a decision point:
      *
-     * @return true when the encode completed, false when the deadline
-     *         elapsed (the caller then applies the corroboration gate).
+     *  - the device is re-asked whether it has been lost, so a GENUINE
+     *    fault is caught within one slice (~100 ms) rather than after the
+     *    whole deadline. That preserves the TDR lifeboat's reaction window
+     *    and gets the LuminalVGD ring reader releasing shared textures
+     *    promptly, which is the behaviour the pre-change 100 ms timeout
+     *    accidentally provided and which must not be lost;
+     *  - process teardown is observed, so a stall cannot hold shutdown past
+     *    the force-shutdown watchdog.
+     *
+     * Costs nothing on a healthy frame: the event returns immediately on
+     * signal, so a normal frame is still one syscall and no device query.
+     *
+     * @param out_reason Receives the device failure code on `device_lost`.
      */
-    bool wait_for_encode_completion();
+    encode_wait_result wait_for_encode_completion(std::uint32_t &out_reason);
 
     /**
      * @brief Record a hard (full-deadline) stall and report whether the
@@ -264,5 +280,15 @@ namespace nvenc {
    *        uses this to schedule a clean host restart once idle.
    */
   std::uint64_t drain_leak_count();
+
+  /**
+   * @brief Tell in-flight encode waits to stop waiting.
+   *
+   * Called from main's teardown, alongside the other notify_shutdown
+   * hooks. Without it an encode stalled against the OS-scale deadline
+   * would hold shutdown for seconds and could outlast the 10 s
+   * force-shutdown watchdog.
+   */
+  void notify_shutdown();
 
 }  // namespace nvenc

--- a/src/nvenc/nvenc_config.h
+++ b/src/nvenc/nvenc_config.h
@@ -115,7 +115,11 @@ namespace nvenc {
    * Pure and constexpr so the clamping is unit-testable without a GPU.
    */
   constexpr uint32_t encode_wait_deadline_from_tdr(uint32_t tdr_delay_s, uint32_t tdr_ddi_delay_s) {
-    constexpr uint64_t floor_ms = 3000;
+    // Floor sits ABOVE the largest legitimate wait measured in the field
+    // (3913 ms on an RTX 5080 with zero GPU resets). A lower floor would
+    // let a machine with a small TdrDelay abandon a frame that was merely
+    // slow — the original bug in a new guise.
+    constexpr uint64_t floor_ms = 5000;
     constexpr uint64_t ceiling_ms = 10000;
     const uint64_t sum_ms = (static_cast<uint64_t>(tdr_delay_s) + static_cast<uint64_t>(tdr_ddi_delay_s)) * 1000ull;
     if (sum_ms < floor_ms) {

--- a/src/nvenc/nvenc_config.h
+++ b/src/nvenc/nvenc_config.h
@@ -60,18 +60,71 @@ namespace nvenc {
     // Add filler data to encoded frames to stay at target bitrate, mainly for testing
     bool insert_filler_data = false;
 
-    // Per-frame ceiling for the encode-async-completion wait inside
-    // encode_frame's WaitForSingleObject. Default 100 ms is the
-    // historical tuning that's safe for RTX 20/30-era workloads.
-    // Render-stack-aware callers bump this to 250 ms when the
-    // foreground process has DLSS-FG or DLAA loaded (see
-    // src/platform/windows/display_vram.cpp::init_encoder), where the
-    // GPU's queued render + frame-gen work routinely exceeds the
-    // 100 ms budget at 4K HDR and would otherwise classify a
-    // legitimately-slow frame as a TDR-class event. See the team's
-    // own comment near evaluate_and_tip in src/video.cpp for the
-    // documented worst case (Frame-Gen + DLAA + AV1 NVENC at 4K).
-    uint32_t encode_wait_timeout_ms = 100;
+    // HARD deadline for the encode-async-completion wait in encode_frame:
+    // the point at which we abandon the frame. NOT a GPU-health verdict —
+    // see nvenc_base.cpp's wait loop, which only reports a TDR when the
+    // device itself corroborates it.
+    //
+    // The old value was 100 ms, sized to bound the ENCODE. That was the
+    // wrong quantity. The encode is a small minority of this wait: the
+    // NVENC input texture doubles as the colour-conversion render target
+    // (display_vram.cpp init_output), so the encode packet carries a
+    // cross-engine fence on a 3D draw queued behind the game's render
+    // work. The wait therefore tracks GAME GPU load, not encoder
+    // throughput, and no per-GPU tuning can fix that — a field capture on
+    // an RTX 5080 (the fastest supported part) showed p99 frame latency of
+    // 271 ms and a legitimate max of 3.9 s with zero GPU resets, while the
+    // worst PURE encode on the SLOWEST supported part (Pascal, 2160p,
+    // 10-bit, P6, full-res two-pass) is only ~55-60 ms.
+    //
+    // So the default is anchored to the OS instead of to any GPU:
+    // TdrDelay (2 s) + TdrDdiDelay (5 s) = the full documented span from
+    // Windows starting to count a stalled packet to abandoning the driver
+    // unwind. Past that a real fault is visible via GetDeviceRemovedReason
+    // and waiting longer yields nothing. Windows-side callers recompute
+    // this from the machine's actual registry values via
+    // encode_wait_deadline_from_tdr().
+    uint32_t encode_wait_timeout_ms = 7000;
+
+    // Polling granularity for that wait. The wait is sliced so the encode
+    // thread observes shutdown (and re-checks device health) at this
+    // cadence instead of blocking for the whole deadline. Costs nothing on
+    // healthy frames — the completion event returns immediately on signal,
+    // so a normal frame is still a single syscall.
+    uint32_t encode_wait_poll_slice_ms = 100;
+
+    // Soft telemetry threshold. A wait longer than this logs once and is
+    // counted; it NEVER escalates and never ends a session. Rare on fast
+    // hardware, progressively more common on slower parts — which is the
+    // diagnostic gradient we want out of a universal build.
+    uint32_t encode_stall_warn_ms = 500;
   };
+
+  /**
+   * @brief Derive the hard encode-wait deadline from Windows' own TDR
+   *        constants: (TdrDelay + TdrDdiDelay) seconds, clamped.
+   *
+   * Lower clamp 3000 ms keeps the deadline above the largest legitimate
+   * wait observed in the field even if someone sets TdrDelay=1. Upper
+   * clamp 10000 ms exists because TdrLevel=0 or the TdrDelay=60 that
+   * overclocking/compute guides recommend (and some OEM images ship) must
+   * not turn into a minute-long encode-thread block. 10 s is still safe
+   * against the client: moonlight-common-c has no mid-stream video
+   * deadline (FIRST_FRAME_TIMEOUT_SEC is gated on the first-frame latches).
+   *
+   * Pure and constexpr so the clamping is unit-testable without a GPU.
+   */
+  constexpr uint32_t encode_wait_deadline_from_tdr(uint32_t tdr_delay_s, uint32_t tdr_ddi_delay_s) {
+    constexpr uint64_t floor_ms = 3000;
+    constexpr uint64_t ceiling_ms = 10000;
+    const uint64_t sum_ms = (static_cast<uint64_t>(tdr_delay_s) + static_cast<uint64_t>(tdr_ddi_delay_s)) * 1000ull;
+    if (sum_ms < floor_ms) {
+      return static_cast<uint32_t>(floor_ms);
+    }
+    if (sum_ms > ceiling_ms) {
+      return static_cast<uint32_t>(ceiling_ms);
+    }
+    return static_cast<uint32_t>(sum_ms);
+  }
 
 }  // namespace nvenc

--- a/src/nvenc/nvenc_d3d11.cpp
+++ b/src/nvenc/nvenc_d3d11.cpp
@@ -136,11 +136,21 @@ namespace {
       return false;
     }
     const HRESULT reason = seh_device_removed_reason(dev);
-    if (reason == S_OK) {
-      return false;
+    // Whitelist the documented device-loss codes rather than treating any
+    // non-S_OK as loss. GetDeviceRemovedReason can return other HRESULTs
+    // (DXGI_ERROR_INVALID_CALL among them); treating those as a dead GPU
+    // would manufacture exactly the false escalation this gate exists to
+    // prevent. Anything unrecognised is "no opinion".
+    switch (reason) {
+      case DXGI_ERROR_DEVICE_REMOVED:
+      case DXGI_ERROR_DEVICE_HUNG:
+      case DXGI_ERROR_DEVICE_RESET:
+      case DXGI_ERROR_DRIVER_INTERNAL_ERROR:
+        out_reason = static_cast<std::uint32_t>(reason);
+        return true;
+      default:
+        return false;
     }
-    out_reason = static_cast<std::uint32_t>(reason);
-    return true;
   }
 
   void nvenc_d3d11::reset_async_event() {

--- a/src/nvenc/nvenc_d3d11.cpp
+++ b/src/nvenc/nvenc_d3d11.cpp
@@ -108,6 +108,41 @@ namespace nvenc {
     return WaitForSingleObject(async_event_handle, timeout_ms) == WAIT_OBJECT_0;
   }
 
+namespace {
+  // SEH-isolated GetDeviceRemovedReason. Kept in its own function with no
+  // unwindable objects — a function containing __try/__except may not have
+  // locals requiring destruction. Same split as display_vgd.cpp's
+  // seh_acquire_sync.
+  #if defined(_MSC_VER) || defined(__clang__)
+  HRESULT seh_device_removed_reason(ID3D11Device *dev) noexcept {
+    __try {
+      return dev->GetDeviceRemovedReason();
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+      // Faulting inside the query is itself conclusive: the device is gone.
+      return DXGI_ERROR_DEVICE_REMOVED;
+    }
+  }
+  #else
+  HRESULT seh_device_removed_reason(ID3D11Device *dev) noexcept {
+    return dev->GetDeviceRemovedReason();
+  }
+  #endif
+}  // namespace
+
+  bool nvenc_d3d11::d3d_device_lost(ID3D11Device *dev, std::uint32_t &out_reason) {
+    out_reason = 0;
+    if (!dev) {
+      // No device to ask — "no opinion", which must not corroborate.
+      return false;
+    }
+    const HRESULT reason = seh_device_removed_reason(dev);
+    if (reason == S_OK) {
+      return false;
+    }
+    out_reason = static_cast<std::uint32_t>(reason);
+    return true;
+  }
+
   void nvenc_d3d11::reset_async_event() {
     if (async_event_handle) {
       // ResetEvent is a no-op when the event is already unsignaled (the

--- a/src/nvenc/nvenc_d3d11.h
+++ b/src/nvenc/nvenc_d3d11.h
@@ -39,6 +39,20 @@ namespace nvenc {
     bool wait_for_async_event(uint32_t timeout_ms) override;
     void reset_async_event() override;
 
+    /**
+     * @brief SEH-guarded ID3D11Device::GetDeviceRemovedReason — the
+     *        corroboration source for nvenc_base::device_lost.
+     *
+     * Shared by both D3D11 subclasses, which each own their own device
+     * pointer privately. SEH-guarded because the call is made precisely
+     * when the graphics stack is suspect, and a faulting device can take
+     * the query itself down; an access violation there must read as
+     * "device is gone", not crash the encode thread.
+     *
+     * @return true only on a positive removal/reset verdict.
+     */
+    static bool d3d_device_lost(ID3D11Device *dev, std::uint32_t &out_reason);
+
   private:
     HMODULE dll = nullptr;
     uint32_t function_list_api_version = 0;

--- a/src/nvenc/nvenc_d3d11_native.h
+++ b/src/nvenc/nvenc_d3d11_native.h
@@ -29,6 +29,10 @@ namespace nvenc {
   private:
     bool create_and_register_input_buffer() override;
 
+    bool device_lost(std::uint32_t &out_reason) override {
+      return d3d_device_lost(d3d_device, out_reason);
+    }
+
     const ID3D11DevicePtr d3d_device;
     ID3D11Texture2DPtr d3d_input_texture;
   };

--- a/src/nvenc/nvenc_d3d11_on_cuda.h
+++ b/src/nvenc/nvenc_d3d11_on_cuda.h
@@ -34,6 +34,10 @@ namespace nvenc {
 
     bool synchronize_input_buffer() override;
 
+    bool device_lost(std::uint32_t &out_reason) override {
+      return d3d_device_lost(d3d_device, out_reason);
+    }
+
     bool cuda_succeeded(CUresult result);
 
     bool cuda_failed(CUresult result);

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -25,7 +25,7 @@ extern "C" {
 #include "src/nvenc/nvenc_d3d11_native.h"
 #include "src/nvenc/nvenc_d3d11_on_cuda.h"
 #include "src/nvenc/nvenc_utils.h"
-#include "src/platform/windows/render_stack_detect.h"
+#include "src/nvenc/nvenc_config.h"
 #include "src/video.h"
 #include "utf_utils.h"
 
@@ -46,6 +46,45 @@ static void free_frame(AVFrame *frame) {
 using frame_t = util::safe_ptr<AVFrame, free_frame>;
 
 namespace platf::dxgi {
+
+  namespace {
+    /// Read a Windows TDR tuning value from
+    /// HKLM\SYSTEM\CurrentControlSet\Control\GraphicsDrivers, falling back
+    /// to the documented Microsoft default when the value is absent (the
+    /// usual case — Windows ships these unset and applies the defaults
+    /// internally). Cached: both keys only take effect on reboot, so a
+    /// mid-run re-read could not observe a change that had taken effect.
+    std::uint32_t tdr_registry_seconds(const wchar_t *value_name, std::uint32_t default_seconds) {
+      DWORD data = 0;
+      DWORD size = sizeof(data);
+      const auto status = RegGetValueW(
+        HKEY_LOCAL_MACHINE,
+        L"SYSTEM\\CurrentControlSet\\Control\\GraphicsDrivers",
+        value_name,
+        RRF_RT_REG_DWORD,
+        nullptr,
+        &data,
+        &size
+      );
+      if (status != ERROR_SUCCESS) {
+        return default_seconds;
+      }
+      return static_cast<std::uint32_t>(data);
+    }
+
+    /// Seconds Windows lets a GPU packet run before declaring a timeout.
+    std::uint32_t os_tdr_delay_seconds() {
+      static const std::uint32_t cached = tdr_registry_seconds(L"TdrDelay", 2);
+      return cached;
+    }
+
+    /// Additional seconds Windows allows for the driver to unwind after
+    /// that timeout before abandoning it.
+    std::uint32_t os_tdr_ddi_delay_seconds() {
+      static const std::uint32_t cached = tdr_registry_seconds(L"TdrDdiDelay", 5);
+      return cached;
+    }
+  }  // namespace
 
   template<class T>
   buf_t make_buffer(device_t::pointer device, const T &t) {
@@ -1110,37 +1149,36 @@ namespace platf::dxgi {
 
       auto nvenc_colorspace = nvenc::nvenc_colorspace_from_sunshine_colorspace(colorspace);
 
-      // Render-stack-aware per-session timeout. Take ONE snapshot here
-      // (encoder init = session start), not per frame: snapshot() walks
-      // every accessible process for module matches and costs ~10ms,
-      // and the foreground render workload doesn't reclassify in the
-      // sub-second timescale the encode-wait gate cares about. If the
-      // detection reports DLSS Frame Generation or DLAA loaded in the
-      // foreground process, the GPU's queued render + frame-gen work
-      // regularly exceeds the 100ms default at 4K HDR — keeping the
-      // default would misclassify legitimately-slow frames as TDR-class
-      // and start tearing the encoder down (which prior PRs in the
-      // series harden, but is best avoided in the first place).
+      // OS-anchored per-session encode-wait deadline.
       //
-      // Bump to 250ms when DLSS-FG or DLAA is detected. Plain DLSS
-      // (no FG) does not currently trigger the bump because its
-      // per-frame overhead stays well under 100ms even at 4K. If a
-      // future user-report indicates otherwise, add `has_dlss` to the
-      // condition below.
+      // This used to be a render-stack-aware bump: snapshot the foreground
+      // processes once and, if DLSS-FG or DLAA was loaded, set the timeout
+      // to 250ms instead of the 100ms default. Field forensics retired that
+      // design on three counts. (1) It never fired — the snapshot happens
+      // at encoder init, and a game launched by hand inside an already
+      // running desktop stream does not exist yet at that moment, so the
+      // log line it emits has zero occurrences across every log ever
+      // written on the reference machine. (2) It gated on the wrong
+      // feature: the observed stalls were plain 4K HDR 10-bit encodes with
+      // frame generation switched OFF, so even perfect detection would not
+      // have applied it. (3) It was an unconditional ASSIGNMENT, not a
+      // raise, so against an OS-scale base it would have been a large
+      // DOWNGRADE applied to exactly the workload needing the most room.
       //
-      // The bump is one-way: don't downgrade mid-session if a later
-      // snapshot lost the flag (jitter > value).
+      // The replacement needs no detection at all. The wait is dominated by
+      // queueing, not by encode: the NVENC input texture is also the
+      // colour-conversion render target (init_output below), so the encode
+      // packet carries a cross-engine fence on a 3D draw sitting behind the
+      // game's render work. That scales with game load rather than encoder
+      // throughput, which is why no per-GPU number is correct. Anchor to
+      // the OS instead: Windows does not consider a GPU hung until
+      // TdrDelay, and does not abandon the driver unwind until
+      // TdrDdiDelay after that.
       auto encoder_cfg = config::video.nv;
-      const auto rs = platf::render_stack::snapshot();
-      if (rs.any_match && (rs.has_dlss_fg || rs.has_dlaa)) {
-        encoder_cfg.encode_wait_timeout_ms = 250;
-        BOOST_LOG(info) << "NvEnc: render-stack detection found "
-                        << (rs.has_dlss_fg ? "DLSS-FG " : "")
-                        << (rs.has_dlaa ? "DLAA " : "")
-                        << "in a foreground process; raising encode-wait timeout "
-                        << "from 100ms to " << encoder_cfg.encode_wait_timeout_ms
-                        << "ms for this session.";
-      }
+      encoder_cfg.encode_wait_timeout_ms = nvenc::encode_wait_deadline_from_tdr(
+        os_tdr_delay_seconds(),
+        os_tdr_ddi_delay_seconds()
+      );
 
       if (!nvenc_d3d->create_encoder(encoder_cfg, client_config, nvenc_colorspace, buffer_format)) {
         return false;

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -25,7 +25,6 @@ extern "C" {
 #include "src/nvenc/nvenc_d3d11_native.h"
 #include "src/nvenc/nvenc_d3d11_on_cuda.h"
 #include "src/nvenc/nvenc_utils.h"
-#include "src/nvenc/nvenc_config.h"
 #include "src/video.h"
 #include "utf_utils.h"
 

--- a/tests/unit/test_nvenc_encode_wait.cpp
+++ b/tests/unit/test_nvenc_encode_wait.cpp
@@ -1,0 +1,104 @@
+/**
+ * @file tests/unit/test_nvenc_encode_wait.cpp
+ * @brief The OS-anchored encode-wait deadline.
+ *
+ * Regression coverage for the false-TDR incident: a single 100 ms NVENC
+ * completion-event timeout was reported as "GPU TDR escalated to WDDM stack
+ * failure" and terminated the live session. Five field escalations were
+ * examined and all five were false — stalls of 100-105 ms, hresult 0x0,
+ * zero GPU resets in telemetry, and no nvlddmkm/dxgkrnl/4101 events.
+ *
+ * The deadline is now derived from Windows' own TDR constants rather than
+ * tuned per GPU, because the wait is dominated by cross-engine queueing
+ * behind the game's render work, not by encoder throughput. These tests pin
+ * the derivation and its clamps; they are pure and need no GPU.
+ */
+
+// standard includes
+#include <cstdint>
+
+// lib includes
+#include <gtest/gtest.h>
+
+// local includes
+#include "../tests_common.h"
+#include "src/nvenc/nvenc_config.h"
+
+namespace {
+
+  TEST(NvencEncodeWaitDeadline, StockWindowsDefaultsYieldSevenSeconds) {
+    // TdrDelay 2 s + TdrDdiDelay 5 s — the documented Microsoft defaults,
+    // which apply whenever the registry values are absent (the usual case).
+    EXPECT_EQ(nvenc::encode_wait_deadline_from_tdr(2, 5), 7000u);
+  }
+
+  TEST(NvencEncodeWaitDeadline, NeverDropsBelowTheObservedLegitimateMax) {
+    // The floor exists because a machine with TdrDelay=1 must still not
+    // produce a deadline under the largest legitimate wait seen in the
+    // field (3.9 s on an RTX 5080 with zero GPU resets). 3000 ms is the
+    // floor; anything summing below it clamps up.
+    EXPECT_EQ(nvenc::encode_wait_deadline_from_tdr(1, 1), 3000u);
+    EXPECT_EQ(nvenc::encode_wait_deadline_from_tdr(0, 0), 3000u);
+    EXPECT_EQ(nvenc::encode_wait_deadline_from_tdr(1, 2), 3000u);
+  }
+
+  TEST(NvencEncodeWaitDeadline, CapsPathologicalRegistryValues) {
+    // TdrDelay=60 is common overclocking/compute advice and ships on some
+    // OEM images; it must not become a minute-long encode-thread block.
+    // The 10 s cap is still safe against the client, which has no
+    // mid-stream video deadline.
+    EXPECT_EQ(nvenc::encode_wait_deadline_from_tdr(60, 5), 10000u);
+    EXPECT_EQ(nvenc::encode_wait_deadline_from_tdr(10, 10), 10000u);
+    // Boundary: exactly the cap is kept, not clamped away.
+    EXPECT_EQ(nvenc::encode_wait_deadline_from_tdr(5, 5), 10000u);
+  }
+
+  TEST(NvencEncodeWaitDeadline, IsMonotonicInBothInputs) {
+    // A more permissive OS setting must never produce a tighter deadline.
+    for (std::uint32_t d = 0; d <= 12; ++d) {
+      for (std::uint32_t ddi = 0; ddi <= 12; ++ddi) {
+        const auto here = nvenc::encode_wait_deadline_from_tdr(d, ddi);
+        EXPECT_GE(nvenc::encode_wait_deadline_from_tdr(d + 1, ddi), here);
+        EXPECT_GE(nvenc::encode_wait_deadline_from_tdr(d, ddi + 1), here);
+      }
+    }
+  }
+
+  TEST(NvencEncodeWaitDeadline, AlwaysLandsInsideTheDocumentedEnvelope) {
+    // Whatever the registry says, the result must stay within [3 s, 10 s]:
+    // above the legitimate-wait tail, below the point where blocking the
+    // encode thread becomes its own failure mode.
+    for (std::uint32_t d = 0; d <= 120; d += 7) {
+      for (std::uint32_t ddi = 0; ddi <= 120; ddi += 11) {
+        const auto ms = nvenc::encode_wait_deadline_from_tdr(d, ddi);
+        EXPECT_GE(ms, 3000u);
+        EXPECT_LE(ms, 10000u);
+      }
+    }
+  }
+
+  TEST(NvencEncodeWaitDeadline, DefaultConfigMatchesStockWindows) {
+    // The struct default is what non-Windows callers and any path that
+    // skips the registry read will use; it must equal the stock-Windows
+    // derivation rather than drifting on its own.
+    const nvenc::nvenc_config cfg {};
+    EXPECT_EQ(cfg.encode_wait_timeout_ms, nvenc::encode_wait_deadline_from_tdr(2, 5));
+    // The slice must divide the work finely enough to stay responsive, and
+    // the soft warn must sit strictly between a slice and the deadline so
+    // it can actually fire before the hard deadline is reached.
+    EXPECT_LT(cfg.encode_wait_poll_slice_ms, cfg.encode_stall_warn_ms);
+    EXPECT_LT(cfg.encode_stall_warn_ms, cfg.encode_wait_timeout_ms);
+  }
+
+  TEST(NvencEncodeWaitDeadline, DeadlineExceedsTheStallsThatUsedToKillSessions) {
+    // Every observed false escalation stalled 100-105 ms. The new deadline
+    // must be far above that band, so none of them would reach it — and
+    // even reaching it no longer terminates a session without the device
+    // corroborating (see nvenc_base.cpp's corroboration gate).
+    const auto deadline = nvenc::encode_wait_deadline_from_tdr(2, 5);
+    for (const std::uint32_t observed_stall_ms : {100u, 102u, 104u, 105u}) {
+      EXPECT_GT(deadline, observed_stall_ms * 10);
+    }
+  }
+
+}  // namespace

--- a/tests/unit/test_nvenc_encode_wait.cpp
+++ b/tests/unit/test_nvenc_encode_wait.cpp
@@ -33,13 +33,20 @@ namespace {
   }
 
   TEST(NvencEncodeWaitDeadline, NeverDropsBelowTheObservedLegitimateMax) {
-    // The floor exists because a machine with TdrDelay=1 must still not
-    // produce a deadline under the largest legitimate wait seen in the
-    // field (3.9 s on an RTX 5080 with zero GPU resets). 3000 ms is the
-    // floor; anything summing below it clamps up.
-    EXPECT_EQ(nvenc::encode_wait_deadline_from_tdr(1, 1), 3000u);
-    EXPECT_EQ(nvenc::encode_wait_deadline_from_tdr(0, 0), 3000u);
-    EXPECT_EQ(nvenc::encode_wait_deadline_from_tdr(1, 2), 3000u);
+    // The floor must sit ABOVE the largest legitimate wait seen in the
+    // field (3913 ms on an RTX 5080 with zero GPU resets), or a machine
+    // with a small TdrDelay would abandon merely-slow frames — the
+    // original bug in a new guise. Hence 5000, not 3000.
+    EXPECT_EQ(nvenc::encode_wait_deadline_from_tdr(1, 1), 5000u);
+    EXPECT_EQ(nvenc::encode_wait_deadline_from_tdr(0, 0), 5000u);
+    EXPECT_EQ(nvenc::encode_wait_deadline_from_tdr(1, 2), 5000u);
+    // The specific regression this guards: 3913 ms was legitimate, so no
+    // derivable deadline may land at or below it.
+    for (std::uint32_t d = 0; d <= 6; ++d) {
+      for (std::uint32_t ddi = 0; ddi <= 6; ++ddi) {
+        EXPECT_GT(nvenc::encode_wait_deadline_from_tdr(d, ddi), 3913u);
+      }
+    }
   }
 
   TEST(NvencEncodeWaitDeadline, CapsPathologicalRegistryValues) {
@@ -65,13 +72,13 @@ namespace {
   }
 
   TEST(NvencEncodeWaitDeadline, AlwaysLandsInsideTheDocumentedEnvelope) {
-    // Whatever the registry says, the result must stay within [3 s, 10 s]:
+    // Whatever the registry says, the result must stay within [5 s, 10 s]:
     // above the legitimate-wait tail, below the point where blocking the
     // encode thread becomes its own failure mode.
     for (std::uint32_t d = 0; d <= 120; d += 7) {
       for (std::uint32_t ddi = 0; ddi <= 120; ddi += 11) {
         const auto ms = nvenc::encode_wait_deadline_from_tdr(d, ddi);
-        EXPECT_GE(ms, 3000u);
+        EXPECT_GE(ms, 5000u);
         EXPECT_LE(ms, 10000u);
       }
     }


### PR DESCRIPTION
## The bug

A single NVENC completion-event timeout at the 100 ms `encode_wait_timeout_ms` budget called `tdr::mark_event(encoder_stall, ...)`, which escalated to **"GPU TDR escalated to WDDM stack failure"** and terminated the live session — while also poisoning machine-wide TDR state.

Field forensics on **five** escalations found every one of them false:

| | |
|---|---|
| stall duration | 100 / 102 / 104 / 105 / 100 ms — all within 5 ms of the budget |
| `hresult` | `0x0` on every one (hardcoded at the call site) |
| `gpu_resets` in telemetry | **0**, across all sessions |
| nvlddmkm / dxgkrnl / Event 4101 | **none**, for the entire period |

No GPU reset occurred in any of them.

## Why 100 ms was the wrong number

The budget was sized to bound the *encode*. That is not what the wait measures. The NVENC input texture is also the colour-conversion render target, so the encode packet carries a **cross-engine fence on a 3D draw queued behind the game''s render work** — the wait tracks *game* GPU load, not encoder throughput. No per-GPU tuning can fix that:

- worst **pure encode** on the *slowest* supported part (Pascal, 2160p, 10-bit, P6, full-res two-pass): **~55–60 ms**
- observed p99 frame latency on the *fastest* supported part (RTX 5080): **271 ms**, legitimate max **3913 ms**

So the deadline is now anchored to the OS rather than to any GPU: **`(TdrDelay + TdrDdiDelay)`**, read from the machine''s registry with the documented 2 s / 5 s defaults, clamped to **[5000, 10000] ms**. Windows does not consider a GPU hung until `TdrDelay`; declaring one at 100 ms was **20× premature**. The 10 s ceiling is safe against the client — moonlight-common-c has no mid-stream video deadline (`FIRST_FRAME_TIMEOUT_SEC` is gated on the first-frame latches).

## Separating the wait from the verdict

- The wait is **sliced into 100 ms polls**, and each slice does real work: it re-asks the device whether it has been lost, so a **genuine fault is caught within ~100 ms** rather than after the full deadline — preserving the TDR lifeboat''s reaction window and the VGD ring reader''s prompt texture release. It also observes a new `nvenc::notify_shutdown()` so a stall cannot hold teardown past the force-shutdown watchdog.
- **500 ms** logs a once-per-session soft warning and never escalates.
- The **TDR verdict now requires corroboration**: the device itself must report removal via `GetDeviceRemovedReason` (new `nvenc_base::device_lost`, SEH-guarded, whitelisting the four documented device-loss codes), with a 3-stalls-in-60 s circuit breaker as the fallback for backends that cannot answer and for `TdrLevel=0` machines where the OS never resets the GPU.

**Scope, precisely**: an uncorroborated timeout still fails the encode, and video.cpp still treats that as fatal for the session. That teardown is deliberate — `destroy_encoder`''s async drain is what resolves the deferred unmap of `pending_mapped_resource`, so limping on would leak NVENC mappings and expose the stale-completion-signal hazard `reset_async_event` guards. What changes is the **blast radius**: no machine-wide stack-failure verdict, so the ring reader keeps its shared textures, reconnects aren''t refused for ~30 s, the lifeboat doesn''t fire, and the drain-leak counter doesn''t march toward a host restart. With the OS-anchored deadline this path should be nearly unreachable anyway.

Also **deletes the DLSS-FG/DLAA conditional**: it was an unconditional assignment of 250 ms, so against an OS-scale base it would have been a large *downgrade* applied to exactly the workload needing the most headroom. It had never once executed on the reference machine, and the observed stalls were plain 4K HDR encodes with frame generation switched **off** — so even perfect detection would not have applied it.

## Adversarial review (second commit)

The review caught four real defects in the first commit, including one that made the whole feature inert:

1. **Blocker — the OS-anchored deadline was dead code.** `create_encoder` cached the parameters, then `encoder_state = {}` wiped them back to defaults. The registry derivation and its clamps were unreachable. *(This same trap silently defeated the old 250 ms bump.)* Caching moved after the reset, hazard documented, and the effective deadline is now logged so it cannot regress unnoticed.
2. **The sliced wait did no per-slice work** — both doc comments were false. It now re-checks device health (fast fault detection) and shutdown.
3. **The floor was 3000 ms — below the 3913 ms legitimate wait this change documents.** Raised to 5000 ms, with a test asserting no derivable deadline lands at or below 3913 ms.
4. **`d3d_device_lost` treated any non-S_OK as loss**, so `DXGI_ERROR_INVALID_CALL` would have manufactured the very false escalation the gate prevents. Now whitelists the four documented codes.

Plus: the breaker is no longer charged when the device already corroborated; the loop sleeps out a slice that returns without consuming time (a broken event handle would otherwise spin at 100%); duplicate include removed.

## Testing

Builds clean; **25/25** targeted tests pass (7 new `NvencEncodeWaitDeadline`, plus NvencApi / VgdTransition / TdrState). The new tests are pure and need no GPU. No config keys added, so no five-file consistency churn.

Ships in **26.08.0-rc.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)