### PR TITLE
Restore exclusive as the shipped virtual_display_layout default

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -728,10 +728,12 @@ namespace config {
     _CONVERT_LAYOUT_(extended_isolated);
     _CONVERT_LAYOUT_(extended_primary_isolated);
 #undef _CONVERT_LAYOUT_
-    // Unrecognised value falls back to the shipped default. It must not fall
-    // back to `exclusive`, which deactivates every physical monitor — a typo in
-    // this key should not be able to leave the machine with the virtual display
-    // as its only output.
+    // Deliberately NOT the shipped default (which is `exclusive`). This is the
+    // typo path: an unrecognised value means the user's intent is unknown, and
+    // `exclusive` deactivates every physical monitor. Choosing it here would let
+    // a misspelling leave the machine with the virtual display as its only
+    // output. Asking for exclusive explicitly is a decision; misspelling it is
+    // not, so the two cases resolve differently on purpose.
     return video_t::virtual_display_layout_e::extended;
   }
 
@@ -796,7 +798,7 @@ namespace config {
     {},  // output_name
 
     video_t::virtual_display_mode_e::per_client,  // virtual_display_mode
-    video_t::virtual_display_layout_e::extended,  // virtual_display_layout
+    video_t::virtual_display_layout_e::exclusive,  // virtual_display_layout
     "auto",  // virtual_display_backend
     800,  // vgd_hdr_peak_nits
 


### PR DESCRIPTION
Owner decision: ship `exclusive` again. `virtual_display_mode` was already `per_client` and is unchanged.

rc.2 moved the default to `extended` on the reasoning that a default must never leave a machine with no output. That reasoning still holds for the *typo* path, which is why it is left alone (see below) — but `exclusive` is the configuration this project is built around, it is what the owner's machine runs explicitly, and per-client display allocation only means anything when the virtual display is the output.

**This also fixes a code/docs disagreement.** `docs/configuration.md` has said `exclusive` throughout; only the code moved in rc.2, so the two have disagreed since then. They now agree again — which is why the config-consistency suite passes rather than needing a doc edit.

**The typo path deliberately still resolves to `extended`.** An unrecognised value means the user's intent is unknown, and resolving that to `exclusive` would let a misspelling deactivate every physical monitor. Asking for exclusive is a decision; misspelling it is not. The comment there previously claimed it returned "the shipped default" — no longer true, so it now states the real reason.

Config consistency suite green (183/184; the one failure is the pre-existing `LocaleConsistencyTest` case, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)