### PR TITLE
fix(crypto): stop util::uniq_ptr silently adopting raw pointers (X509 over-release)

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -331,7 +331,10 @@ namespace crypto {
     }
 
     ecb_t::ecb_t(const aes_t &key, bool padding):
-        cipher_t {EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_new(), key, padding} {
+        // Adoption is spelled out now that util::uniq_ptr's converting
+        // constructor is explicit; the contexts are freshly allocated here and
+        // owned by the cipher from this point on.
+        cipher_t {cipher_ctx_t {EVP_CIPHER_CTX_new()}, cipher_ctx_t {EVP_CIPHER_CTX_new()}, key, padding} {
     }
 
     cbc_t::cbc_t(const aes_t &key, bool padding):
@@ -538,11 +541,19 @@ namespace crypto {
     return {mem_ptr->data, mem_ptr->length};
   }
 
-  std::string_view signature(const x509_t &x) {
-    // X509_ALGOR *_ = nullptr;
+  std::string_view signature(const X509 *x) {
+    // Borrowing, never owning — see the header for why this must not take
+    // `const x509_t &`.
+    if (!x) {
+      return {};
+    }
 
     const ASN1_BIT_STRING *asn1 = nullptr;
-    X509_get0_signature(&asn1, nullptr, x.get());
+    X509_get0_signature(&asn1, nullptr, x);
+
+    if (!asn1 || !asn1->data || asn1->length <= 0) {
+      return {};
+    }
 
     return {(const char *) asn1->data, (std::size_t) asn1->length};
   }

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -115,7 +115,20 @@ namespace crypto {
 
   creds_t gen_creds(const std::string_view &cn, std::uint32_t key_bits);
 
-  std::string_view signature(const x509_t &x);
+  /**
+   * @brief Borrowed view of a certificate's ASN.1 signature bytes.
+   *
+   * Takes a NON-OWNING raw pointer deliberately. A `const x509_t &`
+   * parameter silently accepted a raw `X509 *` argument by materialising an
+   * *owning* temporary through `util::uniq_ptr`'s converting constructor,
+   * which then freed a certificate the caller still owned — a use-after-free
+   * on the client-identity path in nvhttp. Keep this signature raw.
+   *
+   * The returned view aliases memory inside `x` and is invalidated when `x`
+   * is freed, so `x` must outlive every use of the result. Returns an empty
+   * view for a null or unsigned certificate.
+   */
+  std::string_view signature(const X509 *x);
 
   std::string rand(std::size_t bytes);
   std::string rand_alphabet(std::size_t bytes, const std::string_view &alphabet = std::string_view {"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!%&()=-"});

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1180,7 +1180,13 @@ namespace nvhttp {
       return {};
     }
 
-    auto client_cert_signature = crypto::signature(const_cast<X509 *>(client_cert.get()));
+    // Both signatures below are BORROWED views into their certificate's ASN.1
+    // data, so each certificate must stay alive for as long as its view is
+    // read. `client_cert` is owned by the caller and `stored_x509` by this
+    // scope, which is exactly why crypto::signature() takes a raw pointer:
+    // passing one to a `const x509_t &` parameter used to build an owning
+    // temporary that freed the certificate out from under us.
+    auto client_cert_signature = crypto::signature(client_cert.get());
 
     client_t &client = client_root;
     for (auto &named_cert : client.named_devices) {
@@ -1554,7 +1560,7 @@ namespace nvhttp {
     cipher.decrypt(challenge, decrypted);
 
     auto x509 = crypto::x509(conf_intern.servercert);
-    auto sign = crypto::signature(x509);
+    auto sign = crypto::signature(x509.get());
     auto serversecret = crypto::rand(16);
 
     decrypted.insert(std::end(decrypted), std::begin(sign), std::end(sign));
@@ -1631,7 +1637,7 @@ namespace nvhttp {
       fail_pair(sess, tree, "Invalid client certificate");
       return;
     }
-    auto x509_sign = crypto::signature(x509);
+    auto x509_sign = crypto::signature(x509.get());
 
     std::string data;
     data.reserve(sess.serverchallenge.size() + x509_sign.size() + secret.size());

--- a/src/platform/linux/graphics.cpp
+++ b/src/platform/linux/graphics.cpp
@@ -354,7 +354,7 @@ namespace egl {
     }
 
     // native_display.left() equals native_display.right()
-    display_t display = eglGetPlatformDisplay(egl_platform, native_display_p, nullptr);
+    display_t display {eglGetPlatformDisplay(egl_platform, native_display_p, nullptr)};
 
     if (fail()) {
       BOOST_LOG(error) << "Couldn't open EGL display: ["sv << util::hex(eglGetError()).to_string_view() << ']';

--- a/src/platform/linux/input/inputtino.cpp
+++ b/src/platform/linux/input/inputtino.cpp
@@ -22,7 +22,7 @@ using namespace std::literals;
 namespace platf {
 
   input_t input() {
-    return {new input_raw_t()};
+    return input_t {new input_raw_t()};
   }
 
   std::unique_ptr<client_input_t> allocate_client_input_context(input_t &input) {

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -250,7 +250,7 @@ namespace platf {
         this->plane.reset();
 
         for (; plane_p != end; ++plane_p) {
-          plane_t plane = drmModeGetPlane(fd, *plane_p);
+          plane_t plane {drmModeGetPlane(fd, *plane_p)};
           if (!plane) {
             BOOST_LOG(error) << "Couldn't get drm plane ["sv << (end - plane_p) << "]: "sv << strerror(errno);
             continue;
@@ -371,15 +371,15 @@ namespace platf {
       }
 
       crtc_t crtc(std::uint32_t id) {
-        return drmModeGetCrtc(fd.el, id);
+        return crtc_t {drmModeGetCrtc(fd.el, id)};
       }
 
       encoder_t encoder(std::uint32_t id) {
-        return drmModeGetEncoder(fd.el, id);
+        return encoder_t {drmModeGetEncoder(fd.el, id)};
       }
 
       res_t res() {
-        return drmModeGetResources(fd.el);
+        return res_t {drmModeGetResources(fd.el)};
       }
 
       bool is_nvidia() {
@@ -433,7 +433,7 @@ namespace platf {
       }
 
       connector_interal_t connector(std::uint32_t id) {
-        return drmModeGetConnector(fd.el, id);
+        return connector_interal_t {drmModeGetConnector(fd.el, id)};
       }
 
       std::vector<connector_t> monitors(conn_type_count_t &conn_type_count) {
@@ -482,7 +482,7 @@ namespace platf {
       }
 
       std::vector<std::pair<prop_t, std::uint64_t>> props(std::uint32_t id, std::uint32_t type) {
-        obj_prop_t obj_prop = drmModeObjectGetProperties(fd.el, id, type);
+        obj_prop_t obj_prop {drmModeObjectGetProperties(fd.el, id, type)};
         if (!obj_prop) {
           return {};
         }
@@ -510,7 +510,7 @@ namespace platf {
       }
 
       plane_t operator[](std::uint32_t index) {
-        return drmModeGetPlane(fd.el, plane_res->planes[index]);
+        return plane_t {drmModeGetPlane(fd.el, plane_res->planes[index])};
       }
 
       std::uint32_t count() {
@@ -802,7 +802,7 @@ namespace platf {
           return false;
         }
 
-        prop_blob_t hdr_metadata_blob = drmModeGetPropertyBlob(card.fd.el, *hdr_metadata_blob_id);
+        prop_blob_t hdr_metadata_blob {drmModeGetPropertyBlob(card.fd.el, *hdr_metadata_blob_id)};
         if (hdr_metadata_blob == nullptr) {
           BOOST_LOG(error) << "Unable to get HDR metadata blob: "sv << strerror(errno);
           return false;
@@ -849,7 +849,7 @@ namespace platf {
           return false;
         }
 
-        prop_blob_t hdr_metadata_blob = drmModeGetPropertyBlob(card.fd.el, *hdr_metadata_blob_id);
+        prop_blob_t hdr_metadata_blob {drmModeGetPropertyBlob(card.fd.el, *hdr_metadata_blob_id)};
         if (hdr_metadata_blob == nullptr) {
           BOOST_LOG(error) << "Unable to get HDR metadata blob: "sv << strerror(errno);
           return false;
@@ -877,7 +877,7 @@ namespace platf {
           return;
         }
 
-        plane_t plane = drmModeGetPlane(card.fd.el, cursor_plane_id);
+        plane_t plane {drmModeGetPlane(card.fd.el, cursor_plane_id)};
 
         std::optional<std::int32_t> prop_crtc_x;
         std::optional<std::int32_t> prop_crtc_y;
@@ -1063,7 +1063,7 @@ namespace platf {
           }
         }
 
-        plane_t plane = drmModeGetPlane(card.fd.el, plane_id);
+        plane_t plane {drmModeGetPlane(card.fd.el, plane_id)};
         frame_timestamp = std::chrono::steady_clock::now();
 
         auto fb = card.fb(plane.get());

--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -840,7 +840,7 @@ namespace platf {
     void cursor_t::capture(egl::cursor_t &img) {
       auto display = (xdisplay_t::pointer) ctx.get();
 
-      xcursor_t xcursor = fix::GetCursorImage(display);
+      xcursor_t xcursor {fix::GetCursorImage(display)};
 
       if (img.serial != xcursor->cursor_serial) {
         auto buf_size = xcursor->width * xcursor->height * sizeof(int);
@@ -869,7 +869,7 @@ namespace platf {
     }
 
     xdisplay_t make_display() {
-      return OpenDisplay(nullptr);
+      return xdisplay_t {OpenDisplay(nullptr)};
     }
 
     void freeDisplay(_XDisplay *xdisplay) {

--- a/src/utility.h
+++ b/src/utility.h
@@ -545,8 +545,21 @@ namespace util {
     uniq_ptr(const uniq_ptr &other) noexcept = delete;
     uniq_ptr &operator=(const uniq_ptr &other) noexcept = delete;
 
+    /**
+     * Adopting constructor — takes ownership of `p` and will free it.
+     *
+     * `explicit` on purpose. While this conversion was implicit, any call of
+     * the form `f(owner.get())` where `f` took a `const uniq_ptr &` compiled
+     * into a silent ownership transfer: the argument materialised a temporary
+     * that adopted the raw pointer and released it at the end of the full
+     * expression, so the reference was over-released while the real owner
+     * still believed it held one. That is the defect behind the nvhttp
+     * client-identity use-after-free — see crypto::signature()'s header
+     * comment. Taking ownership is now something a caller says out loud, and
+     * there is deliberately no adopting `operator=`: use reset().
+     */
     template<class V>
-    uniq_ptr(V *p) noexcept:
+    explicit uniq_ptr(V *p) noexcept:
         _p {p} {
       static_assert(std::is_same_v<element_type, void> || std::is_same_v<element_type, V> || std::is_base_of_v<element_type, V>, "element_type must be base class of V");
     }
@@ -585,6 +598,13 @@ namespace util {
     }
 
     void reset(pointer p = pointer()) {
+      // Self-reset is a no-op, not a free-then-dangle. `reset(get())` reads as
+      // "I still own this", but without this guard it destroyed the object and
+      // stored the freed pointer, double-freeing at scope exit.
+      if (_p == p) {
+        return;
+      }
+
       if (_p) {
         _deleter(_p);
       }

--- a/tests/unit/test_crypto_ownership.cpp
+++ b/tests/unit/test_crypto_ownership.cpp
@@ -1,0 +1,260 @@
+/**
+ * @file tests/unit/test_crypto_ownership.cpp
+ * @brief Ownership discipline around util::uniq_ptr and crypto::signature.
+ *
+ * Regression coverage for the crash that killed the host twice on
+ * 2026-07-29 (minidumps luminalshine-20260729-125516 and -154658): an
+ * access violation writing to freed memory inside X509_free's reference
+ * count, reached from nvhttp's TLS verify callback.
+ *
+ * The cause was not in nvhttp. `crypto::signature()` took its certificate
+ * as `const crypto::x509_t &` — an OWNING smart pointer — while callers
+ * passed a raw `X509 *`. util::uniq_ptr's converting constructor was
+ * implicit, so each such call materialised a temporary owner that adopted
+ * the caller's pointer and freed it at the end of the full expression.
+ * Two distinct failures followed from that one line:
+ *
+ *   1. The peer certificate was destroyed at the end of every successful
+ *      TLS handshake while both OpenSSL's session and nvhttp's
+ *      thread_local still referenced it. The next handshake on the same
+ *      io_context thread freed the dangling pointer again — the observed
+ *      access violation.
+ *   2. In the paired-client scan, the borrowed pointer belonged to a live
+ *      local `x509_t`, so that certificate was freed by the temporary and
+ *      then freed AGAIN when the local went out of scope: an unconditional
+ *      double free on every authenticated request, once per stored client.
+ *
+ * These tests pin both halves of the fix — the non-owning signature and the
+ * explicit constructor that makes the whole bug class a compile error — and
+ * are pure: no network, no GPU.
+ */
+
+// standard includes
+#include <string_view>
+#include <type_traits>
+
+// lib includes
+#include <gtest/gtest.h>
+
+// local includes
+#include "../tests_common.h"
+
+#include <src/crypto.h>
+#include <src/utility.h>
+
+namespace {
+
+  // --- The systemic guard -------------------------------------------------
+  //
+  // This is the assertion that matters most. While a raw pointer converted
+  // implicitly to an owning uniq_ptr, EVERY function taking a smart pointer
+  // by const reference silently accepted `.get()` and freed it. Keeping the
+  // conversion explicit is what prevents a fresh instance of this bug from
+  // ever compiling again.
+
+  static_assert(
+    !std::is_convertible_v<X509 *, crypto::x509_t>,
+    "util::uniq_ptr's adopting constructor must stay explicit: an implicit "
+    "conversion turns every f(owner.get()) call into a silent free of the "
+    "caller's pointer."
+  );
+  static_assert(
+    !std::is_convertible_v<EVP_PKEY *, crypto::pkey_t>,
+    "the explicit-adoption rule must hold for every safe_ptr alias, not just x509_t"
+  );
+
+  // Adoption must still be possible — just spelled out.
+  static_assert(std::is_constructible_v<crypto::x509_t, X509 *>);
+
+  // ...and NOT via assignment either. There is deliberately no adopting
+  // `operator=`, so `owner = raw_ptr;` does not compile; reset() is the one
+  // way to hand ownership over. (This never compiled before the fix either —
+  // the deleted copy-assignment won overload resolution — so nothing in the
+  // tree depends on it.)
+  static_assert(!std::is_assignable_v<crypto::x509_t &, X509 *>);
+
+  // The nullptr constructor stays implicit, so `x509_t x {};` and passing
+  // `nullptr` where an x509_t is expected keep working.
+  static_assert(std::is_convertible_v<std::nullptr_t, crypto::x509_t>);
+
+  // --- crypto::signature must not take ownership --------------------------
+
+  static_assert(
+    std::is_same_v<decltype(&crypto::signature), std::string_view (*)(const X509 *)>,
+    "crypto::signature must take a NON-OWNING const X509 *. Changing it back "
+    "to a smart-pointer parameter reintroduces the use-after-free."
+  );
+
+  /**
+   * A deleter that counts calls, so ownership can be asserted directly
+   * rather than inferred from whether the process happens to survive.
+   */
+  int g_free_count = 0;
+
+  void counting_free(int *p) {
+    ++g_free_count;
+    delete p;
+  }
+
+  using counted_t = util::safe_ptr<int, counting_free>;
+
+  /// Stand-in for a borrowing helper like crypto::signature.
+  int borrow_value(const int *p) {
+    return p ? *p : -1;
+  }
+
+  class CryptoOwnership : public ::testing::Test {
+  protected:
+    void SetUp() override {
+      g_free_count = 0;
+    }
+  };
+
+  TEST_F(CryptoOwnership, BorrowingHelperDoesNotFreeTheCallersPointer) {
+    {
+      counted_t owner {new int {7}};
+      EXPECT_EQ(borrow_value(owner.get()), 7);
+
+      // The whole point: handing `.get()` to a borrower must not have
+      // consumed the object. Under the old implicit constructor an
+      // equivalent call against a `const counted_t &` parameter freed it
+      // here, and g_free_count would already be 1.
+      EXPECT_EQ(g_free_count, 0);
+      ASSERT_TRUE(owner);
+      EXPECT_EQ(*owner, 7);
+    }
+
+    // Exactly one free, performed by the real owner at scope exit.
+    EXPECT_EQ(g_free_count, 1);
+  }
+
+  TEST_F(CryptoOwnership, AdoptionFreesExactlyOnce) {
+    {
+      counted_t owner {new int {3}};
+      EXPECT_EQ(g_free_count, 0);
+    }
+    EXPECT_EQ(g_free_count, 1);
+  }
+
+  TEST_F(CryptoOwnership, ResetFreesThePreviousValue) {
+    counted_t owner {new int {1}};
+    owner.reset(new int {2});  // frees the 1
+    EXPECT_EQ(g_free_count, 1);
+    ASSERT_TRUE(owner);
+    EXPECT_EQ(*owner, 2);
+
+    owner.reset();
+    EXPECT_EQ(g_free_count, 2);
+    EXPECT_FALSE(owner);
+  }
+
+  TEST_F(CryptoOwnership, SelfResetIsANoOp) {
+    counted_t owner {new int {5}};
+
+    // Reads as "I still own this". Without the equality guard in reset() it
+    // freed the object and stored the freed pointer, then double-freed at
+    // scope exit.
+    owner.reset(owner.get());
+    EXPECT_EQ(g_free_count, 0);
+    ASSERT_TRUE(owner);
+    EXPECT_EQ(*owner, 5);
+
+    owner.reset();
+    EXPECT_EQ(g_free_count, 1);
+  }
+
+  // --- Behaviour of the fixed signature() ---------------------------------
+
+  TEST_F(CryptoOwnership, SignatureLeavesTheCertificateUsable) {
+    auto creds = crypto::gen_creds("ownership-test", 2048);
+    auto cert = crypto::x509(creds.x509);
+    ASSERT_TRUE(cert);
+
+    const auto first = crypto::signature(cert.get());
+    EXPECT_FALSE(first.empty());
+
+    // The certificate must survive the call. Before the fix the pointer was
+    // freed here, so everything below was a use-after-free and the second
+    // read could return anything at all.
+    ASSERT_TRUE(cert);
+    EXPECT_NE(X509_get_subject_name(cert.get()), nullptr);
+
+    const auto second = crypto::signature(cert.get());
+    EXPECT_EQ(first, second);
+    EXPECT_EQ(first.data(), second.data()) << "the view must alias the certificate, not a copy";
+  }
+
+  TEST_F(CryptoOwnership, SignatureMatchesOpensslDirectly) {
+    auto creds = crypto::gen_creds("ownership-test", 2048);
+    auto cert = crypto::x509(creds.x509);
+    ASSERT_TRUE(cert);
+
+    const ASN1_BIT_STRING *asn1 = nullptr;
+    X509_get0_signature(&asn1, nullptr, cert.get());
+    ASSERT_NE(asn1, nullptr);
+
+    const auto sig = crypto::signature(cert.get());
+    ASSERT_EQ(sig.size(), static_cast<std::size_t>(asn1->length));
+    EXPECT_EQ(sig.data(), reinterpret_cast<const char *>(asn1->data));
+  }
+
+  TEST_F(CryptoOwnership, SignatureIsNullSafe) {
+    EXPECT_TRUE(crypto::signature(nullptr).empty());
+  }
+
+  /**
+   * The paired-client scan in nvhttp compares a presented certificate's
+   * signature against every stored certificate's signature, re-parsing each
+   * stored PEM into a local owner. That loop is where the double free fired,
+   * once per stored client per authenticated request. Repeat the shape here
+   * and assert both that the comparison works and that repeating it is
+   * stable — with the bug, the second pass read freed heap.
+   */
+  TEST_F(CryptoOwnership, RepeatedStoredCertificateScanIsStable) {
+    auto stored = crypto::gen_creds("stored-client", 2048);
+    auto other = crypto::gen_creds("other-client", 2048);
+
+    auto presented = crypto::x509(stored.x509);
+    ASSERT_TRUE(presented);
+    const auto presented_sig = crypto::signature(presented.get());
+    ASSERT_FALSE(presented_sig.empty());
+
+    for (int pass = 0; pass < 3; ++pass) {
+      bool matched = false;
+      for (const auto &pem : {stored.x509, other.x509}) {
+        auto stored_x509 = crypto::x509(pem);
+        ASSERT_TRUE(stored_x509) << "pass " << pass;
+
+        const auto stored_sig = crypto::signature(stored_x509.get());
+        EXPECT_FALSE(stored_sig.empty()) << "pass " << pass;
+
+        if (stored_sig == presented_sig) {
+          matched = true;
+        }
+
+        // The local owner is still intact after being borrowed from, so its
+        // destructor below is the first and only free.
+        ASSERT_TRUE(stored_x509) << "pass " << pass;
+      }
+      EXPECT_TRUE(matched) << "the stored certificate must match itself on pass " << pass;
+
+      // The presented certificate outlives every iteration, so its borrowed
+      // view is still valid.
+      ASSERT_TRUE(presented) << "pass " << pass;
+      EXPECT_EQ(crypto::signature(presented.get()), presented_sig) << "pass " << pass;
+    }
+  }
+
+  TEST_F(CryptoOwnership, DistinctCertificatesHaveDistinctSignatures) {
+    auto a = crypto::gen_creds("client-a", 2048);
+    auto b = crypto::gen_creds("client-b", 2048);
+
+    auto ca = crypto::x509(a.x509);
+    auto cb = crypto::x509(b.x509);
+    ASSERT_TRUE(ca);
+    ASSERT_TRUE(cb);
+
+    EXPECT_NE(crypto::signature(ca.get()), crypto::signature(cb.get()));
+  }
+
+}  // namespace


### PR DESCRIPTION
## Why this blocks 26.08.0-rc.2

rc.2 as currently built kills the host ~50 s into a boot-time service start. It happened twice on the dev box on 2026-07-29 (`luminalshine-20260729-125516-12804.dmp`, `-20260729-154658-14236.dmp`), both `0xc0000005` **inside luminalshine.exe**, both faulting on

```
lock xadd dword ptr [rax],0xffffffff     ; rax = X509* + 0xB8
```

i.e. OpenSSL's `ossl_asn1_do_lock` decrementing `X509->references` on an unmapped page, reached from nvhttp's TLS verify callback.

## Root cause

`crypto::signature()` took `const crypto::x509_t &` — an **owning** smart pointer — while callers passed a raw `X509 *`. `util::uniq_ptr`'s converting constructor was implicit, so every such call materialised a temporary that adopted the caller's pointer and released it at end of full-expression.

Verified accounting for one handshake (the verify hook runs from the `async_handshake` completion handler, so `SSL_SESSION->peer` already holds a reference):

| | |
|---|---|
| `+1` | `SSL_SESSION->peer` |
| `+1` | `SSL_get1_peer_certificate` → moved into `tl_peer_certificate` |
| `+1` | `SSL_get1_peer_certificate` → local `x509_verify` |
| `−1` | owning temporary at `nvhttp.cpp:1183` |
| `−1` | `x509_verify` destructor |
| **= 1** | **reference left, with TWO owners each believing they hold it** |

The over-release is **deterministic on every handshake**; the access violation is **probabilistic** — it needs OpenSSL to release last *and* the freed page to be decommitted. That is why there was no easy reproducer.

Second failure from the same parameter type: in the paired-client scan at `nvhttp.cpp:1189` the borrowed pointer belongs to a live local `x509_t`, so it is released twice — once per stored client, on every handshake — and both compared signatures are dangling `string_view`s into that memory.

Live since 2025-10-21; the 2026-05-25 GHSA-ph75-mgxh-mv57 fix put it on the path of every handshake.

## The fix

- `util::uniq_ptr`'s adopting constructor is **`explicit`**, making this bug class a compile error. Deliberately **no** adopting `operator=`: `owner = raw;` never compiled here anyway (the deleted copy-assignment wins overload resolution), so adding one would only reopen the hole in assignment position.
- `crypto::signature()` takes a non-owning `const X509 *`, and is null/unsigned-safe.
- `uniq_ptr::reset()` treats self-reset as a no-op — `reset(get())` previously freed the object and stored the dangling pointer.
- 16 copy-init sites spelled out: 1 in the shipping Windows build, 15 in the legacy Linux backends (corrected by inspection — this fork does not build or CI-test that tree).
- New `tests/unit/test_crypto_ownership.cpp`.

## Verification

Clean build, no diagnostics. **479 passed, 9 skipped.** Adversarially reviewed (17 findings, 9 survived, 8 refuted); the review caught three errors in the original commit, all fixed here.

## Out of scope, filed separately

`client_root.named_devices` is read on this same authorisation path with no lock while five mutators run on other threads; `cert_chain` can be cleared under an in-flight verify; and `tl_peer_certificate` is still a never-cleared thread_local written before the authorisation decision. All three are **pre-existing and byte-identical at `0d3a9158`**. This change removes the crash but leaves client misattribution — now silent rather than fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
