### PR TITLE
ci+display: pin release tags to the built commit; default layout to extended

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,24 @@ jobs:
           draft: true
           prerelease: ${{ needs.release-setup.outputs.prerelease }}
           tag_name: ${{ needs.release-setup.outputs.release_tag }}
+          # Pin the tag to the commit these binaries were actually built from.
+          #
+          # A draft release creates no tag ref — GitHub creates the tag when the
+          # maintainer clicks Publish. Without this input, action-gh-release
+          # records the default branch NAME as the target, so the tag is
+          # resolved against whatever `main` happens to point at *at publish
+          # time*. Anything merged between the release build and the click
+          # silently mis-tags the release, and the tag then disagrees with the
+          # PROJECT_VERSION_COMMIT compiled into the binaries and shown on the
+          # About page. beta.7 escaped this by luck; rc.2 only escaped it
+          # because main was manually frozen for the whole window.
+          #
+          # release_commit is `git rev-parse HEAD` from release-setup's
+          # checkout, i.e. the exact commit the build ran against. Pinning it
+          # here removes the need to freeze main between building a release and
+          # publishing it. Verify after any publish: `git rev-parse <tag>`
+          # should equal the commit on the About page.
+          target_commitish: ${{ needs.release-setup.outputs.release_commit }}
           # Explicit file list — the raw MSI is intentionally excluded
           # from the published release. The MSI still ships inside the
           # build-Windows-AMD64 Actions artifact for internal /

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1187,7 +1187,7 @@ editing the `conf` file in a text editor. Use the examples as reference.
     <tr>
         <td>Default</td>
         <td colspan="2">@code{}
-            exclusive
+            extended
             @endcode</td>
     </tr>
     <tr>
@@ -1199,7 +1199,7 @@ editing the `conf` file in a text editor. Use the examples as reference.
     <tr>
         <td rowspan="5">Choices</td>
         <td>exclusive</td>
-        <td>Deactivate every other monitor so only the virtual display remains visible.</td>
+        <td>Deactivate every other monitor so only the virtual display remains visible. Note the tradeoff: with no physical monitor active, a display-driver reset (including the <code>Win+Ctrl+Shift+B</code> hotkey) leaves Windows with no hardware-backed output to recompose onto, and a failed reset can wedge the display stack until reboot.</td>
     </tr>
     <tr>
         <td>extended</td>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -728,7 +728,11 @@ namespace config {
     _CONVERT_LAYOUT_(extended_isolated);
     _CONVERT_LAYOUT_(extended_primary_isolated);
 #undef _CONVERT_LAYOUT_
-    return video_t::virtual_display_layout_e::exclusive;
+    // Unrecognised value falls back to the shipped default. It must not fall
+    // back to `exclusive`, which deactivates every physical monitor — a typo in
+    // this key should not be able to leave the machine with the virtual display
+    // as its only output.
+    return video_t::virtual_display_layout_e::extended;
   }
 
   video_t video {
@@ -792,7 +796,7 @@ namespace config {
     {},  // output_name
 
     video_t::virtual_display_mode_e::per_client,  // virtual_display_mode
-    video_t::virtual_display_layout_e::exclusive,  // virtual_display_layout
+    video_t::virtual_display_layout_e::extended,  // virtual_display_layout
     "auto",  // virtual_display_backend
     800,  // vgd_hdr_peak_nits
 

--- a/src_assets/common/assets/web/components/HighPerformanceCard.vue
+++ b/src_assets/common/assets/web/components/HighPerformanceCard.vue
@@ -118,7 +118,11 @@ const HP_INTEL: Record<string, unknown> = {
 
 const DEFAULTS: Record<string, unknown> = {
   virtual_display_mode: 'per_client',
-  virtual_display_layout: 'exclusive',
+  // Tracks the shipped default in src/config.cpp. Note HP_BASE above
+  // deliberately keeps 'exclusive' — that is the point of the preset — so
+  // turning High Performance ON still hands the machine a single virtual
+  // output, and turning it OFF restores the safer extended layout.
+  virtual_display_layout: 'extended',
   dd_configuration_option: 'verify_only',
   dd_wa_virtual_double_refresh: true,
   min_threads: 2,

--- a/src_assets/common/assets/web/stores/config.ts
+++ b/src_assets/common/assets/web/stores/config.ts
@@ -155,7 +155,7 @@ const defaultGroups = [
       output_name: '',
       virtual_display_backend: 'auto',
       virtual_display_mode: 'per_client',
-      virtual_display_layout: 'exclusive',
+      virtual_display_layout: 'extended',
       dd_configuration_option: 'verify_only',
       dd_resolution_option: 'auto',
       dd_manual_resolution: '',


### PR DESCRIPTION
Two release-scoped changes, one commit each, both needed before 26.08.0-rc.2 is re-cut.

## 1. `ci: pin release tags to the commit the binaries were built from`

The release step passed no `target_commitish`, so `gh release view` reported `targetCommitish: "main"` — a branch **name**. A draft release creates no tag ref; GitHub creates the tag at Publish time and resolves that name against whatever `main` points at *then*. Anything merged in between silently mis-tags the release, and the tag then disagrees with the `PROJECT_VERSION_COMMIT` compiled into the binaries and shown on the About page.

beta.7 escaped this by luck. rc.2 escaped it only because `main` was **manually frozen** for the entire window between build and publish — a constraint that has made every recent release fragile and that no process note reliably enforces.

`release-setup` already exports `release_commit` as `git rev-parse HEAD` from its own checkout, so pinning to it is one line and **removes the freeze requirement entirely**.

Verify after any publish: `git rev-parse <tag>` should equal the commit on the About page.

## 2. `feat(display): default virtual_display_layout to extended, not exclusive`

`exclusive` deactivates every physical monitor, leaving the virtual display as the machine's only active output. It is the one configuration variable common to every machine-wide display-stack wedge on the dev box (2026-05-17, 07-26, 07-27, 07-28, 07-29), and it is what makes those wedges *unrecoverable* rather than merely disruptive:

- With no hardware-backed output active, a display-driver reset has nothing to recompose onto. The 07-29 13:38 outage began with a **deliberate** reset — `Win+Ctrl+Shift+B`, pressed to recover a hung game (WER `WindowsBlackScreenDiagnosticsV1`, `P4=Hotkey`, 13:38:06.576). 27 s later `QueryDisplayConfig` began returning `ERROR_NOT_SUPPORTED` and never recovered; the machine needed a reboot 2 h 07 min later. Windows logged **no TDR at all** (zero Event 4101 / nvlddmkm, all-time) — adapter loss without a recovery cycle.
- The TDR topology lifeboat exists to activate a physical display on a hang, but it enumerates through the same display API the failure removes. Under `exclusive` it has neither a target nor a working query; on 07-29 it failed **1 ms** after its own precondition passed.
- Every virtual-display create/destroy broadcasts `DBT_DEVNODES_CHANGED` machine-wide. GTA V Enhanced has an uncatchable bug in its `WM_DEVICECHANGE` handler (an AV escaping a kernel user-callback, which ntdll converts to `STATUS_FATAL_USER_CALLBACK_EXCEPTION 0xC000041D`), and a monitor **create alone** has been observed killing it — 07-27, +0.240 s after a create on connector 0.

### Tradeoffs, stated plainly

The desk monitors stay powered during a stream, and because the desktop genuinely extends, an unconfined mouse can leave the streamed surface. `exclusive` remains available; `extended_primary_isolated` gives the extended desktop without mouse wander.

The `virtual_display_layout_from_view` fallback moves from `exclusive` to `extended` too — a typo in this key should not be able to leave the machine with no physical output.

### What is deliberately *not* changed

`HP_BASE` in `HighPerformanceCard.vue` still applies `exclusive`. Single-output is the point of that preset and it is an explicit opt-in. Only its `DEFAULTS` map — the revert target — is updated, so switching High Performance **off** restores `extended` instead of pinning `exclusive` forever. Reviewers should know the preset re-arms the wedge precondition for the users most likely to be gaming.

### Honest framing

This **reduces blast radius; it is not a fix.** `POSTMORTEM-2026-07-27.md:53` still labels the exclusive/wedge correlation "not yet proven" and `:112` asks for exactly this controlled comparison — so shipping `extended` is also how the evidence gets generated. It would not have rescued the 07-29 lifeboat attempt, which was already enumerating zero devices.

## Verification

Clean build. Config-consistency gate passes: **189/190** in `ConfigConsistency*:Config*:*VirtualDisplay*:*DisplayDevice*`, the single failure being the pre-existing `ConfigHttpCheckAuthTest` disallowed-ip case. All six default sites confirmed consistent (config.cpp struct default + from_view fallback, docs, `stores/config.ts`, HighPerformanceCard `DEFAULTS`, with `HP_BASE` intentionally left).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
