### PR TITLE
Advertise the base refresh rate on every session, not just flagged ones

### DIFF
--- a/src/platform/windows/virtual_display_vgd.cpp
+++ b/src/platform/windows/virtual_display_vgd.cpp
@@ -358,9 +358,30 @@ namespace VDISPLAY::vgd {
     // Callers pass millihertz (nvhttp/webrtc normalize Hz → mHz before the
     // call); the spec below must NOT rescale it again.
     req.modes[0] = VgdModeSpec {width, height, fps_millihz};
-    if (framegen_refresh_active && base_fps_millihz != 0 && base_fps_millihz != fps_millihz) {
-      // Advertise the base rate too so the OS can drop out of the
-      // frame-generation-doubled mode without a monitor cycle.
+    // Advertise the base rate alongside the requested one whenever they differ,
+    // NOT only when a per-app frame-generation flag happened to be set.
+    //
+    // A monitor's mode list is fixed for its lifetime: IddCx has no DDI, in 1.10
+    // or 1.11, that replaces a monitor description on an arrived monitor, and
+    // the only way to change the advertised set is destroy + recreate — the
+    // monitor cycle that broadcasts DBT_DEVNODES_CHANGED and kills GTA V
+    // Enhanced. So whatever is advertised here is all this session will ever
+    // have. Anything not in this list cannot be reached later at any price.
+    //
+    // That makes the guard actively harmful in the case that matters. A client
+    // streams "Desktop" — which has no per-app flag — and then launches a
+    // frame-generation game inside the session. With the guard, mode_count is 1
+    // and the doubled rate was never advertised, so it can never be selected.
+    // Worse, the failure is silent: the host's apply path already requests 2x
+    // base on every session (virtual_double_refresh defaults true and
+    // virtual_display_mode defaults per_client), and libdisplaydevice snaps an
+    // unadvertised request to the nearest supported mode and reports success.
+    // The log says the refresh changed; nothing changed.
+    //
+    // Advertising the superset up front costs two mode-list entries and removes
+    // both problems, with no display event at game launch because nothing has to
+    // change. A virtual display idling at the higher rate is free.
+    if (base_fps_millihz != 0 && base_fps_millihz != fps_millihz) {
       req.modes[1] = VgdModeSpec {width, height, base_fps_millihz};
       req.mode_count = 2;
     }


### PR DESCRIPTION
Answers *"I launch Desktop through Moonlight, then open GTA V Enhanced with frame gen — how does the refresh rate adapt without crashing, and why should I have to configure the Desktop app?"*

You shouldn't, and now you don't.

## Why this has to happen at creation

A monitor's mode list is fixed for its lifetime. IddCx has no DDI, in **1.10 or 1.11**, that replaces a monitor description on an arrived monitor; the only way to change the advertised set is destroy + recreate — the monitor cycle that broadcasts `DBT_DEVNODES_CHANGED` and kills GTA V Enhanced. Whatever is advertised at `CREATE_MONITOR` is all that session will ever have, and anything absent cannot be reached later at any price.

The old guard tied the second mode to a per-app frame-generation flag, which fails in exactly the case that matters: a client streams **Desktop** — which has no per-app flag — then launches a frame-generation game *inside* the session. `mode_count` was 1, the doubled rate was never advertised, and it was unreachable thereafter.

## It was also silently defeating a setting you already have on

The apply path already requests **2× base on every session** — `virtual_double_refresh` defaults true and `virtual_display_mode` defaults `per_client` (`display_helper_request_helpers.cpp:265-270`) — while the create path advertised one mode. So the host has been asking Windows for 120 Hz on a 60 Hz-only monitor.

The failure is silent, not loud: `resolveRequestedModes` snaps an unadvertised request to the nearest supported mode and returns success with `requires_apply=false`. The log records a refresh change that never happened.

The equivalent doubling *does* exist on the create side, in `apply_refresh_overrides` — but it is only reachable from the dead SudoVDA branch, since `createVirtualDisplay` returns to the VGD backend first.

## The change

Drop the `framegen_refresh_active &&` guard at `virtual_display_vgd.cpp:361`, keeping the `base != doubled` check. Every session now advertises both rates.

Cost: two mode-list entries. `MAX_MODES_PER_MONITOR = 4`, `caps::MULTI_MODE` is already advertised, and `Mode::validate_list` already handles multi-entry lists with duplicate rejection — **no driver change, no signing round**.

When the game launches, **no display event occurs at all**: no arrival, no departure, no mode change, no `WM_DISPLAYCHANGE`, no `DBT_DEVNODES_CHANGED`. The rate is already there. Risk of killing GTA V: none, because nothing happens.

The stream is unaffected — capture cadence and every encoder parameter derive from the client-negotiated fps, never from display refresh (`display_base.cpp:932`; on the VGD ring path `display_refresh_rate` is never even assigned).

## Note for review

`framegen_refresh_active` (parameter at `:250`) is now unused in this function. Left in place deliberately: removing it touches the nvhttp and webrtc call sites, and it is the natural gate for the target-mode subset layer that LuminalVGD build 17's `UPDATE_MODES` enables — that layer gates *within* this superset, which is precisely why advertising the superset is its precondition rather than its alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)