### PR TITLE
Resolve an inactive VGD monitor by identity, not by client label

### DIFF
--- a/src/platform/windows/virtual_display.cpp
+++ b/src/platform/windows/virtual_display.cpp
@@ -1011,6 +1011,7 @@ namespace VDISPLAY {
       return true;
     }
 
+
     std::string normalize_display_name(std::string name) {
       auto trim = [](std::string &inout) {
         size_t start = 0;
@@ -4341,6 +4342,40 @@ namespace VDISPLAY {
     return std::nullopt;
   }
 
+  std::optional<std::string> resolveVirtualDisplayDeviceIdExact(const std::wstring &display_name) {
+    if (display_name.empty()) {
+      return std::nullopt;
+    }
+
+    auto devices = platf::display_helper::Coordinator::instance().enumerate_devices(display_device::DeviceEnumerationDetail::Minimal);
+    if (!devices) {
+      return std::nullopt;
+    }
+
+    const auto target = normalize_display_name(platf::to_utf8(display_name));
+    if (target.empty()) {
+      return std::nullopt;
+    }
+
+    for (const auto &device : *devices) {
+      if (!is_virtual_display_device(device) || device.m_device_id.empty()) {
+        continue;
+      }
+      const auto device_name = normalize_display_name(device.m_display_name);
+      if (!device_name.empty() && device_name == target) {
+        return device.m_device_id;
+      }
+    }
+    return std::nullopt;
+  }
+
+  bool is_truncated_client_label(const std::string &monitor_name, const std::string &client_name) {
+    if (monitor_name.size() != kEdidProductNameCapacity || client_name.size() <= kEdidProductNameCapacity) {
+      return false;
+    }
+    return equals_ci(monitor_name, client_name.substr(0, kEdidProductNameCapacity));
+  }
+
   std::optional<std::string> resolveVirtualDisplayDeviceIdForClient(const std::string &client_name) {
     if (client_name.empty()) {
       return std::nullopt;
@@ -4353,20 +4388,34 @@ namespace VDISPLAY {
 
     std::optional<std::string> active_match;
     std::optional<std::string> any_match;
+    // Truncated matches are kept apart from exact ones and only used when
+    // nothing matched exactly — a prefix is weaker evidence, so it must
+    // never outrank a full-length agreement.
+    std::optional<std::string> truncated_active;
+    std::optional<std::string> truncated_any;
+    size_t truncated_count = 0;
     for (const auto &device : *devices) {
-      if (!is_virtual_display_device(device) || device.m_device_id.empty()) {
+      if (!is_virtual_display_device(device) || device.m_device_id.empty() || device.m_friendly_name.empty()) {
         continue;
       }
-      if (device.m_friendly_name.empty() || !equals_ci(device.m_friendly_name, client_name)) {
+      const bool active = device.m_info.has_value();
+      if (equals_ci(device.m_friendly_name, client_name)) {
+        if (!any_match) {
+          any_match = device.m_device_id;
+        }
+        if (active && !active_match) {
+          active_match = device.m_device_id;
+        }
         continue;
       }
-
-      if (!any_match) {
-        any_match = device.m_device_id;
-      }
-      if (device.m_info) {
-        active_match = device.m_device_id;
-        break;
+      if (is_truncated_client_label(device.m_friendly_name, client_name)) {
+        ++truncated_count;
+        if (!truncated_any) {
+          truncated_any = device.m_device_id;
+        }
+        if (active && !truncated_active) {
+          truncated_active = device.m_device_id;
+        }
       }
     }
 
@@ -4376,7 +4425,51 @@ namespace VDISPLAY {
     if (any_match) {
       return any_match;
     }
+    // A truncated label only identifies a monitor when exactly one carries
+    // it. Two clients sharing their first 13 characters are genuinely
+    // indistinguishable here, and handing back the wrong client's display
+    // is worse than reporting nothing and letting the caller's other arms
+    // (identity-based resolution) decide.
+    if (truncated_count == 1) {
+      return truncated_active ? truncated_active : truncated_any;
+    }
+    if (truncated_count > 1) {
+      BOOST_LOG(warning) << "Virtual display: " << truncated_count << " monitors share the first "
+                         << kEdidProductNameCapacity << " characters of client name '" << client_name
+                         << "'; refusing to guess which one is theirs.";
+    }
     return std::nullopt;
+  }
+
+  std::optional<std::string> resolveVirtualDisplayDeviceIdForEdidSerial(uint32_t edid_serial) {
+    // 0 is what a monitor with no serial descriptor parses to, so it
+    // identifies nothing and must never match.
+    if (edid_serial == 0) {
+      return std::nullopt;
+    }
+
+    auto devices = platf::display_helper::Coordinator::instance().enumerate_devices(display_device::DeviceEnumerationDetail::Minimal);
+    if (!devices) {
+      return std::nullopt;
+    }
+
+    std::optional<std::string> any_match;
+    for (const auto &device : *devices) {
+      if (!is_virtual_display_device(device) || device.m_device_id.empty()) {
+        continue;
+      }
+      if (!device.m_edid || device.m_edid->m_serial_number != edid_serial) {
+        continue;
+      }
+      if (device.m_info) {
+        // Already attached to the desktop — the best answer available.
+        return device.m_device_id;
+      }
+      if (!any_match) {
+        any_match = device.m_device_id;
+      }
+    }
+    return any_match;
   }
 
   // Track consecutive enumerate_devices failures so we can detect a stuck

--- a/src/platform/windows/virtual_display.h
+++ b/src/platform/windows/virtual_display.h
@@ -137,6 +137,55 @@ namespace VDISPLAY {
 
   std::optional<std::string> resolveVirtualDisplayDeviceId(const std::wstring &display_name);
   std::optional<std::string> resolveVirtualDisplayDeviceIdForClient(const std::string &client_name);
+
+  /// Strict name → device-id lookup: the device id of the virtual display
+  /// whose GDI name really is `display_name`, or nullopt.
+  ///
+  /// `resolveVirtualDisplayDeviceId` above is deliberately lenient — when
+  /// no name matches it falls back to "any active virtual display", then
+  /// "any virtual display", so it essentially never returns nullopt while
+  /// one exists. That is right for its callers, which pass a name they
+  /// just read out of the attached-display list and only want a usable id.
+  /// It is wrong wherever the answer is used as an IDENTITY, because an
+  /// inactive display enumerates with an EMPTY GDI name and can therefore
+  /// never match by name — so the lenient resolver silently hands back a
+  /// different display's id and the caller pairs it with the wrong session.
+  std::optional<std::string> resolveVirtualDisplayDeviceIdExact(const std::wstring &display_name);
+
+  /// Bytes an EDID display-product-name descriptor can carry. Fixed by the
+  /// EDID structure, not by any driver choice.
+  inline constexpr size_t kEdidProductNameCapacity = 13;
+
+  /// True when `monitor_name` is what Windows reports for a client that
+  /// called itself `client_name` but whose label did not fit the EDID.
+  ///
+  /// A virtual-display driver publishes the client label through the EDID
+  /// product-name descriptor, so anything past 13 characters is dropped
+  /// before Windows ever sees it. Comparing the full label for equality
+  /// therefore excluded every client with a longer name — 'LG C2 83" OLED
+  /// webOS' arrives as 'LG C2 83" OLE', 'XBOXONE Series X' as 'XBOXONE
+  /// Serie' — while short ones like 'macOS' matched, so the resolver
+  /// looked like it worked. Exposed for the regression test that pins it.
+  ///
+  /// Only a SATURATED monitor name may match this way: a shorter one was
+  /// published in full, and a mismatch there is a genuine mismatch.
+  bool is_truncated_client_label(const std::string &monitor_name, const std::string &client_name);
+
+  /// Resolve a virtual display by the EDID serial its driver stamped for a
+  /// given display identity — exact, and independent of what the client
+  /// called itself.
+  ///
+  /// This exists because the client-name resolver above cannot see most
+  /// clients at all. EDID's display-product-name descriptor holds 13 bytes,
+  /// so a longer client label reaches Windows truncated ('LG C2 83" OLED
+  /// webOS' arrives as 'LG C2 83" OLE') and never compares equal to the
+  /// label the caller is holding. The serial has no such ceiling.
+  ///
+  /// Like the client-name resolver, this sees INACTIVE monitors: a virtual
+  /// display arrives detached and is only attached when the display helper
+  /// applies the topology, so resolving it before that point is the whole
+  /// purpose of both functions.
+  std::optional<std::string> resolveVirtualDisplayDeviceIdForEdidSerial(uint32_t edid_serial);
   std::optional<std::string> resolveActiveVirtualDisplayDeviceId(
     const std::string &preferred_output_identifier,
     const std::string &client_name

--- a/src/platform/windows/virtual_display_vgd.cpp
+++ b/src/platform/windows/virtual_display_vgd.cpp
@@ -37,6 +37,12 @@ namespace VDISPLAY::vgd {
       /// branch can prove the re-requested stream GUID belongs to the same
       /// client before handing back a monitor built to someone else's mode.
       std::string client_uid;
+      /// libdisplaydevice device id, recorded whenever the monitor was
+      /// resolved while still INACTIVE (so `display_name` is necessarily
+      /// empty). It is the only handle on such a session until the display
+      /// helper attaches it, and `ring_target_for_display` needs one to
+      /// tell two pre-APPLY sessions apart.
+      std::string device_id;
     };
 
     struct GuidKey {
@@ -81,6 +87,20 @@ namespace VDISPLAY::vgd {
       const uint64_t h = client_uid ? fnv1a64(client_uid, std::strlen(client_uid)) : 0;
       uint64_t id = (h & 0x0FFF'FFFF'FFFF'FFFFULL) | 0x4000'0000'0000'0000ULL;
       return id;
+    }
+
+    /// The EDID serial the driver stamps for a display identity.
+    ///
+    /// MUST stay in step with `luminal-vgd-core`'s
+    /// `identity::serial_from_display_id` (the 32-bit fold below); it is
+    /// duplicated rather than plumbed through the FFI because
+    /// `VgdCreateReply` carries no serial field and reply structs in this
+    /// proto can never grow. If the driver ever changes the derivation,
+    /// identity resolution silently degrades to the client-name arm — it
+    /// does not break, but the LuminalVGD backend loses its only
+    /// name-length-independent way to find an inactive monitor.
+    uint32_t edid_serial_for_display_id(uint64_t display_id) {
+      return static_cast<uint32_t>(display_id ^ (display_id >> 32));
     }
 
     uint64_t fresh_session_id(const GUID &guid) {
@@ -406,6 +426,7 @@ namespace VDISPLAY::vgd {
       reply.ring_slots,
       {},
       s_client_uid ? s_client_uid : "",
+      {},
     };
     BOOST_LOG(info) << "LuminalVGD monitor created: session 0x" << std::hex << req.session_id
                     << " display 0x" << reply.display_id << std::dec << " connector "
@@ -418,7 +439,10 @@ namespace VDISPLAY::vgd {
     result.reused_existing = false;
     result.ready_since = std::chrono::steady_clock::now();
     result.client_name = s_client_name ? std::optional<std::string> {s_client_name} : std::nullopt;
-    for (int attempt = 0; attempt < 50; ++attempt) {  // ≤5 s
+    // 50 passes, but NOT 5 s: each pass also runs two full display
+    // enumerations, so the measured wall clock is ~7 s. Keep the number
+    // quoted in the failure message below in step with that.
+    for (int attempt = 0; attempt < 50; ++attempt) {
       auto now = luminal_display_names();
       for (auto &name : now) {
         if (std::find(before.begin(), before.end(), name) == before.end()) {
@@ -440,14 +464,35 @@ namespace VDISPLAY::vgd {
       }
       // The monitor arrives inactive (it only attaches to the desktop once
       // the display helper applies the topology), so the attached-display
-      // poll above may never see it. The client-name resolver enumerates
+      // poll above may never see it. Both resolvers below enumerate
       // inactive devices too — a resolved device id is enough for the
       // topology layer to activate the display.
-      if (s_client_name) {
-        if (auto id = resolveVirtualDisplayDeviceIdForClient(s_client_name)) {
-          result.device_id = std::move(id);
-          return result;
+      //
+      // IDENTITY FIRST, LABEL SECOND. The driver stamps this monitor's
+      // EDID serial from the very display id we asked for, so the serial
+      // match is exact and says nothing about what the client called
+      // itself. The label arm cannot see any client whose name outgrows
+      // the 13-byte EDID product-name descriptor — which is most of them
+      // ('LG C2 83" OLED webOS', 'XBOXONE Series X') — so leaving it as
+      // the only fallback meant an arrived-but-inactive monitor was
+      // reported missing and then destroyed, on a loop, for those clients.
+      // reply.display_id, not req.display_id: the driver's answer is what
+      // it actually stamped the EDID from, and it is free to hand back an
+      // identity other than the one asked for.
+      auto resolved = resolveVirtualDisplayDeviceIdForEdidSerial(edid_serial_for_display_id(reply.display_id));
+      if (!resolved && s_client_name) {
+        resolved = resolveVirtualDisplayDeviceIdForClient(s_client_name);
+      }
+      if (resolved) {
+        result.device_id = resolved;
+        // Record it: the display has no GDI name yet (that arrives with
+        // the topology apply), so this id is the only thing that can tell
+        // this session apart from another pre-APPLY one later.
+        std::lock_guard relock(g_mutex);
+        if (auto it = g_sessions.find(key_of(guid)); it != g_sessions.end()) {
+          it->second.device_id = *resolved;
         }
+        return result;
       }
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
@@ -460,7 +505,7 @@ namespace VDISPLAY::vgd {
     // 2026-07-27 incident), and the driver's watchdog couldn't reap them
     // because our ping thread kept the leases fed. Destroy what we
     // created and report failure so the caller can fall back cleanly.
-    BOOST_LOG(error) << "LuminalVGD monitor created but no new display surfaced within 5 s; "
+    BOOST_LOG(error) << "LuminalVGD monitor created but no new display surfaced within ~7 s; "
                         "destroying the orphaned driver session (session 0x"
                      << std::hex << req.session_id << std::dec
                      << "). If this repeats, the Windows display stack is likely down — "
@@ -538,7 +583,7 @@ namespace VDISPLAY::vgd {
 
   std::optional<RingTargetInfo> ring_target_for_display(const std::string &display_name) {
     std::wstring wanted(display_name.begin(), display_name.end());
-    std::lock_guard lk(g_mutex);
+    std::unique_lock lk(g_mutex);
     if (g_sessions.empty()) {
       return std::nullopt;
     }
@@ -567,6 +612,16 @@ namespace VDISPLAY::vgd {
         return std::nullopt;
       }
       if (!wanted.empty() && s.display_name != wanted) {
+        // Silent until now, and indistinguishable in a log from "no
+        // session at all". Worth a line: during topology churn the caller
+        // can ask for a name the sole session does not (yet) own, and
+        // knowing WHICH name was asked for is the difference between a
+        // benign mid-modeset miss and a genuinely mistracked display.
+        // Narrowed the same way `wanted` was widened; GDI names are ASCII.
+        const std::string tracked(s.display_name.begin(), s.display_name.end());
+        BOOST_LOG(debug) << "LuminalVGD: sole session 0x" << std::hex << s.session_id << std::dec
+                         << " tracks display '" << tracked << "', not '" << display_name
+                         << "'; declining ring capture for it.";
         return std::nullopt;
       }
       return RingTargetInfo {s.session_id, s.ring_slots};
@@ -574,6 +629,53 @@ namespace VDISPLAY::vgd {
     for (const auto &[k, s] : g_sessions) {
       if (!s.display_name.empty() && s.display_name == wanted) {
         return RingTargetInfo {s.session_id, s.ring_slots};
+      }
+    }
+    // No name matched. A session whose monitor was resolved while still
+    // INACTIVE has no GDI name to match with — create()'s poll found it by
+    // identity, and the name only exists once the helper attaches it — so
+    // with two or more sessions the loop above can never match it and ring
+    // capture was refused for a display that is now perfectly usable.
+    // Map the requested GDI name back to its device id and match on that,
+    // then backfill the name so the cheap comparison works from here on.
+    const bool have_pre_apply_session = std::any_of(
+      g_sessions.begin(),
+      g_sessions.end(),
+      [](const auto &kv) {
+        return kv.second.display_name.empty() && !kv.second.device_id.empty();
+      }
+    );
+    if (!wanted.empty() && have_pre_apply_session) {
+      // Resolving a device id is a display-config query with its own
+      // internal retries — on a wedged stack it takes seconds. It must not
+      // run under g_mutex, which create/destroy/ping all need; that is the
+      // same "never hold a lock a teardown path needs across an OS call"
+      // rule the ring-lock convoy taught us. Drop it, query, retake, and
+      // re-derive everything from the map as it is afterwards.
+      //
+      // STRICT resolver, deliberately. `resolveVirtualDisplayDeviceId`
+      // falls back to "any active virtual display" and then "any virtual
+      // display", so it practically never reports nothing — and an
+      // INACTIVE display enumerates with an empty GDI name, so the name it
+      // is given here routinely matches nothing and the fallback fires.
+      // Pairing that arbitrary id with a session would adopt a display
+      // name onto the wrong session, hand a client another client's ring,
+      // and poison the tracked name permanently (nothing ever clears it,
+      // so that session would lose ring capture for good).
+      lk.unlock();
+      auto wanted_device_id = resolveVirtualDisplayDeviceIdExact(wanted);
+      lk.lock();
+      if (wanted_device_id) {
+        for (auto &[k, s] : g_sessions) {
+          if (!s.display_name.empty() || s.device_id.empty() || s.device_id != *wanted_device_id) {
+            continue;
+          }
+          s.display_name = wanted;
+          BOOST_LOG(info) << "LuminalVGD: adopted display '" << display_name << "' for session 0x"
+                          << std::hex << s.session_id << std::dec
+                          << " by device id (monitor activated after creation).";
+          return RingTargetInfo {s.session_id, s.ring_slots};
+        }
       }
     }
     BOOST_LOG(warning) << "LuminalVGD: no tracked session matches display '"

--- a/tests/unit/test_virtual_display_client_label.cpp
+++ b/tests/unit/test_virtual_display_client_label.cpp
@@ -1,0 +1,88 @@
+/**
+ * @file tests/unit/test_virtual_display_client_label.cpp
+ * @brief The EDID product-name ceiling, and why matching a client label
+ *        against a monitor name cannot be plain equality.
+ *
+ * A virtual-display driver can only publish a client's label through the
+ * EDID display-product-name descriptor, which holds 13 bytes. Anything
+ * longer reaches Windows truncated, so the host's "find the monitor this
+ * client's session created" resolver compared a 13-character monitor name
+ * against the full label and never matched. The failure was silent and
+ * length-dependent: 'macOS' (5) worked, so the resolver looked healthy,
+ * while 'LG C2 83" OLED webOS' (20) and 'XBOXONE Series X' (16) could
+ * never resolve — and for those clients an arrived-but-inactive monitor
+ * was reported missing and destroyed, on a loop.
+ *
+ * Pure predicate, no device I/O, so this behaves identically on CI and on
+ * driver dev boxes.
+ */
+#ifdef _WIN32
+
+  // standard includes
+  #include <string>
+
+  // lib includes
+  #include <gtest/gtest.h>
+
+  // local includes
+  #include "../tests_common.h"
+
+  #include "src/platform/windows/virtual_display.h"
+
+namespace {
+
+  // The three real client labels this box streams to, and what the driver
+  // can actually publish for each.
+  constexpr const char *kLgLabel = "LG C2 83\" OLED webOS";  // 20 chars
+  constexpr const char *kLgPublished = "LG C2 83\" OLE";  // 13 chars
+  constexpr const char *kXboxLabel = "XBOXONE Series X";  // 16 chars
+  constexpr const char *kXboxPublished = "XBOXONE Serie";  // 13 chars
+  constexpr const char *kMacLabel = "macOS";  // 5 chars, fits
+
+}  // namespace
+
+TEST(VirtualDisplayClientLabel, TruncatedLabelsMatchTheirClient) {
+  EXPECT_TRUE(VDISPLAY::is_truncated_client_label(kLgPublished, kLgLabel));
+  EXPECT_TRUE(VDISPLAY::is_truncated_client_label(kXboxPublished, kXboxLabel));
+}
+
+TEST(VirtualDisplayClientLabel, MatchIsCaseInsensitiveLikeTheExactComparison) {
+  EXPECT_TRUE(VDISPLAY::is_truncated_client_label("lg c2 83\" ole", kLgLabel));
+}
+
+TEST(VirtualDisplayClientLabel, LabelsThatFitAreNeverTreatedAsTruncated) {
+  // 'macOS' is published in full, so equality already decides it and a
+  // prefix match must not add a second, weaker answer.
+  EXPECT_FALSE(VDISPLAY::is_truncated_client_label(kMacLabel, kMacLabel));
+  // Exactly at the ceiling, published in full: still not a truncation.
+  EXPECT_FALSE(VDISPLAY::is_truncated_client_label("XBOXONE Serie", "XBOXONE Serie"));
+}
+
+TEST(VirtualDisplayClientLabel, OnlyASaturatedMonitorNameCanMatchAsAPrefix) {
+  // A short monitor name that happens to prefix a long client label was
+  // published in full and genuinely belongs to a different client.
+  EXPECT_FALSE(VDISPLAY::is_truncated_client_label("LG", kLgLabel));
+  EXPECT_FALSE(VDISPLAY::is_truncated_client_label("LG C2 83\" OL", kLgLabel));
+}
+
+TEST(VirtualDisplayClientLabel, DifferentClientsDoNotCrossMatch) {
+  EXPECT_FALSE(VDISPLAY::is_truncated_client_label(kXboxPublished, kLgLabel));
+  EXPECT_FALSE(VDISPLAY::is_truncated_client_label(kLgPublished, kXboxLabel));
+  EXPECT_FALSE(VDISPLAY::is_truncated_client_label(kLgPublished, kMacLabel));
+}
+
+TEST(VirtualDisplayClientLabel, EmptyInputsNeverMatch) {
+  EXPECT_FALSE(VDISPLAY::is_truncated_client_label("", kLgLabel));
+  EXPECT_FALSE(VDISPLAY::is_truncated_client_label(kLgPublished, ""));
+  EXPECT_FALSE(VDISPLAY::is_truncated_client_label("", ""));
+}
+
+TEST(VirtualDisplayClientLabel, CeilingMatchesTheEdidDescriptorSize) {
+  // If this ever changes, every truncated match silently stops working —
+  // the number is fixed by the EDID structure, not by a driver choice.
+  EXPECT_EQ(VDISPLAY::kEdidProductNameCapacity, 13u);
+  EXPECT_EQ(std::string(kLgPublished).size(), VDISPLAY::kEdidProductNameCapacity);
+  EXPECT_EQ(std::string(kXboxPublished).size(), VDISPLAY::kEdidProductNameCapacity);
+}
+
+#endif  // _WIN32


### PR DESCRIPTION
## The bug

An LG webOS client could never start a virtual-display session; a Mac always could.

The driver was blameless. ETW shows `IddCxMonitorArrival` returning `status=0` on all thirteen
attempts, with Windows soliciting `ParseDescription2` / `QueryTargetModes2` — it saw the monitor
and its modes — and then never committing a path. The monitor was present and enumerable, just
**inactive**, which is its normal state until the display helper applies the topology, and exactly
the case the create poll's second arm exists to cover.

That arm could not see it. A client label only reaches Windows through the EDID display-product-name
descriptor, which holds 13 bytes (`luminal-vgd-core` `edid.rs:201`, `take(13)`), while the host
compared the **full** label with `equals_ci`, which returns false on a length mismatch before looking
at a single character:

| client label | what Windows publishes | matched? |
| --- | --- | --- |
| `macOS` (5) | `macOS` | yes |
| `Steamdeck` (9) | `Steamdeck` | yes |
| `LG C2 83" OLED webOS` (20) | `LG C2 83" OLE` | **no** |
| `XBOXONE Series X` (16) | `XBOXONE Serie` | **no** |

So the resolver looked healthy — every short-named client worked — while being structurally dead for
anything longer. With it dead the LG depended entirely on Windows auto-attaching the monitor, and once
Windows stopped doing that the host destroyed a perfectly good monitor every ~7 s, forever, falling
back to letterboxed physical capture.

## The fix

Resolve by **EDID serial** instead: derived from the display id the driver reports, no length ceiling,
and `libdisplaydevice` parses it for inactive devices as well as active ones
(`win_display_device_general.cpp:58` is ungated; assigned on both branches).

Verified end to end rather than assumed — the driver writes `e[12..16] = serial.to_le_bytes()`,
`libdisplaydevice` reads bytes 12-15 little-endian, and the reporting box's live devnode EDID reads
back `0xDDAEC599` = `0x4d0a422d ^ 0x90a487b4`.

The label arm stays as a fallback and now tolerates truncation, so a saturated 13-character monitor
name matches the longer label it was cut from — preferring exact matches, preferring active devices,
and refusing outright when two devices match only by prefix, because handing back the wrong client's
display is worse than reporting nothing.

## Also here, because the primary fix makes them reachable rather than latent

- `TrackedSession` records `device_id` when the monitor resolved while inactive. Such a session has no
  GDI name at all, so the multi-session arm of `ring_target_for_display` could never match it by name
  and refused ring capture for a display that was by then perfectly usable.
- That backfill uses a **new strict resolver**. `resolveVirtualDisplayDeviceId` falls back to "any
  active virtual display" and then "any virtual display", so it practically never reports nothing —
  and inactive devices enumerate with an empty GDI name, so its name loop routinely misses and the
  fallback fires. Pairing that arbitrary id with a session would adopt a display name onto the wrong
  session, hand a client another client's frame ring, and poison the tracked name permanently, since
  nothing ever clears it. Caught by adversarial review before it shipped.
- The enumeration runs with `g_mutex` **dropped** — it is a display-config query with internal retries,
  seconds long on a wedged stack, and create/destroy/ping all need that lock (the ring-lock convoy rule).
- The serial comes from `reply.display_id`, the identity the driver actually used, not the one requested.
- The poll's "within 5 s" comment and message said 5 s while the loop runs 50 passes of two enumerations
  plus a sleep — measured 6.3-7.6 s.
- `ring_target_for_display`'s sole-session mismatch return was silent, indistinguishable in a log from
  having no session at all.

## Testing

- `tests/unit/test_virtual_display_client_label.cpp` — 7 new tests pinning the 13-byte ceiling against
  the real LG, Xbox and Mac labels, so a regression is a red test rather than one client that quietly
  cannot stream.
- 234 tests across 17 VGD/display/TDR/config suites pass.
- **Validated live on the reporting hardware.** With this build installed, `16:47:43.533` created the
  LG's monitor and 54 ms later logged `Virtual display created (device name pending enumeration)` —
  the serial arm resolving an inactive monitor — and the session streamed at 3840x2160 off the virtual
  display instead of the 3840x1600 physical fallback. That is the exact case that previously failed
  after ~7 s on every attempt.

## Not fixed here

Why the monitor is inactive in the first place: Windows stopped auto-attaching this identity after a
session-end revert committed an inactive path for it. The host now hands the display helper a device id,
so `EnsureOnlyDisplay` builds an explicit `{{device}}` topology and `setTopology` activates the target
regardless. Tracked separately, along with four review residuals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
