### PR TITLE
rc.3 tranche 1: make exclusive + per_client work, and stop destroying the evidence

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -78,6 +78,42 @@ namespace {
   constexpr std::string_view k_session_separator = "-";
   constexpr std::string_view k_log_suffix = ".log";
 
+#ifndef PROJECT_NAME
+  #define PROJECT_NAME "LuminalShine"
+#endif
+#ifndef PROJECT_VERSION
+  #define PROJECT_VERSION "unknown"
+#endif
+#ifndef PROJECT_VERSION_COMMIT
+  #define PROJECT_VERSION_COMMIT "unknown"
+#endif
+
+  /**
+   * @brief Identity line written at the top of every log file, including rollovers.
+   *
+   * A rollover used to inherit nothing from the file it succeeded, so a session
+   * that produced enough output to roll (a QueryDisplayConfig failure storm will
+   * do it in minutes) ended up with log files that named no binary at all. The
+   * 2026-07-29 20:22 incident is unattributable to a specific build for exactly
+   * that reason: the startup banner had been rotated out from under it. Every
+   * file now carries the build that wrote it.
+   *
+   * @param sequence Rollover ordinal; 0 is the file opened at session start.
+   * @return A single newline-terminated banner line.
+   */
+  std::string make_log_banner(std::uint64_t sequence) {
+    auto now = std::chrono::system_clock::now();
+    auto tt = std::chrono::system_clock::to_time_t(now);
+    auto local_tm = *std::localtime(&tt);
+
+    std::ostringstream oss;
+    oss << "[" << std::put_time(&local_tm, "%Y-%m-%d %H:%M:%S") << "]: Info: "
+        << PROJECT_NAME << " version: " << PROJECT_VERSION
+        << " commit: " << PROJECT_VERSION_COMMIT
+        << " (log segment " << sequence << ")\n";
+    return oss.str();
+  }
+
   std::filesystem::path resolve_log_root(const std::filesystem::path &configured_path) {
     namespace fs = std::filesystem;
     auto default_root_base = []() {
@@ -285,8 +321,16 @@ namespace {
       }
       const unsigned char bom[3] = {0xEF, 0xBB, 0xBF};
       stream_->write(reinterpret_cast<const char *>(bom), sizeof(bom));
-      stream_->flush();
       bytes_written_ = 0;
+
+      // Stamp the build identity into every segment, not just the first one.
+      const auto banner = make_log_banner(rollover_counter_);
+      stream_->write(banner.data(), static_cast<std::streamsize>(banner.size()));
+      if (stream_->good()) {
+        // Count the banner so the rollover threshold still bounds the file.
+        bytes_written_ = banner.size();
+      }
+      stream_->flush();
       return true;
     }
 
@@ -354,6 +398,8 @@ namespace {
     }
     const unsigned char bom[3] = {0xEF, 0xBB, 0xBF};
     file_stream->write(reinterpret_cast<const char *>(bom), sizeof(bom));
+    const auto banner = make_log_banner(0);
+    file_stream->write(banner.data(), static_cast<std::streamsize>(banner.size()));
     file_stream->flush();
     return file_stream;
   }

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -13,10 +13,12 @@
 #include <cstdint>
 #include <cstring>
 #include <ctime>
+#include <deque>
 #include <filesystem>
 #include <format>
 #include <future>
 #include <limits>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -85,7 +87,10 @@ namespace nvhttp {
       context.use_private_key_file(private_key_file, boost::asio::ssl::context::pem);
     }
 
-    std::function<int(SSL *)> verify;
+    /// Peer verification hook. Receives the remote endpoint alongside the SSL
+    /// handle so the verified certificate can be filed against the connection
+    /// it arrived on rather than against whichever thread happened to run.
+    std::function<int(SSL *, const boost::asio::ip::tcp::endpoint &)> verify;
     std::function<void(std::shared_ptr<Response>, std::shared_ptr<Request>)> on_verify_failed;
 
   protected:
@@ -130,7 +135,13 @@ namespace nvhttp {
               return;
             }
             if (!ec) {
-              if (verify && !verify(session->connection->socket->native_handle())) {
+              // Non-throwing overload: the peer can vanish between handshake
+              // completion and this call, and an exception escaping an asio
+              // completion handler would take the io_service down. A failure
+              // yields the default endpoint, which the store treats as "no key".
+              SimpleWeb::error_code ep_ec;
+              const auto peer_endpoint = session->connection->socket->lowest_layer().remote_endpoint(ep_ec);
+              if (verify && !verify(session->connection->socket->native_handle(), ep_ec ? boost::asio::ip::tcp::endpoint {} : peer_endpoint)) {
                 this->write(session, on_verify_failed);
               } else {
                 this->read(session);
@@ -432,8 +443,21 @@ namespace nvhttp {
 
         const auto effective_virtual_display_mode =
           launch_session->virtual_display_mode_override.value_or(config::video.virtual_display_mode);
+        // A session with no resolved client identity cannot be allocated per-client:
+        // there is nothing to key it on. Degrade to shared allocation for THIS launch
+        // rather than keying every anonymous client to one shared placeholder identity.
+        // Deliberately a local — mutating virtual_display_mode_override would flip
+        // virtual-display creation on for a user who set mode=disabled and would
+        // suppress the per-app override merge later in this function.
+        const bool identity_known = !launch_session->client_uuid.empty();
         const bool shared_mode =
-          (effective_virtual_display_mode == config::video_t::virtual_display_mode_e::shared);
+          (effective_virtual_display_mode == config::video_t::virtual_display_mode_e::shared) || !identity_known;
+        if (!identity_known &&
+            effective_virtual_display_mode != config::video_t::virtual_display_mode_e::shared) {
+          BOOST_LOG(warning) << "Virtual display: no per-client identity for this session; using SHARED "
+                                "allocation for this launch only (configured mode is unchanged). client_name='"
+                             << launch_session->client_name << "'.";
+        }
         uuid_util::uuid_t session_uuid;
         if (shared_mode) {
           session_uuid = ensure_shared_guid();
@@ -441,17 +465,32 @@ namespace nvhttp {
         } else if (auto parsed = parse_uuid(launch_session->unique_id)) {
           session_uuid = *parsed;
         } else {
-          session_uuid = VDISPLAY::persistentVirtualDisplayUuid();
+          // Mint a fresh GUID rather than reusing persistentVirtualDisplayUuid().
+          // That UUID is machine-wide AND is the encoder probe's GUID, so every
+          // client that reached this fallback keyed into the SAME driver session
+          // and was handed the probe's 1080p60 SDR monitor instead of one built
+          // for its own mode. WebRTC already mints per session (webrtc_stream.cpp).
+          session_uuid = uuid_util::uuid_t::generate();
           launch_session->unique_id = session_uuid.string();
         }
 
+        // The stream GUID above keys the host's per-session tracking and must be
+        // unique per launch. The display identity below is a different thing: the
+        // driver hashes it into a stable display id so a returning client reclaims
+        // its connector and its per-monitor Windows settings. Randomising it every
+        // launch would churn connectors, which is what destroys that memory.
         std::string display_uuid_source;
         if (!shared_mode && !launch_session->client_uuid.empty()) {
           display_uuid_source = launch_session->client_uuid;
           BOOST_LOG(debug) << "Using client UUID for virtual display: " << display_uuid_source;
-        } else {
+        } else if (shared_mode) {
           display_uuid_source = session_uuid.string();
-          BOOST_LOG(debug) << "Using session UUID for virtual display: " << display_uuid_source;
+          BOOST_LOG(debug) << "Using shared session UUID for virtual display: " << display_uuid_source;
+        } else {
+          display_uuid_source = VDISPLAY::persistentVirtualDisplayUuid().string();
+          BOOST_LOG(debug) << "No per-client identity for this session; using the machine display identity "
+                              "for virtual display: "
+                           << display_uuid_source;
         }
 
         GUID virtual_display_guid {};
@@ -1171,8 +1210,52 @@ namespace nvhttp {
     }
   }
 
-  // Thread-local storage for peer certificate during SSL verification
-  thread_local crypto::x509_t tl_peer_certificate;
+  /**
+   * @brief Verified peer certificates, keyed by the connection they arrived on.
+   *
+   * This used to be a single `thread_local crypto::x509_t`. The HTTPS server
+   * defaults to a one-thread pool and nothing overrides it, so "thread-local"
+   * meant "process-wide": every handshake overwrote the one slot, and every
+   * request handler read whichever certificate happened to have handshaked most
+   * recently rather than the one belonging to its own connection.
+   *
+   * That misfires with no attacker involved. Two paired clients streaming
+   * concurrently is enough — the second client's handshake silently rebinds the
+   * first client's identity, and with virtual_display_mode=per_client the wrong
+   * named_cert then supplies the display-mode, layout and config overrides.
+   *
+   * Keyed by remote endpoint rather than by Request pointer: keep-alive builds a
+   * fresh Request per exchange on the same connection and never re-runs verify.
+   * Entries are written only after the peer has passed both the chain check and
+   * the paired-store check, so an unpaired peer can no longer leave anything
+   * behind. Bounded and evicted in insertion order — hooking connection
+   * destruction would require patching the vendored server.
+   */
+  constexpr std::size_t kMaxTrackedPeerCerts = 64;
+  std::mutex peer_cert_mutex;
+  std::map<boost::asio::ip::tcp::endpoint, crypto::x509_t> peer_certs;
+  std::deque<boost::asio::ip::tcp::endpoint> peer_cert_order;
+
+  /// A default-constructed endpoint (0.0.0.0:0) is what asio yields when the
+  /// socket has already errored or the weak_ptr expired. Two unrelated failures
+  /// would collide on it, so it is never a valid key.
+  bool is_usable_peer_key(const boost::asio::ip::tcp::endpoint &ep) {
+    return !ep.address().is_unspecified() && ep.port() != 0;
+  }
+
+  void store_peer_certificate(const boost::asio::ip::tcp::endpoint &ep, crypto::x509_t cert) {
+    if (!is_usable_peer_key(ep) || !cert) {
+      return;
+    }
+    std::lock_guard lg {peer_cert_mutex};
+    if (auto [it, inserted] = peer_certs.insert_or_assign(ep, std::move(cert)); inserted) {
+      peer_cert_order.push_back(ep);
+    }
+    while (peer_cert_order.size() > kMaxTrackedPeerCerts) {
+      peer_certs.erase(peer_cert_order.front());
+      peer_cert_order.pop_front();
+    }
+  }
 
   std::string get_client_uuid_from_peer_cert(const crypto::x509_t &client_cert, std::string *client_name_out = nullptr) {
     if (!client_cert) {
@@ -1208,8 +1291,24 @@ namespace nvhttp {
   }
 
   std::string get_client_uuid_from_request(req_https_t request, std::string *client_name_out = nullptr) {
-    // Try to use the peer certificate that was stored during SSL verification
-    return get_client_uuid_from_peer_cert(tl_peer_certificate, client_name_out);
+    if (!request) {
+      return {};
+    }
+    // remote_endpoint() is noexcept and yields a default endpoint if the
+    // connection is already gone; that is a miss, never a match.
+    const auto ep = request->remote_endpoint();
+    if (!is_usable_peer_key(ep)) {
+      BOOST_LOG(debug) << "No usable peer endpoint for this request; client identity unavailable.";
+      return {};
+    }
+
+    std::lock_guard lg {peer_cert_mutex};
+    const auto it = peer_certs.find(ep);
+    if (it == peer_certs.end()) {
+      BOOST_LOG(debug) << "No verified peer certificate on record for this connection.";
+      return {};
+    }
+    return get_client_uuid_from_peer_cert(it->second, client_name_out);
   }
 
   named_cert_t *get_named_cert_by_uuid(const std::string &uuid) {
@@ -1302,10 +1401,24 @@ namespace nvhttp {
       launch_session->client_uuid = get_client_uuid_from_request(request, &launch_session->client_name);
     }
 
-    // Some launch paths may not provide a peer certificate (e.g. non-TLS resume).
-    // Fall back to the client-provided unique ID so per-client settings still apply.
+    // There used to be a fallback here to the client-supplied "uniqueid" arg,
+    // justified as "so per-client settings still apply". It never could: a
+    // named_cert uuid is always a 36-char generated UUID, so a 16-hex-char
+    // uniqueid never matched one. What it did do is hand every client the same
+    // identity, because Moonlight sends the literal "0123456789ABCDEF" — one
+    // attacker-controllable value, shared by every session on the machine, fed
+    // straight into the virtual display's identity hash.
+    //
+    // An unknown identity is now reported as unknown. It is NOT a refusal: the
+    // session continues, and the virtual-display allocation below falls back to
+    // shared mode for this launch only.
     if (launch_session->client_uuid.empty()) {
-      launch_session->client_uuid = get_arg(args, "uniqueid", "");
+      BOOST_LOG(warning) << "Client identity unavailable for this session (no paired certificate matched this "
+                            "connection); it will use SHARED virtual-display allocation. clientName='"
+                         << get_arg(args, "clientName", "") << "'.";
+    } else {
+      BOOST_LOG(info) << "Client identity resolved from the paired certificate: uuid="
+                      << launch_session->client_uuid << " name='" << launch_session->client_name << "'.";
     }
 
     auto client_name_arg = get_arg(args, "clientName", "");
@@ -2153,9 +2266,9 @@ namespace nvhttp {
         if (request) {
           client_uuid = get_client_uuid_from_request(request);
         }
-        if (client_uuid.empty()) {
-          client_uuid = get_arg(args, "uniqueid", "");
-        }
+        // No "uniqueid" fallback here either — see make_launch_session. An empty
+        // uuid simply finds no named_cert, which is the correct outcome for an
+        // unidentified client; get_named_cert_by_uuid early-returns on empty.
         if (auto *client_settings = get_named_cert_by_uuid(client_uuid)) {
           for (const auto &[k, v] : client_settings->config_overrides) {
             overrides.insert_or_assign(k, v);
@@ -2662,7 +2775,7 @@ namespace nvhttp {
     http_server_t http_server;
 
     // Verify certificates after establishing connection
-    https_server.verify = [add_cert](SSL *ssl) {
+    https_server.verify = [add_cert](SSL *ssl, const boost::asio::ip::tcp::endpoint &peer_endpoint) {
       crypto::x509_t x509 {
 #if OPENSSL_VERSION_MAJOR >= 3
         SSL_get1_peer_certificate(ssl)
@@ -2671,10 +2784,11 @@ namespace nvhttp {
 #endif
       };
 
-      // Store peer certificate in thread-local storage for use in request handlers
-      if (x509) {
-        tl_peer_certificate = std::move(x509);
-      }
+      // Deliberately NOT stored yet. This certificate is filed against the
+      // connection only after it has cleared both the chain check and the
+      // paired-store check below; storing it here would let any peer that can
+      // complete a handshake with a self-signed certificate leave its identity
+      // behind, since after_bind()'s verify_callback accepts unconditionally.
 
       // Re-fetch for verification logic
       crypto::x509_t x509_verify {
@@ -2725,6 +2839,10 @@ namespace nvhttp {
 
         return verified;
       }
+
+      // Fully verified and paired: file it against this connection so the
+      // request handlers on it resolve this client, and only this client.
+      store_peer_certificate(peer_endpoint, std::move(x509));
 
       verified = 1;
 

--- a/src/platform/windows/display_helper_integration.cpp
+++ b/src/platform/windows/display_helper_integration.cpp
@@ -1628,10 +1628,17 @@ namespace display_helper_integration {
   }
 
   namespace {
+    /// Streak counter and its start timestamp are one logical unit: updating them
+    /// as two independent atomics lets a success/failure interleave zero the
+    /// counter while leaving a live timestamp stranded, after which the "and
+    /// thirty seconds" half of the gate below is measured against an anchor that
+    /// never advances again. One small mutex keeps them consistent; this is not
+    /// a hot path (one enumeration has already happened by the time we get here).
+    std::mutex g_enumeration_state_mutex;
     /// Consecutive enumerate_devices() calls that came back with nothing.
-    std::atomic<std::uint64_t> g_empty_enumerations {0};
+    std::uint64_t g_empty_enumerations = 0;
     /// steady_clock ms at which the current failing streak began; 0 == not failing.
-    std::atomic<std::int64_t> g_enumeration_failing_since_ms {0};
+    std::int64_t g_enumeration_failing_since_ms = 0;
     /// steady_clock ms of the last confirm probe, so its 2 s sleep runs rarely.
     std::atomic<std::int64_t> g_last_stack_probe_ms {0};
 
@@ -1672,23 +1679,25 @@ namespace display_helper_integration {
      * loop, so it is additionally rate-limited to once a minute.
      */
     void note_enumeration_result(bool produced_devices) {
-      if (produced_devices) {
-        if (g_empty_enumerations.exchange(0, std::memory_order_release) != 0) {
-          g_enumeration_failing_since_ms.store(0, std::memory_order_release);
-        }
-        return;
-      }
-
       const auto now_ms = steady_ms_now();
-      const auto streak = g_empty_enumerations.fetch_add(1, std::memory_order_acq_rel) + 1;
-      std::int64_t expected = 0;
-      g_enumeration_failing_since_ms.compare_exchange_strong(expected, now_ms, std::memory_order_acq_rel);
-
-      if (streak < kEmptyEnumerationsBeforeProbe) {
-        return;
+      std::uint64_t streak = 0;
+      std::int64_t failing_since = 0;
+      {
+        std::lock_guard lg {g_enumeration_state_mutex};
+        if (produced_devices) {
+          g_empty_enumerations = 0;
+          g_enumeration_failing_since_ms = 0;
+          return;
+        }
+        if (g_empty_enumerations == 0) {
+          g_enumeration_failing_since_ms = now_ms;
+        }
+        streak = ++g_empty_enumerations;
+        failing_since = g_enumeration_failing_since_ms;
       }
-      const auto failing_since = g_enumeration_failing_since_ms.load(std::memory_order_acquire);
-      if (failing_since == 0 || (now_ms - failing_since) < kMinFailingMsBeforeProbe) {
+
+      if (streak < kEmptyEnumerationsBeforeProbe ||
+          (now_ms - failing_since) < kMinFailingMsBeforeProbe) {
         return;
       }
       if (tdr::stack_down()) {

--- a/src/platform/windows/display_helper_integration.cpp
+++ b/src/platform/windows/display_helper_integration.cpp
@@ -39,9 +39,11 @@
   #include "src/platform/windows/ipc/display_settings_client.h"
   #include "src/platform/windows/ipc/misc_utils.h"
   #include "src/platform/windows/ipc/process_handler.h"
+  #include "src/platform/windows/display.h"
   #include "src/platform/windows/misc.h"
   #include "src/platform/windows/virtual_display.h"
   #include "src/process.h"
+  #include "src/tdr_state.h"
 
   #include <display_device/noop_audio_context.h>
   #include <display_device/noop_settings_persistence.h>
@@ -1625,6 +1627,112 @@ namespace display_helper_integration {
     return result;
   }
 
+  namespace {
+    /// Consecutive enumerate_devices() calls that came back with nothing.
+    std::atomic<std::uint64_t> g_empty_enumerations {0};
+    /// steady_clock ms at which the current failing streak began; 0 == not failing.
+    std::atomic<std::int64_t> g_enumeration_failing_since_ms {0};
+    /// steady_clock ms of the last confirm probe, so its 2 s sleep runs rarely.
+    std::atomic<std::int64_t> g_last_stack_probe_ms {0};
+
+    constexpr std::uint64_t kEmptyEnumerationsBeforeProbe = 20;
+    constexpr std::int64_t kMinFailingMsBeforeProbe = 30'000;
+    constexpr std::int64_t kMinMsBetweenStackProbes = 60'000;
+
+    std::int64_t steady_ms_now() {
+      return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now().time_since_epoch()
+      )
+        .count();
+    }
+
+    /**
+     * @brief Escalate a sustained enumeration blackout to the terminal stack-down verdict.
+     *
+     * Until this existed, the only routes to tdr::mark_stack_down ran off
+     * D3D11CreateDevice exhaustion (display_base.cpp) and the session-start
+     * encoder probe (stream.cpp). Both need something to be actively trying to
+     * create a device, so a wedge with no stream running was invisible: during
+     * the 2026-07-29 20:22 incident the host spun ~12,500 QueryDisplayConfig
+     * give-up cycles over thirty minutes and never once latched. /api/health/tdr
+     * reported stack_down=false the entire time, so the Troubleshooting page
+     * told the user nothing was wrong while nothing worked.
+     *
+     * The bar is deliberately high, because latching refuses new sessions:
+     * twenty consecutive empty enumerations AND thirty seconds of continuous
+     * failure before the confirm probe is even considered, then
+     * display_stack_confirmed_down()'s own two ERROR_NOT_SUPPORTED reads two
+     * seconds apart. Anything short of the machine-wide wedge signature
+     * (ERROR_GEN_FAILURE, ACCESS_DENIED, a healthy API reporting zero paths)
+     * does not latch. A machine that recovers clears the latch by itself:
+     * tdr::stack_down() re-probes every five seconds through the recheck hook
+     * installed by tdr_lifeboat, and note_stack_healthy() un-latches.
+     *
+     * The probe sleeps two seconds internally and is called from a 150 ms poll
+     * loop, so it is additionally rate-limited to once a minute.
+     */
+    void note_enumeration_result(bool produced_devices) {
+      if (produced_devices) {
+        if (g_empty_enumerations.exchange(0, std::memory_order_release) != 0) {
+          g_enumeration_failing_since_ms.store(0, std::memory_order_release);
+        }
+        return;
+      }
+
+      const auto now_ms = steady_ms_now();
+      const auto streak = g_empty_enumerations.fetch_add(1, std::memory_order_acq_rel) + 1;
+      std::int64_t expected = 0;
+      g_enumeration_failing_since_ms.compare_exchange_strong(expected, now_ms, std::memory_order_acq_rel);
+
+      if (streak < kEmptyEnumerationsBeforeProbe) {
+        return;
+      }
+      const auto failing_since = g_enumeration_failing_since_ms.load(std::memory_order_acquire);
+      if (failing_since == 0 || (now_ms - failing_since) < kMinFailingMsBeforeProbe) {
+        return;
+      }
+      if (tdr::stack_down()) {
+        return;  // already latched; nothing to add
+      }
+
+      auto last_probe = g_last_stack_probe_ms.load(std::memory_order_acquire);
+      if (last_probe != 0 && (now_ms - last_probe) < kMinMsBetweenStackProbes) {
+        return;
+      }
+      if (!g_last_stack_probe_ms.compare_exchange_strong(last_probe, now_ms, std::memory_order_acq_rel)) {
+        return;  // another thread is probing
+      }
+
+      LONG qdc_status = ERROR_SUCCESS;
+      UINT32 qdc_paths = 0;
+      if (!platf::dxgi::display_stack_confirmed_down(&qdc_status, &qdc_paths)) {
+        BOOST_LOG(warning) << "Display enumeration has returned no devices for " << streak
+                           << " consecutive calls over " << ((now_ms - failing_since) / 1000)
+                           << "s, but the display API did not confirm the machine-wide wedge signature"
+                              " (status "
+                           << qdc_status << ", " << qdc_paths
+                           << " paths). Not latching a terminal verdict; will re-check.";
+        return;
+      }
+
+      std::string detail = "display enumeration returned no devices for ";
+      detail += std::to_string(streak);
+      detail += " consecutive calls over ";
+      detail += std::to_string((now_ms - failing_since) / 1000);
+      detail += "s; QueryDisplayConfig unavailable (status ";
+      detail += std::to_string(qdc_status);
+      detail += ", ";
+      detail += std::to_string(qdc_paths);
+      detail += " paths, confirmed twice)";
+
+      BOOST_LOG(fatal) << "DISPLAY STACK UNAVAILABLE MACHINE-WIDE: " << detail
+                       << ". No display can be configured or captured by any program until this clears."
+                          " First try Win+Ctrl+Shift+B to restart the Windows graphics stack; if displays"
+                          " do not return, this machine must be REBOOTED.";
+      tdr::mark_stack_down(static_cast<long>(qdc_status), std::move(detail));
+    }
+  }  // namespace
+
   std::optional<display_device::EnumeratedDeviceList> enumerate_devices(
     display_device::DeviceEnumerationDetail detail
   ) {
@@ -1632,8 +1740,14 @@ namespace display_helper_integration {
       display_device::DisplayRecoveryBehaviorGuard guard(display_device::DisplayRecoveryBehavior::Skip);
       auto api = std::make_shared<display_device::WinApiLayer>();
       display_device::WinDisplayDevice dd(api);
-      return dd.enumAvailableDevices(detail);
+      auto devices = dd.enumAvailableDevices(detail);
+      // enumAvailableDevices returns an ENGAGED but EMPTY list when the
+      // underlying QueryDisplayConfig fails, so "did it throw" is not the
+      // signal -- "did it produce anything" is.
+      note_enumeration_result(!devices.empty());
+      return devices;
     } catch (...) {
+      note_enumeration_result(false);
       return std::nullopt;
     }
   }

--- a/src/platform/windows/virtual_display_vgd.cpp
+++ b/src/platform/windows/virtual_display_vgd.cpp
@@ -33,6 +33,10 @@ namespace VDISPLAY::vgd {
       /// GDI display name ("\\\\.\\DISPLAY274") once the monitor surfaced;
       /// empty while the display is still inactive pre-APPLY.
       std::wstring display_name;
+      /// The client UID this monitor was built for. Recorded so the reuse
+      /// branch can prove the re-requested stream GUID belongs to the same
+      /// client before handing back a monitor built to someone else's mode.
+      std::string client_uid;
     };
 
     struct GuidKey {
@@ -266,23 +270,52 @@ namespace VDISPLAY::vgd {
     }
 
     if (auto it = g_sessions.find(key_of(guid)); it != g_sessions.end()) {
-      // Same stream GUID re-requested: report the existing display.
-      VirtualDisplayCreationResult result {};
-      result.reused_existing = true;
-      result.ready_since = std::chrono::steady_clock::now();
-      result.client_name = it->second.client_name;
-      lk.unlock();
-      auto names = luminal_display_names();
-      if (!names.empty()) {
-        result.display_name = names.front();
-        result.monitor_device_path = monitor_device_path_of(names.front());
-        result.device_id = resolveVirtualDisplayDeviceId(names.front());
-        std::lock_guard relock(g_mutex);
-        if (auto again = g_sessions.find(key_of(guid)); again != g_sessions.end()) {
-          again->second.display_name = names.front();
-        }
+      // Same stream GUID re-requested. Only hand back the existing monitor if
+      // it was actually built for this client and still exists: the tracked
+      // entry carries the mode, HDR depth and friendly name the OTHER client
+      // asked for, so reusing it across identities silently streams the wrong
+      // resolution/refresh/HDR state with nothing in the log to say why.
+      const std::string requested_uid = s_client_uid ? s_client_uid : "";
+      const bool same_client = it->second.client_uid == requested_uid;
+      const bool have_name = !it->second.display_name.empty();
+      bool still_present = false;
+      if (same_client && have_name) {
+        const auto present = luminal_display_names();
+        still_present = std::find(present.begin(), present.end(), it->second.display_name) != present.end();
       }
-      return result;
+
+      if (same_client && have_name && still_present) {
+        VirtualDisplayCreationResult result {};
+        result.reused_existing = true;
+        result.ready_since = std::chrono::steady_clock::now();
+        result.client_name = it->second.client_name;
+        // Use the display THIS session recorded, not names.front(): the latter
+        // is an arbitrary pick from every attached LuminalVGD adapter in
+        // EnumDisplayDevicesW order, which is only correct when exactly one
+        // virtual monitor exists.
+        const auto tracked_name = it->second.display_name;
+        lk.unlock();
+        result.display_name = tracked_name;
+        result.monitor_device_path = monitor_device_path_of(tracked_name);
+        result.device_id = resolveVirtualDisplayDeviceId(tracked_name);
+        BOOST_LOG(info) << "LuminalVGD: reusing existing monitor for the same client (session 0x"
+                        << std::hex << it->second.session_id << std::dec << ").";
+        return result;
+      }
+
+      // Identity mismatch or the monitor is gone. Drop the stale tracking and
+      // fall through to create a monitor at THIS client's mode. Never refuse:
+      // returning nullopt here would leave an exclusive-layout host with no
+      // output at all.
+      BOOST_LOG(warning) << "LuminalVGD: stream GUID collision on an existing monitor — tracked client_uid='"
+                         << it->second.client_uid << "' vs requested '" << requested_uid
+                         << "'" << (have_name ? "" : ", tracked display never surfaced")
+                         << ((same_client && have_name && !still_present) ? ", tracked display no longer present" : "")
+                         << ". Discarding the stale session and creating a monitor for this client.";
+      if (g_device) {
+        vgd_destroy_monitor(g_device, it->second.session_id);
+      }
+      g_sessions.erase(it);
     }
 
     VgdCreateRequest req {};
@@ -348,6 +381,7 @@ namespace VDISPLAY::vgd {
       s_client_name ? s_client_name : "",
       reply.ring_slots,
       {},
+      s_client_uid ? s_client_uid : "",
     };
     BOOST_LOG(info) << "LuminalVGD monitor created: session 0x" << std::hex << req.session_id
                     << " display 0x" << reply.display_id << std::dec << " connector "

--- a/src/platform/windows/virtual_display_vgd.cpp
+++ b/src/platform/windows/virtual_display_vgd.cpp
@@ -293,13 +293,16 @@ namespace VDISPLAY::vgd {
         // is an arbitrary pick from every attached LuminalVGD adapter in
         // EnumDisplayDevicesW order, which is only correct when exactly one
         // virtual monitor exists.
+        // Copy everything needed off the entry BEFORE unlocking: once the lock
+        // is dropped another thread may erase it, and `it` dangles.
         const auto tracked_name = it->second.display_name;
+        const auto tracked_session_id = it->second.session_id;
         lk.unlock();
         result.display_name = tracked_name;
         result.monitor_device_path = monitor_device_path_of(tracked_name);
         result.device_id = resolveVirtualDisplayDeviceId(tracked_name);
         BOOST_LOG(info) << "LuminalVGD: reusing existing monitor for the same client (session 0x"
-                        << std::hex << it->second.session_id << std::dec << ").";
+                        << std::hex << tracked_session_id << std::dec << ").";
         return result;
       }
 

--- a/src_assets/common/assets/web/Troubleshooting.vue
+++ b/src_assets/common/assets/web/Troubleshooting.vue
@@ -4,10 +4,33 @@
       {{ $t('troubleshooting.troubleshooting') }}
     </h1>
 
-    <!-- Persistent banner shown while the GPU/WDDM stack is mid-recovery
-         from a TDR. Driven by /api/health/tdr.recovery_recent. -->
+    <!-- Machine-wide display-stack failure. Outranks the TDR-recovery banner
+         below: recovery is transient and self-clearing, this is terminal and
+         needs a reboot. Driven by /api/health/tdr.stack_down. -->
     <n-alert
-      v-if="tdrRecoveryRecent"
+      v-if="tdrStackDown"
+      type="error"
+      :show-icon="true"
+      class="mb-3 rounded-xl"
+      :title="
+        translate('troubleshooting.tdr_stack_down_title', 'Display stack down — reboot required')
+      "
+    >
+      <p class="text-sm">
+        {{
+          translate(
+            'troubleshooting.tdr_stack_down_body',
+            "Windows' display API is unavailable for every program on this machine, so no display can be configured or captured. This happens when the graphics driver fails to recover from a GPU reset. Nothing LuminalShine (or any other application) can do will clear it — restart the host machine. Streaming will keep being refused until then.",
+          )
+        }}
+      </p>
+    </n-alert>
+
+    <!-- Persistent banner shown while the GPU/WDDM stack is mid-recovery
+         from a TDR. Driven by /api/health/tdr.recovery_recent. Suppressed
+         while the stack is confirmed down: the banner above supersedes it. -->
+    <n-alert
+      v-if="tdrRecoveryRecent && !tdrStackDown"
       type="warning"
       :show-icon="true"
       class="mb-3 rounded-xl"

--- a/tools/display_settings_helper.cpp
+++ b/tools/display_settings_helper.cpp
@@ -5027,7 +5027,36 @@ namespace {
       const bool task_created = create_restore_scheduled_task();
       BOOST_LOG(info) << "Scheduled task creation result: " << (task_created ? "SUCCESS" : "FAILED");
 
-      if (!state.controller.apply(cfg, sunshine_topology)) {
+      // Under exclusive layout the host sends a single-group topology holding
+      // exactly the device being configured (display_helper_request_helpers.cpp
+      // builds it that way, and the exclusive path never carries a topology
+      // snapshot). computeNewTopology(EnsureOnlyDisplay, <named device>) then
+      // returns that same single group, so applySettings already deactivates the
+      // physical displays on its own. Pre-setting it first only overwrites
+      // libdisplaydevice's record of the pre-change topology -- making the
+      // exclusive topology its own revert target and leaving topology_prep_guard
+      // with nothing meaningful to roll back to if the apply fails partway.
+      //
+      // All three conjuncts are load-bearing. The layout string keeps this out of
+      // extended, where the host's merged topology IS the only thing that
+      // re-establishes the physical arrangement; EnsureOnlyDisplay corroborates
+      // the layout against the config actually being applied; and a non-empty
+      // device id matters because computeNewTopology falls back to the joined
+      // PRIMARY group when the id is empty, where the pre-set is genuinely
+      // load-bearing. The soft test above deliberately keeps sunshine_topology:
+      // dropping it there would run validate_topology_with_os and could skip the
+      // apply entirely, which is a refusal, not a fix.
+      auto pre_apply_topology = sunshine_topology;
+      if (requested_virtual_layout && *requested_virtual_layout == "exclusive" &&
+          cfg.m_device_prep == display_device::SingleDisplayConfiguration::DevicePreparation::EnsureOnlyDisplay &&
+          !cfg.m_device_id.empty()) {
+        BOOST_LOG(info) << "Display helper: exclusive layout targeting " << cfg.m_device_id
+                        << "; skipping the redundant pre-apply setTopology so the real pre-change "
+                           "topology is recorded as the revert target.";
+        pre_apply_topology.reset();
+      }
+
+      if (!state.controller.apply(cfg, pre_apply_topology)) {
         error_msg = "Helper failed to apply requested display configuration";
         return false;
       }

--- a/tools/display_settings_helper.cpp
+++ b/tools/display_settings_helper.cpp
@@ -4717,6 +4717,30 @@ namespace {
     }
   }
 
+  /**
+   * @brief Startup check for a session snapshot, deleting it only when it is provably stale.
+   *
+   * Every rejection reason below is computed by comparing the snapshot against a
+   * live device enumeration, so a machine that cannot enumerate at all rejects
+   * every snapshot it owns. That is not a hypothetical: on 2026-07-29 at
+   * 20:22:25 QueryDisplayConfig began returning ERROR_NOT_SUPPORTED machine-wide,
+   * the loader logged "no valid devices available" at 20:22:28.074 because the
+   * enumeration was empty rather than because the devices were gone, and this
+   * function deleted display_session_current.json 3 ms later — before restore
+   * polling had started, so nothing was ever restored from it.
+   *
+   * Deleting is therefore gated on the display stack actually being readable.
+   * When it is not, the snapshot is preserved untouched and reported invalid for
+   * this attempt only: a later helper run re-evaluates it against a working
+   * enumeration. The probe cannot manufacture a false "alive" verdict — any
+   * machine with a display attached enumerates at least one device, active or
+   * inactive — and it only ever suppresses a delete, so it can neither refuse a
+   * session nor block a restore.
+   *
+   * @param state Helper state owning the display controller and the probe.
+   * @param path Snapshot file to validate.
+   * @return true only if the snapshot loaded and survived filtering.
+   */
   bool validate_session_snapshot(ServiceState &state, const std::filesystem::path &path) {
     std::error_code ec;
     if (!std::filesystem::exists(path, ec) || ec) {
@@ -4727,12 +4751,25 @@ namespace {
       if (!loaded->snapshot.m_topology.empty() && !loaded->snapshot.m_modes.empty()) {
         return true;
       }
-      BOOST_LOG(warning) << "Existing session snapshot collapsed after applying current exclusion/device filters; removing path="
+      BOOST_LOG(warning) << "Existing session snapshot collapsed after applying current exclusion/device filters: "
                          << path.string();
     } else {
-      BOOST_LOG(warning) << "Existing session snapshot is invalid or filtered out; removing path=" << path.string();
+      BOOST_LOG(warning) << "Existing session snapshot is invalid or filtered out: " << path.string();
     }
 
+    // Only a readable display stack can distinguish "these devices are gone"
+    // from "we cannot see any device right now".
+    if (state.probe_display_device_count() == 0) {
+      BOOST_LOG(warning) << "PRESERVING session snapshot '" << path.string()
+                         << "': display enumeration returned zero devices, so the rejection above cannot be"
+                            " trusted to mean the snapshot is stale. The display stack appears to be down"
+                            " machine-wide; this snapshot is the only record of the pre-session layout and"
+                            " will be re-evaluated once enumeration works again.";
+      return false;
+    }
+
+    BOOST_LOG(warning) << "Removing session snapshot '" << path.string()
+                       << "': rejected against a working display enumeration.";
     {
       std::error_code ec_rm;
       std::filesystem::remove(path, ec_rm);


### PR DESCRIPTION
Seven commits. The goal is the one stated for rc.3: `virtual_display_layout=exclusive` and `virtual_display_mode=per_client` working safely. Nothing here refuses a session or removes a capability.

Three of these items changed shape once checked against the actual crash-bundle logs rather than the plan they came from.

## Make per_client actually per-client

**Peer certificate bound to the connection, not the thread** (closes #68). `thread_local crypto::x509_t` sounds scoped, but the HTTPS server defaults to a one-thread pool and nothing raises it — so it was process-wide. Every handshake overwrote the single slot and every handler read whichever certificate handshaked most recently. Two paired clients streaming concurrently is enough to misfire, no attacker required, and under `per_client` the wrong `named_cert` then supplies display mode, layout and config overrides. It was also written *before* the paired-store check, so any peer completing a handshake with a self-signed cert left its identity behind.

The plan said this needed a vendored Simple-Web-Server patch. It did not — `Request::remote_endpoint()` is already public and the verify hook is declared by our own server class.

**`uniqueid` fallback removed.** Its comment claimed it preserved per-client settings; it never could, since a `named_cert` uuid is a 36-char UUID and no 16-hex-char uniqueid matches one. What it did was feed Moonlight's hardcoded `0123456789ABCDEF` — identical for every client, and client-controlled — into the virtual display identity hash. Unidentified sessions now degrade to shared allocation for that launch only, via a local; writing `virtual_display_mode_override` would have turned virtual displays on for `mode=disabled` users.

**Per-session stream GUID.** The fallback used `persistentVirtualDisplayUuid()`, which is *also* the encoder probe's GUID — so a client hitting it collided with the probe's tracked session, took the reuse branch, and was handed `names.front()`. The stream came up on the probe's 1080p60 SDR monitor: requested mode never reached the driver's EDID, no HDR, per-client settings lost, and the reuse branch logged nothing. The display *identity* stays derived from a stable source — randomising it churns connectors, which is what destroys Windows' per-monitor memory.

`webrtc_stream.cpp:335` is deliberately untouched: it's the shared-mode seed, not this fallback. Editing it would have broken shared mode.

**Exclusive apply.** The redundant pre-`setTopology` is skipped when layout is exclusive, `EnsureOnlyDisplay`, and the device id is non-empty. It overwrote libdisplaydevice's record of the pre-change topology, making the exclusive topology its own revert target and leaving `topology_prep_guard` a no-op — exactly the state a mid-apply failure lands in. Scoped in `handle_apply`, since `apply()` cannot see the layout.

## Stop destroying the evidence

**Snapshot deletion gated on the stack being readable.** `validate_session_snapshot` rejects a snapshot by comparing it to a live enumeration, then deletes it — so a machine that cannot enumerate deletes every snapshot it owns. From the 20:22 helper log:

```
20:22:28.068  Giving up after retries while querying display config.
20:22:28.074  Snapshot load rejected: no valid devices available
20:22:28.077  Existing session snapshot is invalid or filtered out; removing
```

Deleted 3 ms after an empty enumeration, at helper startup, before restore polling was armed. Nothing could be restored because nothing was left. (The plan named three different delete sites; all three are unreachable during a wedge.)

**Stack-down latch reachable from enumeration.** `tdr::mark_stack_down` had two routes in, both requiring something to be creating a D3D11 device — so a wedge with no stream running was invisible. Across all five rotated host log segments covering the 30-minute wedge (~84,800 lines, ~12,500 QDC give-up cycles), the host never latched once. `/api/health/tdr` reported healthy the whole time. A pre-existing check meant to catch this was dead because `enumAvailableDevices` returns an *engaged but empty* optional on failure, not `nullopt`.

Gated behind 20 consecutive empty enumerations **and** 30 s of continuous failure **and** `display_stack_confirmed_down()`'s two `ERROR_NOT_SUPPORTED` reads. `GEN_FAILURE`, `ACCESS_DENIED` and healthy-API-zero-paths all decline to latch. Self-clears via the existing 5 s recheck.

**Build identity on every log segment.** The startup banner was written once; rollover inherited nothing. The 20:22 incident is unattributable to a binary today because the storm recycled the segment holding it.

## Verification

- Adversarial review: 5 findings raised, 5 refuted with code-level reasoning. The one blocker (iterator UAF) was refuted because it had already been fixed in `b2c20c69` — found by self-review before the workflow ran.
- One refutation conceded a real interleave in the enumeration counter; fixed in `1c174877` so the documented AND-gate holds.
- 200/201 targeted tests pass; the failure is the pre-existing `LocaleConsistencyTest`.
- Web typecheck: 10 errors on base, 10 with the change — zero new.

## Not verified here

The C2 latch and the A4 gate only fire on a wedged machine, so neither is exercised by this build. Acceptance is 5 consecutive `exclusive` + `per_client` desktop sessions (both physical monitors return each time; `display_id` stable per client and different between clients; `0x4362d96b2d23ce5f` and the probe GUID never appear as a session monitor), then a 20-minute GTA V Enhanced run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)