### PR TITLE
Adopt Build 23 VGD recovery and signed driver bundle

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -341,7 +341,11 @@ jobs:
           # (github.com/NortheBridge/LuminalVGD releases). Bump on driver
           # releases. SudoVDA is gone by decision (2026-07-23) — the MSI's
           # drivers\luminalvgd\install.ps1 also removes it wherever found.
-          LUMINALVGD_VERSION: 'v0.1.0-alpha.6'
+          LUMINALVGD_VERSION: 'v0.1.0-alpha.7'
+          # SHA-256 published in the release's SHA256SUMS asset. Keep this
+          # pinned with the tag so a replaced or partial download cannot enter
+          # the installer supply chain unnoticed.
+          LUMINALVGD_SHA256: 'afe890d0b0b94232b20eb0b6e3aac738e2f1ea73c66572541b9bb1b2e97d5afe'
         run: |
           $ErrorActionPreference = 'Stop'
           $packageDir = Join-Path $PWD 'src_assets/windows/drivers/luminalvgd/driver-package'
@@ -351,6 +355,11 @@ jobs:
           $zipPath = Join-Path $env:RUNNER_TEMP 'luminalvgd.zip'
           Write-Host "Downloading LuminalVGD $($env:LUMINALVGD_VERSION)..."
           Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
+          $actualHash = (Get-FileHash -LiteralPath $zipPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualHash -ne $env:LUMINALVGD_SHA256) {
+            throw "LuminalVGD archive SHA-256 mismatch: expected $($env:LUMINALVGD_SHA256), got $actualHash"
+          }
+          Write-Host "Verified LuminalVGD archive SHA-256: $actualHash"
           $tmp = Join-Path $env:RUNNER_TEMP 'luminalvgd'
           Expand-Archive -Path $zipPath -DestinationPath $tmp -Force
 

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -709,6 +709,11 @@ namespace platf::dxgi {
     /// a claimed slot before releasing it to the driver.
     bool prepare_fence_transport(uint32_t generation);
 
+    /// Adopt the transport selected by Build 23 for the claimed generation.
+    /// The driver can downgrade a rejected D3D12 fence ring to keyed mutexes
+    /// without recreating the monitor.
+    bool refresh_transport();
+
     /// Wait for this consumer's copy to leave the source slot. The wait is
     /// bounded so a wedged GPU produces reinit/fallback instead of blocking
     /// capture indefinitely.

--- a/src/platform/windows/display_vgd.cpp
+++ b/src/platform/windows/display_vgd.cpp
@@ -739,6 +739,27 @@ namespace platf::dxgi {
     return true;
   }
 
+  bool display_vgd_vram_t::refresh_transport() {
+    VgdRingStatus status {};
+    if (vgd_ring_status(_ring, &status) != 0) {
+      return false;
+    }
+    const bool fence = (status.transport_flags & VGD_CREATE_D3D12_FENCE_TRANSPORT) != 0;
+    if (fence == _fence_transport) {
+      return true;
+    }
+
+    BOOST_LOG(info) << "LuminalVGD capture: driver selected "
+                    << (fence ? "shared timeline-fence" : "legacy keyed-mutex")
+                    << " transport for ring generation " << status.generation << '.';
+    _fence_transport = fence;
+    _slot_textures.clear();
+    _texture_generation = 0;
+    _producer_fence.reset();
+    _fence_generation = 0;
+    return true;
+  }
+
   bool display_vgd_vram_t::finish_slot_copy() {
     const uint64_t value = ++_consumer_fence_value;
     HRESULT status = _device_ctx4->Signal(_consumer_fence.get(), value);
@@ -1066,6 +1087,11 @@ namespace platf::dxgi {
     auto claim_guard = util::fail_guard([&]() {
       vgd_ring_release(_ring, frame.index);
     });
+
+    if (!refresh_transport()) {
+      BOOST_LOG(warning) << "LuminalVGD capture: unable to read the selected ring transport; reinitializing.";
+      return capture_e::reinit;
+    }
 
     auto *slot = slot_texture(frame.generation, frame.index);
     if (!slot) {

--- a/src/platform/windows/virtual_display.cpp
+++ b/src/platform/windows/virtual_display.cpp
@@ -2895,14 +2895,6 @@ namespace VDISPLAY {
       return;
     }
 
-    const auto initial_presence = monitor_target_presence(initial_state);
-    if (initial_presence != MonitorTargetPresence::present_active) {
-      BOOST_LOG(info) << "Virtual display recovery monitor not armed for " << initial_state.describe_target()
-                      << ": display was not confirmed active at schedule time (presence="
-                      << monitor_target_presence_name(initial_presence) << ").";
-      return;
-    }
-
     const auto abort_flag = reset_recovery_monitor_abort_flag(guid_uuid);
     VirtualDisplayRecoveryParams wrapped = params;
     const auto external_abort = params.should_abort;
@@ -2914,10 +2906,40 @@ namespace VDISPLAY {
     };
 
     RecoveryMonitorState state(wrapped);
-    state.confirmed_active_at_schedule = true;
-    BOOST_LOG(debug) << "Virtual display recovery monitor scheduled for " << state.describe_target()
-                     << " (max_attempts=" << params.max_attempts << ").";
+    const auto initial_presence = monitor_target_presence(state);
+    state.confirmed_active_at_schedule = initial_presence == MonitorTargetPresence::present_active;
+    if (state.confirmed_active_at_schedule) {
+      BOOST_LOG(debug) << "Virtual display recovery monitor scheduled for " << state.describe_target()
+                       << " (max_attempts=" << params.max_attempts << ").";
+    } else {
+      BOOST_LOG(info) << "Virtual display recovery monitor pending activation for " << state.describe_target()
+                      << " (presence=" << monitor_target_presence_name(initial_presence)
+                      << "); it will arm after the staged topology apply confirms the display active.";
+    }
     std::thread monitor_thread([state = std::move(state)]() mutable {
+      if (!state.confirmed_active_at_schedule) {
+        constexpr auto kActivationBudget = std::chrono::seconds(30);
+        constexpr auto kActivationPoll = std::chrono::milliseconds(100);
+        const auto deadline = std::chrono::steady_clock::now() + kActivationBudget;
+        while (std::chrono::steady_clock::now() < deadline) {
+          if (g_recovery_monitors_shutting_down.load(std::memory_order_acquire) ||
+              monitor_should_abort(state)) {
+            return;
+          }
+          if (monitor_target_presence(state) == MonitorTargetPresence::present_active) {
+            state.confirmed_active_at_schedule = true;
+            BOOST_LOG(info) << "Virtual display recovery monitor armed after activation for "
+                            << state.describe_target() << '.';
+            break;
+          }
+          std::this_thread::sleep_for(kActivationPoll);
+        }
+        if (!state.confirmed_active_at_schedule) {
+          BOOST_LOG(warning) << "Virtual display recovery monitor activation window expired for "
+                             << state.describe_target() << "; no active display was ever observed.";
+          return;
+        }
+      }
       run_virtual_display_recovery_monitor(std::move(state));
     });
     monitor_thread.detach();


### PR DESCRIPTION
## Summary

- advance the vendored LuminalVGD host/FFI source to protocol 0.9 Build 23
- adopt the driver-selected keyed-mutex fallback when a D3D12 fence ring is rejected
- keep the virtual-display recovery monitor pending until staged topology activation completes
- pin Windows release packaging to signed `v0.1.0-alpha.7` (`0.1.0.23`, protocol 0.9, Build 23)
- verify the downloaded driver archive against its published SHA-256 before packaging

## Why

Build 22 field traces showed that a failed optional ring transport could repeatedly delete and reassign the IddCx swapchain, exhaust graphics resources, and eventually remove the active virtual monitor. Build 23 contains transport failures without disturbing topology and reports the transport actually selected by the driver. LuminalShine must refresh that selection before opening ring textures and must not abandon recovery monitoring merely because it was scheduled just before the display became active.

## Release packaging

The CI bundle is pinned to:

- release: `v0.1.0-alpha.7`
- driver identity: `0.1.0.23`
- protocol: `0.9`
- build: `23`
- SHA-256: `afe890d0b0b94232b20eb0b6e3aac738e2f1ea73c66572541b9bb1b2e97d5afe`

The driver DLL and catalog remain external signed release inputs; no signed artifacts are committed to this repository.

## Validation

- Build 23 runtime trace reached first-frame admission and selected keyed-mutex transport correctly
- LuminalVGD alpha.7 release asset and published checksum were independently downloaded and verified
- repository CI must complete before merge and before the stable `26.08.0` release workflow is dispatched
