### PR TITLE
Report the display stack's degraded state, not just its death

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -138,6 +138,27 @@ namespace platf::dxgi {
    */
   bool display_stack_confirmed_down(LONG *error_out, UINT32 *path_count_out) noexcept;
 
+  /**
+   * @brief The state between healthy and confirmed-down: the API answers, but nothing is attached.
+   *
+   * QueryDisplayConfig returning ERROR_SUCCESS with zero paths is invisible to
+   * both display_config_api_healthy (false) and display_stack_confirmed_down
+   * (needs ERROR_NOT_SUPPORTED). On 2026-07-30 that state held for 7.9 s
+   * between the virtual display being parked and the display API dying — the
+   * whole window in which recovery was still possible.
+   *
+   * OBSERVATIONAL ONLY. A true result must never reach tdr::mark_stack_down or
+   * tdr::mark_event: a clean exclusive-layout teardown legitimately produces
+   * zero active paths for 2-4.5 s, and latching on a zero path count is the
+   * PR #112 regression. Confirmed on two reads ~2 s apart; blocks that long
+   * when the first read carries the signature.
+   *
+   * @param error_out Receives the last raw Win32 status, or nullptr.
+   * @param path_count_out Receives the last path count, or nullptr.
+   * @return true only when the API answered with zero paths on both reads.
+   */
+  bool display_stack_degraded_zero_paths(LONG *error_out, UINT32 *path_count_out) noexcept;
+
   using factory1_t = util::safe_ptr<IDXGIFactory1, Release<IDXGIFactory1>>;
   using dxgi_t = util::safe_ptr<IDXGIDevice, Release<IDXGIDevice>>;
 

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -150,8 +150,14 @@ namespace platf::dxgi {
    * OBSERVATIONAL ONLY. A true result must never reach tdr::mark_stack_down or
    * tdr::mark_event: a clean exclusive-layout teardown legitimately produces
    * zero active paths for 2-4.5 s, and latching on a zero path count is the
-   * PR #112 regression. Confirmed on two reads ~2 s apart; blocks that long
-   * when the first read carries the signature.
+   * PR #112 regression.
+   *
+   * NON-BLOCKING. One QueryDisplayConfig read, no settle delay, unlike
+   * display_stack_confirmed_down. Callers poll enumeration under wall-clock
+   * budgets as short as 2 s, and overrunning one of those calls tdr::mark_event
+   * -> recovery_recent -> new sessions refused for 30 s. A stall here refuses
+   * sessions even when this returns false, so it must never sleep. Sustained
+   * evidence is the caller's job (a streak of empty enumerations over time).
    *
    * @param error_out Receives the last raw Win32 status, or nullptr.
    * @param path_count_out Receives the last path count, or nullptr.

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -483,6 +483,59 @@ namespace platf::dxgi {
     return reported_paths > 0;
   }
 
+  bool display_stack_degraded_zero_paths(LONG *error_out, UINT32 *path_count_out) noexcept {
+    // The third verdict, between healthy and confirmed-down.
+    //
+    // display_config_api_healthy() folds two very different states into one
+    // "false": the API refused to answer, and the API answered that nothing is
+    // attached. display_stack_confirmed_down() then only recognises the first,
+    // because it requires ERROR_NOT_SUPPORTED (:513). So a stack that answers
+    // ERROR_SUCCESS with zero paths is invisible to both.
+    //
+    // That is not hypothetical. On 2026-07-30 the LuminalVGD Tier-1 duck-out
+    // parked the only active display at 09:02:18.421; from 09:02:18.514 to
+    // 09:02:26.419 QueryDisplayConfig returned ERROR_SUCCESS with zero paths
+    // 48 times, and only at 09:02:26.569 did it degrade to ERROR_NOT_SUPPORTED
+    // and stay there. Those 7.9 seconds were the entire window in which DWM was
+    // still alive and recovery was still possible, and the host had the
+    // observation in hand and discarded it every time.
+    //
+    // This reports that window. It is deliberately OBSERVATIONAL ONLY: it must
+    // never feed tdr::mark_stack_down (which tells the user to reboot) and must
+    // never feed tdr::mark_event (which sets recovery_recent and briefly
+    // refuses sessions). Zero active paths is a legitimate transient — exclusive
+    // teardown leaves no active path for 2-4.5 s on a perfectly clean session
+    // end — and latching anything terminal on a zero count is the PR #112 bug.
+    // Two reads with a settle delay filter the shortest of those transients;
+    // callers must treat even a true result as "look here", not as a fault.
+    LONG status = ERROR_SUCCESS;
+    UINT32 qdc_paths = 0;
+    const bool healthy = display_config_api_healthy(&status, &qdc_paths);
+    if (error_out) {
+      *error_out = status;
+    }
+    if (path_count_out) {
+      *path_count_out = qdc_paths;
+    }
+    // Only the "answered, but nothing attached" shape qualifies. A refusal is
+    // display_stack_confirmed_down()'s business, not ours.
+    const auto answered_empty = [](LONG s, UINT32 paths) {
+      return (s == ERROR_SUCCESS) && paths == 0;
+    };
+    if (healthy || !answered_empty(status, qdc_paths)) {
+      return false;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+    const bool still_healthy = display_config_api_healthy(&status, &qdc_paths);
+    if (error_out) {
+      *error_out = status;
+    }
+    if (path_count_out) {
+      *path_count_out = qdc_paths;
+    }
+    return !still_healthy && answered_empty(status, qdc_paths);
+  }
+
   bool display_stack_confirmed_down(LONG *error_out, UINT32 *path_count_out) noexcept {
     // Gate for the TERMINAL tdr::mark_stack_down verdict. A single
     // unhealthy read is NOT enough evidence to tell the user to reboot:

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -519,21 +519,21 @@ namespace platf::dxgi {
     }
     // Only the "answered, but nothing attached" shape qualifies. A refusal is
     // display_stack_confirmed_down()'s business, not ours.
-    const auto answered_empty = [](LONG s, UINT32 paths) {
-      return (s == ERROR_SUCCESS) && paths == 0;
-    };
-    if (healthy || !answered_empty(status, qdc_paths)) {
-      return false;
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
-    const bool still_healthy = display_config_api_healthy(&status, &qdc_paths);
-    if (error_out) {
-      *error_out = status;
-    }
-    if (path_count_out) {
-      *path_count_out = qdc_paths;
-    }
-    return !still_healthy && answered_empty(status, qdc_paths);
+    //
+    // NON-BLOCKING BY CONSTRUCTION -- one read, no settle delay. This must never
+    // acquire the 2 s confirmation that display_stack_confirmed_down uses.
+    // enumerate_devices is polled by wait_for_virtual_display_ready under a hard
+    // 2 s wall-clock budget (virtual_display.cpp), and a 2 s stall inside the
+    // enumeration blows that budget, which calls tdr::mark_event, which sets
+    // recovery_recent, which refuses EVERY new session for 30 s -- on a machine
+    // whose display stack is perfectly healthy. The sleep alone is enough to do
+    // that; the verdict never has to be true. So there is no sleep.
+    //
+    // The temporal evidence comes from the caller instead: the enumeration hook
+    // only asks after a streak of consecutive empty enumerations, which is a
+    // sustained observation already spread over real time, and a strictly better
+    // one than a single in-line 2 s window.
+    return !healthy && status == ERROR_SUCCESS && qdc_paths == 0;
   }
 
   bool display_stack_confirmed_down(LONG *error_out, UINT32 *path_count_out) noexcept {

--- a/src/platform/windows/display_helper_integration.cpp
+++ b/src/platform/windows/display_helper_integration.cpp
@@ -1721,8 +1721,8 @@ namespace display_helper_integration {
           UINT32 deg_paths = 0;
           if (platf::dxgi::display_stack_degraded_zero_paths(&deg_status, &deg_paths)) {
             BOOST_LOG(warning) << "DISPLAY STACK DEGRADED: the display API is answering normally but reports ZERO "
-                                  "active paths, confirmed twice over ~2s, after "
-                               << streak << " empty enumerations. Nothing is attached to compose onto. If a virtual "
+                                  "active paths, after "
+                               << streak << " consecutive empty enumerations. Nothing is attached to compose onto. If a virtual "
                                   "display should be active this is the window in which recovery can still succeed -- "
                                   "the API stops answering entirely a few seconds later. This is a report, not a "
                                   "verdict: a clean exclusive-layout teardown also passes through this state.";

--- a/src/platform/windows/display_helper_integration.cpp
+++ b/src/platform/windows/display_helper_integration.cpp
@@ -1646,6 +1646,13 @@ namespace display_helper_integration {
     constexpr std::int64_t kMinFailingMsBeforeProbe = 30'000;
     constexpr std::int64_t kMinMsBetweenStackProbes = 60'000;
 
+    /// Degraded ("API answers, zero paths") is reported far sooner than the
+    /// terminal verdict, because it is the state recovery can still act in.
+    constexpr std::uint64_t kEmptyEnumerationsBeforeDegradedProbe = 5;
+    constexpr std::int64_t kMinMsBetweenDegradedProbes = 30'000;
+    /// steady_clock ms of the last degraded probe.
+    std::atomic<std::int64_t> g_last_degraded_probe_ms {0};
+
     std::int64_t steady_ms_now() {
       return std::chrono::duration_cast<std::chrono::milliseconds>(
                std::chrono::steady_clock::now().time_since_epoch()
@@ -1696,12 +1703,36 @@ namespace display_helper_integration {
         failing_since = g_enumeration_failing_since_ms;
       }
 
+      if (tdr::stack_down()) {
+        return;  // already latched; nothing to add
+      }
+
+      // Degraded check first: it fires ~8 s before the terminal one and is the
+      // only signal available while recovery can still work. Purely a report --
+      // it must not reach mark_stack_down (tells the user to reboot) or
+      // mark_event (sets recovery_recent, which briefly refuses sessions),
+      // because a clean exclusive teardown legitimately has zero active paths
+      // for 2-4.5 s and would otherwise refuse the next session.
+      if (streak >= kEmptyEnumerationsBeforeDegradedProbe && streak < kEmptyEnumerationsBeforeProbe) {
+        auto last_degraded = g_last_degraded_probe_ms.load(std::memory_order_acquire);
+        if ((last_degraded == 0 || (now_ms - last_degraded) >= kMinMsBetweenDegradedProbes) &&
+            g_last_degraded_probe_ms.compare_exchange_strong(last_degraded, now_ms, std::memory_order_acq_rel)) {
+          LONG deg_status = ERROR_SUCCESS;
+          UINT32 deg_paths = 0;
+          if (platf::dxgi::display_stack_degraded_zero_paths(&deg_status, &deg_paths)) {
+            BOOST_LOG(warning) << "DISPLAY STACK DEGRADED: the display API is answering normally but reports ZERO "
+                                  "active paths, confirmed twice over ~2s, after "
+                               << streak << " empty enumerations. Nothing is attached to compose onto. If a virtual "
+                                  "display should be active this is the window in which recovery can still succeed -- "
+                                  "the API stops answering entirely a few seconds later. This is a report, not a "
+                                  "verdict: a clean exclusive-layout teardown also passes through this state.";
+          }
+        }
+      }
+
       if (streak < kEmptyEnumerationsBeforeProbe ||
           (now_ms - failing_since) < kMinFailingMsBeforeProbe) {
         return;
-      }
-      if (tdr::stack_down()) {
-        return;  // already latched; nothing to add
       }
 
       auto last_probe = g_last_stack_probe_ms.load(std::memory_order_acquire);


### PR DESCRIPTION
Closes the 7.9-second window in which the 2026-07-30 wedge was still recoverable and the host had the evidence but no name for it.

## The gap

`QueryDisplayConfig` answering `ERROR_SUCCESS` with **zero active paths** was invisible to both classifiers. `display_config_api_healthy()` returns false for it — correctly — but folds it together with "the API refused to answer". `display_stack_confirmed_down()` then only recognises the refusal, because it requires `ERROR_NOT_SUPPORTED`.

From the incident log:

```
09:02:18.421  LuminalVGD Tier-1 duck-out parks the only active display
09:02:18.514  QueryDisplayConfig: ERROR_SUCCESS, 0 paths   (x48, 7.9 s)
09:02:26.569  QueryDisplayConfig: ERROR_NOT_SUPPORTED, permanently
09:02:26.588  GTA V dies
09:02:50.604  the terminal verdict finally latches
```

Those 7.9 seconds were the entire window in which DWM was still alive and recovery was still possible. The host made the observation 48 times and discarded it every time. By the time anything noticed, the display API was gone and stayed gone across a DWM recycle and a service restart; only a power cycle cleared it.

`display_stack_degraded_zero_paths()` names that state, and the enumeration hook reports it after **five** empty enumerations instead of the twenty-plus-thirty-seconds the terminal verdict needs.

## It is observational, and that is load-bearing

It must never reach `mark_stack_down` (tells the user to reboot) or `mark_event` (sets `recovery_recent`, which refuses new sessions for 30 s). A clean exclusive-layout teardown legitimately produces zero active paths for 2–4.5 s, so wiring this into either would refuse the session after every normal exclusive stream. Latching on a zero path count is the PR #112 regression. The log line says so itself so the next reader doesn't mistake a teardown for a fault. The terminal gate is untouched.

## Second commit: the probe must not sleep

The adversarial review found the two-read confirmation I first wrote was itself a session-refusal bug, and that **the sleep alone was sufficient — the verdict never had to be true**:

```
probe sleeps 2000 ms on the CALLING thread
  → note_enumeration_result runs inline inside enumerate_devices
  → wait_for_virtual_display_ready polls it under a hard 2 s budget
  → budget blown → tdr::mark_event(virtual_display_enumerate)
  → recovery_recent() true for 30 s
  → every session start refused, on a healthy machine
  → and the freshly created virtual display is destroyed
```

The settle delay was redundant anyway: the caller only asks after a streak of consecutive empty enumerations, which is already sustained evidence spread over real time. The probe is now a single read. `display_stack_confirmed_down` keeps its 2 s confirmation — it is only called from paths already failing, not from inside an enumeration under someone else's deadline.

## Scope

This closes the observation gap. It does **not** stop the wedge — the kernel live dumps put the thing that actually latches (`QueryDisplayConfig` going permanently `ERROR_NOT_SUPPORTED` across a DWM recycle) inside `dxgkrnl`/`win32k`.

195/196 targeted tests pass; the one failure is the pre-existing `LocaleConsistencyTest` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)