### PR TITLE
CI: package LuminalVGD build 17, not build 15

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -341,7 +341,7 @@ jobs:
           # (github.com/NortheBridge/LuminalVGD releases). Bump on driver
           # releases. SudoVDA is gone by decision (2026-07-23) — the MSI's
           # drivers\luminalvgd\install.ps1 also removes it wherever found.
-          LUMINALVGD_VERSION: 'v0.1.0-alpha.5'
+          LUMINALVGD_VERSION: 'v0.1.0-alpha.6'
         run: |
           $ErrorActionPreference = 'Stop'
           $packageDir = Join-Path $PWD 'src_assets/windows/drivers/luminalvgd/driver-package'


### PR DESCRIPTION
**rc.5 shipped the wrong driver.** `ci-windows.yml` pins the LuminalVGD release whose signed package is unpacked into the MSI, and that pin was still `v0.1.0-alpha.5` — DriverVer `0.1.0.15`.

So 26.08.0-rc.5 paired a host built against proto 0.5 with a build-15 driver. Installing it left `0.1.0.15` in place; build 16's device-duck and build 17's dynamic modes were absent entirely.

Confirmed on a real install before touching anything — the MSI's own `drivers/luminalvgd/driver-package/luminalvgd.inf` read `DriverVer = 07/28/2026,0.1.0.15`. The packaging did exactly what it was told; it was told the wrong version.

Two fixes:

1. Pin bumped to `v0.1.0-alpha.6` (DriverVer `0.1.0.17`, proto 0.5). The comment directly above it already said *"Bump on driver release"*.
2. The [alpha.6 release](https://github.com/NortheBridge/LuminalVGD/releases/tag/v0.1.0-alpha.6) assets were republished in the shape this step consumes — `LuminalVGD-<version>-x64.zip` containing `driver-package/` plus install scripts and licences, with `SHA256SUMS` alongside, matching alpha.5. They had been uploaded as three loose files, so the fetch would have 404'd even with the pin corrected.

rc.5's draft must be re-cut after this lands; its installer cannot be salvaged by editing the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)