### PR TITLE
Stabilize LuminalVGD direct capture and recovery

### DIFF
--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -155,6 +155,10 @@ set(PLATFORM_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/platform/windows/vgd_transition.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/tdr_lifeboat.h"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/tdr_lifeboat.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/video_worker.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/video_worker.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/whea_diagnostics.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/whea_diagnostics.cpp"
         "${CMAKE_SOURCE_DIR}/third-party/sudovda/sudovda-ioctl.h"
         "${CMAKE_SOURCE_DIR}/third-party/sudovda/sudovda.h"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/frame_limiter.h"
@@ -207,6 +211,7 @@ list(PREPEND PLATFORM_LIBRARIES
         shell32
         crypt32
         wintrust
+        wevtapi
         bcrypt
         ncrypt
         synchronization.lib

--- a/cmake/prep/build_version.cmake
+++ b/cmake/prep/build_version.cmake
@@ -60,6 +60,25 @@ else()
             return()
         endif()
 
+        # An exact stable release tag on HEAD is authoritative. Git's
+        # version:refname ordering places 26.08.0-rc.4 above 26.08.0, which
+        # otherwise makes a checkout of the published stable release identify
+        # and package itself as the older prerelease.
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} tag --points-at HEAD --sort=version:refname
+            OUTPUT_VARIABLE _git_exact_tags_raw
+            RESULT_VARIABLE _git_exact_tags_error
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+        if(NOT _git_exact_tags_error)
+            string(REPLACE "\n" ";" _git_exact_tags "${_git_exact_tags_raw}")
+            foreach(_git_exact_tag IN LISTS _git_exact_tags)
+                if(_git_exact_tag MATCHES "^v?[0-9]+\.[0-9]+\.[0-9]+$")
+                    set(${out_var} "${_git_exact_tag}" PARENT_SCOPE)
+                    return()
+                endif()
+            endforeach()
+        endif()
+
         set(_tag_patterns "[0-9]*.[0-9]*.[0-9]*" "v[0-9]*.[0-9]*.[0-9]*")
         foreach(_tag_pattern IN LISTS _tag_patterns)
             execute_process(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1547,6 +1547,29 @@ editing the `conf` file in a text editor. Use the examples as reference.
     </tr>
 </table>
 
+### dd_dark_recovery_anchor
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            During an exclusive LuminalVGD session, retain one physical display as an isolated WDDM recovery path and cover it with pure RGB black on the interactive desktop. This keeps OLED pixels dark while preserving a hardware-backed scan-out target if the GPU resets.
+            Disable only for compatibility testing; without the anchor, a GPU/PCIe fault while VGD is the sole active target can leave Windows unable to restore any display until reboot.
+            @note{Applies to Windows only.}
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}true@endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}
+            dd_dark_recovery_anchor = false
+            @endcode</td>
+    </tr>
+</table>
+
 ### dd_snapshot_exclude_devices
 
 <table>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -44,6 +44,7 @@
 #include "utility.h"
 
 #ifdef _WIN32
+  #include "src/platform/windows/video_worker.h"
   #include "platform/windows/hotkey_manager.h"
   #include "platform/windows/misc.h"
 
@@ -814,6 +815,7 @@ namespace config {
       true,  // config_revert_on_disconnect
       0,  // paused_virtual_display_timeout_secs
       false,  // always_restore_from_golden
+      true,  // dark_recovery_anchor
       0,  // snapshot_restore_hotkey
 #ifdef _WIN32
       MOD_CONTROL | MOD_ALT | MOD_SHIFT,  // snapshot_restore_hotkey_modifiers
@@ -1596,6 +1598,7 @@ namespace config {
       video.dd.paused_virtual_display_timeout_secs = std::max(0, value);
     }
     bool_f(vars, "dd_always_restore_from_golden", video.dd.always_restore_from_golden);
+    bool_f(vars, "dd_dark_recovery_anchor", video.dd.dark_recovery_anchor);
     bool_f(vars, "dd_activate_virtual_display", video.dd.activate_virtual_display);
     generic_f(vars, "dd_snapshot_exclude_devices", video.dd.snapshot_exclude_devices, dd::snapshot_exclude_devices_from_view);
     {
@@ -1996,7 +1999,9 @@ namespace config {
 
       // Persist snapshot exclusion devices to luminalshine_state.json on startup so the display
       // helper can read them directly without depending on IPC from Sunshine.
-      statefile::save_snapshot_exclude_devices(video.dd.snapshot_exclude_devices);
+      if (!platf::video_worker::is_child_process()) {
+        statefile::save_snapshot_exclude_devices(video.dd.snapshot_exclude_devices);
+      }
     } catch (const std::filesystem::filesystem_error &err) {
       BOOST_LOG(fatal) << "Failed to apply config: "sv << err.what();
     } catch (const boost::filesystem::filesystem_error &err) {
@@ -2139,6 +2144,7 @@ namespace config {
         "dd_config_revert_on_disconnect",
         "dd_paused_virtual_display_timeout_secs",
         "dd_always_restore_from_golden",
+        "dd_dark_recovery_anchor",
         "dd_snapshot_exclude_devices",
         "dd_snapshot_restore_hotkey",
         "dd_snapshot_restore_hotkey_modifiers",
@@ -2396,7 +2402,9 @@ namespace config {
       // Persist snapshot exclusion devices to luminalshine_state.json so the display helper
       // can read them directly without depending on IPC from Sunshine.
       // This is done unconditionally to ensure the state file is always up-to-date.
-      statefile::save_snapshot_exclude_devices(video.dd.snapshot_exclude_devices);
+      if (!platf::video_worker::is_child_process()) {
+        statefile::save_snapshot_exclude_devices(video.dd.snapshot_exclude_devices);
+      }
 
       // Check if any DD configuration changed and handle hot-apply when no active sessions
       using dd_cfg_e = config::video_t::dd_t::config_option_e;

--- a/src/config.h
+++ b/src/config.h
@@ -202,6 +202,7 @@ namespace config {
       bool config_revert_on_disconnect;  ///< Specify whether to revert display configuration on client disconnect.
       int paused_virtual_display_timeout_secs;  ///< Optional delay before virtual display cleanup while stream is paused (0 keeps alive).
       bool always_restore_from_golden;  ///< When true, prefer golden snapshot over session snapshots during restore (reduces stuck virtual screens).
+      bool dark_recovery_anchor;  ///< Keep an isolated physical path active and black during exclusive VGD sessions.
       int snapshot_restore_hotkey;  ///< Virtual-key code for restore hotkey (0 disables).
       std::uint32_t snapshot_restore_hotkey_modifiers;  ///< Modifier flags for the restore hotkey.
       bool activate_virtual_display;  ///< Auto-activate Sunshine virtual display when selected as the target output.

--- a/src/display_helper_builder.cpp
+++ b/src/display_helper_builder.cpp
@@ -38,6 +38,11 @@ namespace display_helper_integration {
     return *this;
   }
 
+  DisplayApplyBuilder &DisplayApplyBuilder::set_dark_recovery_anchor(const bool enable) {
+    dark_recovery_anchor_ = enable;
+    return *this;
+  }
+
   DisplayApplyBuilder &DisplayApplyBuilder::set_topology(const DisplayTopologyDefinition &topology) {
     topology_ = topology;
     return *this;
@@ -63,6 +68,7 @@ namespace display_helper_integration {
     request.session_overrides = session_overrides_;
     request.enable_virtual_display_watchdog = enable_virtual_display_watchdog_;
     request.attach_hdr_toggle_flag = attach_hdr_toggle_flag_;
+    request.dark_recovery_anchor = dark_recovery_anchor_;
     request.topology = topology_;
     request.session = session_;
     request.virtual_display_arrangement = virtual_display_arrangement_;

--- a/src/display_helper_builder.h
+++ b/src/display_helper_builder.h
@@ -72,6 +72,7 @@ namespace display_helper_integration {
     ActiveSessionState session_overrides {};
     bool enable_virtual_display_watchdog {false};
     bool attach_hdr_toggle_flag {false};
+    bool dark_recovery_anchor {false};
     // Internal pre-capture phase: apply synchronously without scheduling any
     // delayed verification/reapply/HDR/shell work that could overlap the next phase.
     bool transitional_apply {false};
@@ -91,6 +92,7 @@ namespace display_helper_integration {
     DisplayApplyBuilder &clear_configuration();
     DisplayApplyBuilder &set_virtual_display_watchdog(bool enable);
     DisplayApplyBuilder &set_hdr_toggle_flag(bool enable);
+    DisplayApplyBuilder &set_dark_recovery_anchor(bool enable);
     DisplayApplyBuilder &set_topology(const DisplayTopologyDefinition &topology);
     DisplayTopologyDefinition &mutable_topology();
     ActiveSessionState &mutable_session_overrides();
@@ -106,6 +108,7 @@ namespace display_helper_integration {
     DisplayTopologyDefinition topology_ {};
     bool enable_virtual_display_watchdog_ {false};
     bool attach_hdr_toggle_flag_ {false};
+    bool dark_recovery_anchor_ {false};
     std::optional<VirtualDisplayArrangement> virtual_display_arrangement_;
   };
 

--- a/src/gpu_recovery_policy.h
+++ b/src/gpu_recovery_policy.h
@@ -1,0 +1,27 @@
+/**
+ * @file src/gpu_recovery_policy.h
+ * @brief Process-lifetime containment after a GPU/display recovery edge.
+ */
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace gpu_recovery_policy {
+  inline std::atomic<bool> g_force_d3d11 {false};
+  inline std::atomic<std::uint64_t> g_abort_generation {0};
+
+  inline bool force_d3d11() noexcept {
+    return g_force_d3d11.load(std::memory_order_acquire);
+  }
+
+  inline std::uint64_t abort_generation() noexcept {
+    return g_abort_generation.load(std::memory_order_acquire);
+  }
+
+  inline bool open_d3d11_circuit() noexcept {
+    const bool first = !g_force_d3d11.exchange(true, std::memory_order_acq_rel);
+    g_abort_generation.fetch_add(1, std::memory_order_acq_rel);
+    return first;
+  }
+}  // namespace gpu_recovery_policy

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <thread>
 
 // local includes
@@ -52,6 +53,7 @@
   #include "src/platform/windows/vgd_transition.h"
   #include "src/platform/windows/virtual_display.h"
   #include "src/platform/windows/virtual_display_cleanup.h"
+  #include "src/platform/windows/video_worker.h"
 #endif
 
 extern "C" {
@@ -148,6 +150,21 @@ WINAPI BOOL ConsoleCtrlHandler(DWORD type) {
 
 int main(int argc, char *argv[]) {
   lifetime::argv = argv;
+
+#ifdef _WIN32
+  if (argc == 4 && std::string_view(argv[1]) == "--internal-video-worker"sv) {
+    try {
+      const auto parent_pid = std::stoul(argv[3]);
+      if (parent_pid == 0 || parent_pid > std::numeric_limits<std::uint32_t>::max()) {
+        return 9;
+      }
+      platf::video_worker::set_child_pipe(argv[2], static_cast<std::uint32_t>(parent_pid));
+      argc = 1; // internal switch is not part of the public config CLI
+    } catch (...) {
+      return 9;
+    }
+  }
+#endif
 
   // Last-resort diagnostics: if any thread lets an exception escape (e.g.
   // std::bad_alloc under system-wide memory exhaustion), record what it was
@@ -252,6 +269,12 @@ int main(int argc, char *argv[]) {
   if (config::parse(argc, argv)) {
     return 0;
   }
+
+#ifdef _WIN32
+  if (platf::video_worker::is_child_process()) {
+    config::sunshine.log_file += ".video-worker-" + std::to_string(::GetCurrentProcessId()) + ".log";
+  }
+#endif
 
   auto log_deinit_guard = logging::init(config::sunshine.min_log_level, config::sunshine.log_file);
   if (!log_deinit_guard) {
@@ -376,6 +399,26 @@ int main(int argc, char *argv[]) {
     // continue; the user can retry the Reset shortcut.
     BOOST_LOG(warning) << "Admin reset marker check failed: " << ex.what()
                        << ". Continuing service startup.";
+  }
+#endif
+
+  // The isolated video worker needs D3D/platform initialization, but none of
+  // the host's service, tray, update, NVIDIA-profile, or display-topology
+  // side effects. Branch before those systems start so every stream does not
+  // accidentally initialize a second host instance.
+#ifdef _WIN32
+  if (platf::video_worker::is_child_process()) {
+    task_pool.start(1);
+    auto task_pool_guard = util::fail_guard([] {
+      task_pool.stop();
+      task_pool.join();
+    });
+    auto worker_platform = platf::init_video_worker();
+    if (!worker_platform) {
+      BOOST_LOG(error) << "Video worker: platform initialization failed.";
+      return 13;
+    }
+    return platf::video_worker::run_child();
   }
 #endif
 

--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -41,6 +41,7 @@
 
 // local includes
 #include "src/config.h"
+#include "src/gpu_recovery_policy.h"
 #include "src/tdr_state.h"
 #include "src/logging.h"
 #include "src/utility.h"
@@ -1159,7 +1160,9 @@ namespace nvenc {
       // process is going away and the teardown path handles the rest.
       if (wait_result == encode_wait_result::aborted) {
         BOOST_LOG(info) << "NvEnc: abandoning the wait for frame " << frame_index
-                        << " because the host is shutting down.";
+                        << (g_shutdown_requested.load(std::memory_order_acquire)
+                              ? " because the host is shutting down."
+                              : " because GPU/display recovery requested prompt encoder teardown.");
         encoder_state.has_pending_async = true;
         return {};
       }
@@ -1332,6 +1335,7 @@ namespace nvenc {
     const auto slice = std::max<uint32_t>(10, encoder_state.encode_wait_poll_slice_ms);
     const auto deadline_ms = std::max(slice, encoder_state.encode_wait_timeout_ms);
     const auto started = std::chrono::steady_clock::now();
+    const auto recovery_generation = gpu_recovery_policy::abort_generation();
 
     while (true) {
       const auto slice_started = std::chrono::steady_clock::now();
@@ -1356,6 +1360,11 @@ namespace nvenc {
       // Teardown must not wait out an OS-scale deadline: the force-shutdown
       // watchdog would fire first.
       if (g_shutdown_requested.load(std::memory_order_acquire)) {
+        return encode_wait_result::aborted;
+      }
+      if (gpu_recovery_policy::abort_generation() != recovery_generation) {
+        BOOST_LOG(warning) << "NvEnc: encode wait cancelled by the GPU recovery circuit before the "
+                              "display stack became unavailable.";
         return encode_wait_result::aborted;
       }
 

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1478,17 +1478,29 @@ namespace nvhttp {
       return true;
     };
 
-    // Start with the client requested mode
-    (void) parse_mode_string(get_arg(args, "mode", "0x0x0"));
+    // Start with the client requested mode. Keep the provenance so a later
+    // RTSP viewport disagreement can be diagnosed and reconciled before
+    // capture starts instead of silently streaming the pre-launch fallback.
+    const auto raw_client_mode = get_arg(args, "mode", "0x0x0");
+    if (parse_mode_string(raw_client_mode)) {
+      launch_session->requested_display_mode_source = "client_http";
+    } else {
+      launch_session->requested_display_mode_source = "fallback";
+    }
 
     // Apply client display mode override if present
     if (client_settings && !client_settings->display_mode.empty()) {
       if (parse_mode_string(client_settings->display_mode)) {
         launch_session->client_display_mode_override = true;
+        launch_session->requested_display_mode_source = "per_client_override";
       } else {
         BOOST_LOG(warning) << "Failed to parse client display mode override: " << client_settings->display_mode;
       }
     }
+    BOOST_LOG(info) << "Requested display mode: raw_http='" << raw_client_mode
+                    << "' selected=" << launch_session->width << 'x' << launch_session->height
+                    << '@' << launch_session->fps << "Hz source="
+                    << launch_session->requested_display_mode_source << '.';
 
     if (client_settings) {
       launch_session->client_requests_virtual_display = client_settings->always_use_virtual_display;

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -907,6 +907,10 @@ namespace platf {
   }
 
   [[nodiscard]] std::unique_ptr<deinit_t> init();
+#ifdef _WIN32
+  /** Minimal DXGI/COM initialization for the isolated capture/encode worker. */
+  [[nodiscard]] std::unique_ptr<deinit_t> init_video_worker();
+#endif
 
   /**
    * @brief Returns the current computer name in UTF-8.

--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -1712,4 +1712,14 @@ namespace platf {
 
     return co_init;
   }
+
+  std::unique_ptr<deinit_t> init_video_worker() {
+    if (dxgi::init()) {
+      return nullptr;
+    }
+
+    // The worker needs COM for DXGI/capture, but it must not reset audio,
+    // arm topology recovery, or start host-wide VGD transition watchers.
+    return std::make_unique<platf::audio::co_init_t>();
+  }
 }  // namespace platf

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -37,10 +37,12 @@ typedef enum _D3DKMT_GPU_PREFERENCE_QUERY_STATE : DWORD {
 #include "misc.h"
 #include "src/config.h"
 #include "src/display_device.h"
+#include "src/gpu_recovery_policy.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
 #include "src/platform/windows/vgd_transition.h"
 #include "src/platform/windows/virtual_display_backend.h"
+#include "src/platform/windows/virtual_display_vgd.h"
 #include "src/tdr_state.h"
 #include "src/video.h"
 #include "utf_utils.h"
@@ -1131,10 +1133,15 @@ namespace platf::dxgi {
         if (!recovery_deferral_started) {
           recovery_deferral_started = now;
           recovery_deferral_logged = now;
+          const bool first_transport_trip = gpu_recovery_policy::open_d3d11_circuit();
           BOOST_LOG(info) << "Capture source reports a bounded recovery window; deferring the display "
                              "reinit and holding the session (giving up after "sv
                           << std::chrono::duration_cast<std::chrono::minutes>(kMaxRecoveryDeferral).count()
                           << " minutes)."sv;
+          if (first_transport_trip) {
+            BOOST_LOG(warning) << "GPU recovery circuit: cancelling in-flight encoder waits and disabling "
+                                  "native D3D12 NVENC for this host run; rebuilt encoders will use D3D11.";
+          }
         } else if (now - *recovery_deferral_started > kMaxRecoveryDeferral) {
           BOOST_LOG(warning) << "Capture source reported recovery for longer than "sv
                              << std::chrono::duration_cast<std::chrono::minutes>(kMaxRecoveryDeferral).count()
@@ -2034,6 +2041,7 @@ namespace platf {
     const bool default_to_wgc = dxgi::should_use_wgc_default();
     const bool wgc_requested = capture_mode.starts_with("wgc");
     const bool vgd_requested = capture_mode == "vgd";
+    const bool worker_vgd_target = VDISPLAY::vgd::has_worker_ring_target();
     const bool prefer_wgc_backend = !user_requested_ddx && !vgd_requested && (wgc_requested || default_to_wgc);
 
     if (hwdevice_type == mem_type_e::dxgi) {
@@ -2042,7 +2050,9 @@ namespace platf {
       // for non-VGD displays (or if the ring can't be mapped), falling back
       // to WGC/DDA below; explicit capture=vgd also degrades rather than
       // failing the stream.
-      if (!user_requested_ddx && !wgc_requested && (vgd_requested || VDISPLAY::is_luminalvgd_active())) {
+      if (worker_vgd_target ||
+          (!user_requested_ddx && !wgc_requested &&
+           (vgd_requested || VDISPLAY::is_luminalvgd_active()))) {
         if (auto disp = dxgi::display_vgd_vram_t::create(config, display_name)) {
           vgd_transition::note_capture_backend(vgd_transition::kCaptureKindVgdRing, display_name);
           return disp;
@@ -2050,6 +2060,11 @@ namespace platf {
         if (vgd_requested) {
           BOOST_LOG(warning) << "capture=vgd requested but the LuminalVGD ring is unavailable for "
                              << display_name << "; falling back to WGC/DDA.";
+        }
+        if (worker_vgd_target) {
+          BOOST_LOG(error) << "Video worker: transferred LuminalVGD ring could not be opened for "
+                           << display_name << "; refusing silent WGC/DDA substitution.";
+          return nullptr;
         }
       }
       if (prefer_wgc_backend) {

--- a/src/platform/windows/display_helper_integration.cpp
+++ b/src/platform/windows/display_helper_integration.cpp
@@ -31,6 +31,7 @@
   // sunshine
   #include "display_helper_integration.h"
   #include "src/globals.h"
+  #include "src/gpu_recovery_policy.h"
   #include "src/logging.h"
   #include "src/platform/windows/display_helper_coordinator.h"
   #include "src/platform/windows/display_helper_request_helpers.h"
@@ -773,6 +774,7 @@ namespace {
   static std::atomic<std::uint64_t> g_restore_generation {0};
   static std::atomic<std::uint64_t> g_disarm_generation_sent {0};
   static std::atomic<std::int64_t> g_last_revert_us {0};
+  static std::atomic<std::int64_t> g_last_revert_completed_us {0};
   static std::atomic<std::int64_t> g_last_disarm_attempt_us {0};
   static std::atomic<std::int64_t> g_last_disarm_success_us {0};
 
@@ -1180,6 +1182,10 @@ namespace {
       j["sunshine_transitional_apply"] = true;
     }
 
+    if (request.dark_recovery_anchor) {
+      j["sunshine_dark_recovery_anchor"] = true;
+    }
+
     if (request.virtual_display_arrangement) {
       j["sunshine_virtual_layout"] = virtual_layout_to_string(*request.virtual_display_arrangement);
     }
@@ -1221,12 +1227,15 @@ namespace {
   }
 
   std::string build_revert_payload(bool prefer_golden_if_current_missing) {
-    if (!prefer_golden_if_current_missing) {
-      return {};
-    }
-
     nlohmann::json j = nlohmann::json::object();
-    j["sunshine_prefer_golden_if_current_missing"] = true;
+    if (prefer_golden_if_current_missing) {
+      j["sunshine_prefer_golden_if_current_missing"] = true;
+    } else {
+      // Clean session shutdowns must restore the baseline captured directly
+      // before this VGD session. Golden is a crash/missing-snapshot fallback,
+      // not an excuse to replace a newer two-monitor layout.
+      j["sunshine_clean_session_revert"] = true;
+    }
     return j.dump();
   }
 
@@ -1626,6 +1635,12 @@ namespace display_helper_integration {
 
   bool revert(bool prefer_golden_if_current_missing) {
     clear_pending_apply();
+    const auto completed_us = g_last_revert_completed_us.load(std::memory_order_acquire);
+    if (!prefer_golden_if_current_missing && completed_us > 0 &&
+        now_steady_us() - completed_us < 5'000'000 && !helper_process_running()) {
+      BOOST_LOG(info) << "Display helper: suppressing duplicate REVERT because the prior transactional restore just completed.";
+      return true;
+    }
     if (!ensure_helper_started()) {
       BOOST_LOG(info) << "Display helper unavailable; cannot send revert.";
       return false;
@@ -1641,6 +1656,29 @@ namespace display_helper_integration {
     }
     clear_active_session();
     return ok;
+  }
+
+  bool wait_for_revert_completion(std::chrono::milliseconds timeout) {
+    HANDLE process = nullptr;
+    {
+      std::lock_guard<std::mutex> lg(helper_mutex());
+      process = helper_proc().get_process_handle();
+      if (!process) {
+        BOOST_LOG(error) << "Display helper: cannot wait for REVERT completion without a helper process handle.";
+        return false;
+      }
+      const auto bounded = std::clamp<long long>(timeout.count(), 0, 120000);
+      const DWORD waited = WaitForSingleObject(process, static_cast<DWORD>(bounded));
+      if (waited != WAIT_OBJECT_0) {
+        BOOST_LOG(error) << "Display helper: timed out waiting for strictly verified REVERT completion.";
+        return false;
+      }
+    }
+    g_restore_expected.store(false, std::memory_order_release);
+    g_last_revert_completed_us.store(now_steady_us(), std::memory_order_release);
+    platf::display_helper_client::reset_connection();
+    BOOST_LOG(info) << "Display helper: transactional REVERT completed and helper exited after verification.";
+    return true;
   }
 
   ApplyFailure last_apply_failure() {
@@ -2110,6 +2148,7 @@ namespace display_helper_integration {
     constexpr std::int64_t kMinMsBetweenDegradedProbes = 30'000;
     /// steady_clock ms of the last degraded probe.
     std::atomic<std::int64_t> g_last_degraded_probe_ms {0};
+    std::atomic<std::int64_t> g_enumeration_retry_after_ms {0};
 
     std::int64_t steady_ms_now() {
       return std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -2165,6 +2204,28 @@ namespace display_helper_integration {
         return;  // already latched; nothing to add
       }
 
+      const bool active_stream = get_active_session_copy().has_value();
+      if (active_stream && streak == 1) {
+        LONG qdc_status = ERROR_SUCCESS;
+        UINT32 qdc_paths = 0;
+        (void) platf::dxgi::display_config_api_healthy(&qdc_status, &qdc_paths);
+        if (qdc_status == ERROR_NOT_SUPPORTED) {
+          const bool first = gpu_recovery_policy::open_d3d11_circuit();
+          BOOST_LOG(error) << "Display API refused the first active-stream enumeration (status "
+                           << qdc_status << ", " << qdc_paths
+                           << " paths). Cancelling GPU submissions immediately; terminal confirmation "
+                              "continues in the background.";
+          if (first) {
+            BOOST_LOG(warning) << "GPU recovery circuit: native D3D12 NVENC disabled for this host run.";
+          }
+          tdr::mark_event(
+            tdr::source_t::query_display_config,
+            static_cast<long>(qdc_status),
+            "active-stream QueryDisplayConfig became unavailable; GPU work cancelled before terminal classification"
+          );
+        }
+      }
+
       // Degraded check first: it fires ~8 s before the terminal one and is the
       // only signal available while recovery can still work. Purely a report --
       // it must not reach mark_stack_down (tells the user to reboot) or
@@ -2188,8 +2249,10 @@ namespace display_helper_integration {
         }
       }
 
-      if (streak < kEmptyEnumerationsBeforeProbe ||
-          (now_ms - failing_since) < kMinFailingMsBeforeProbe) {
+      const auto required_streak = active_stream ? std::uint64_t {3} : kEmptyEnumerationsBeforeProbe;
+      const auto required_failing_ms = active_stream ? std::int64_t {3'000} : kMinFailingMsBeforeProbe;
+      if (streak < required_streak ||
+          (now_ms - failing_since) < required_failing_ms) {
         return;
       }
 
@@ -2234,6 +2297,10 @@ namespace display_helper_integration {
   std::optional<display_device::EnumeratedDeviceList> enumerate_devices(
     display_device::DeviceEnumerationDetail detail
   ) {
+    const auto now_ms = steady_ms_now();
+    if (now_ms < g_enumeration_retry_after_ms.load(std::memory_order_acquire)) {
+      return std::nullopt;
+    }
     try {
       display_device::DisplayRecoveryBehaviorGuard guard(display_device::DisplayRecoveryBehavior::Skip);
       auto api = std::make_shared<display_device::WinApiLayer>();
@@ -2243,6 +2310,16 @@ namespace display_helper_integration {
       // underlying QueryDisplayConfig fails, so "did it throw" is not the
       // signal -- "did it produce anything" is.
       note_enumeration_result(!devices.empty());
+      if (devices.empty()) {
+        LONG qdc_status = ERROR_SUCCESS;
+        UINT32 qdc_paths = 0;
+        (void) platf::dxgi::display_config_api_healthy(&qdc_status, &qdc_paths);
+        if (qdc_status == ERROR_NOT_SUPPORTED) {
+          g_enumeration_retry_after_ms.store(now_ms + 1'000, std::memory_order_release);
+        }
+      } else {
+        g_enumeration_retry_after_ms.store(0, std::memory_order_release);
+      }
       return devices;
     } catch (...) {
       note_enumeration_result(false);

--- a/src/platform/windows/display_helper_integration.h
+++ b/src/platform/windows/display_helper_integration.h
@@ -9,6 +9,7 @@
 #include "src/rtsp.h"
 
 #include <display_device/types.h>
+#include <chrono>
 #include <optional>
 #include <vector>
 
@@ -39,6 +40,11 @@ namespace display_helper_integration {
   // Launch the helper (if needed) and send REVERT.
   // Returns true if the helper accepted the command; false to allow fallback.
   bool revert(bool prefer_golden_if_current_missing = false);
+
+  // Wait until the helper process exits after a confirmed snapshot restore.
+  // Explicit REVERT makes the helper exit only after strict topology/layout
+  // verification, so this is the transaction boundary before VGD removal.
+  bool wait_for_revert_completion(std::chrono::milliseconds timeout);
 
   // Replace a stale helper/pipe and wait for the new interactive helper.
   bool restart_helper_for_recovery();

--- a/src/platform/windows/display_helper_request_helpers.cpp
+++ b/src/platform/windows/display_helper_request_helpers.cpp
@@ -44,7 +44,10 @@ namespace display_helper_integration::helpers {
       return static_cast<int>(result);
     }
 
-    layout_flags_t describe_layout(const config::video_t::virtual_display_layout_e layout) {
+    layout_flags_t describe_layout(
+      const config::video_t::virtual_display_layout_e layout,
+      const bool dark_recovery_anchor = false
+    ) {
       using enum display_helper_integration::VirtualDisplayArrangement;
       using Prep = display_device::SingleDisplayConfiguration::DevicePreparation;
       switch (layout) {
@@ -58,6 +61,12 @@ namespace display_helper_integration::helpers {
           return {ExtendedPrimaryIsolated, Prep::EnsurePrimary, true};
         case config::video_t::virtual_display_layout_e::exclusive:
         default:
+          if (dark_recovery_anchor) {
+            // Keep a physical WDDM scan-out path attached as an isolated dark
+            // recovery anchor. The helper covers it with RGB black, while the
+            // virtual target remains primary and is placed far away from it.
+            return {ExtendedPrimaryIsolated, Prep::EnsurePrimary, true};
+          }
           return {Exclusive, Prep::EnsureOnlyDisplay, false};
       }
     }
@@ -222,9 +231,16 @@ namespace display_helper_integration::helpers {
     const auto effective_layout =
       session_.virtual_display_layout_override.value_or(effective_video_config_.virtual_display_layout);
     BOOST_LOG(debug) << "effective_layout: " << static_cast<int>(effective_layout);
-    const auto layout_flags = describe_layout(effective_layout);
+    const bool dark_recovery_anchor =
+      session_.virtual_display &&
+      effective_layout == config::video_t::virtual_display_layout_e::exclusive &&
+      effective_video_config_.dd.dark_recovery_anchor;
+    const auto layout_flags = describe_layout(effective_layout, dark_recovery_anchor);
     BOOST_LOG(debug) << "layout_flags.arrangement: " << static_cast<int>(layout_flags.arrangement);
     builder.set_virtual_display_arrangement(layout_flags.arrangement);
+    builder.set_dark_recovery_anchor(
+      dark_recovery_anchor
+    );
 
     auto &overrides = builder.mutable_session_overrides();
     if (session_.width > 0) {
@@ -324,7 +340,11 @@ namespace display_helper_integration::helpers {
       target_device_id = *resolved;
     }
     vd_cfg.m_device_id = target_device_id;
-    const auto layout_flags = describe_layout(layout);
+    const bool dark_recovery_anchor =
+      session_.virtual_display &&
+      layout == config::video_t::virtual_display_layout_e::exclusive &&
+      effective_video_config_.dd.dark_recovery_anchor;
+    const auto layout_flags = describe_layout(layout, dark_recovery_anchor);
     vd_cfg.m_device_prep = layout_flags.device_prep;
     if (minimum_fps > 0 && vd_cfg.m_refresh_rate) {
       ensure_minimum_refresh_if_present(vd_cfg.m_refresh_rate, minimum_fps);
@@ -381,7 +401,10 @@ namespace display_helper_integration::helpers {
                       << " prep=" << static_cast<int>(cfg_effective.m_device_prep);
 
       if (session_.virtual_display) {
-        const auto layout_flags = describe_layout(layout);
+        const bool dark_recovery_anchor =
+          layout == config::video_t::virtual_display_layout_e::exclusive &&
+          effective_video_config_.dd.dark_recovery_anchor;
+        const auto layout_flags = describe_layout(layout, dark_recovery_anchor);
         cfg_effective.m_device_prep = layout_flags.device_prep;
       }
 
@@ -481,7 +504,11 @@ namespace display_helper_integration::helpers {
     BOOST_LOG(debug) << "video_config_.virtual_display_layout: " << static_cast<int>(effective_video_config_.virtual_display_layout);
     const auto effective_layout =
       session_.virtual_display_layout_override.value_or(effective_video_config_.virtual_display_layout);
-    const auto layout_flags = describe_layout(effective_layout);
+    const bool dark_recovery_anchor =
+      session_.virtual_display &&
+      effective_layout == config::video_t::virtual_display_layout_e::exclusive &&
+      effective_video_config_.dd.dark_recovery_anchor;
+    const auto layout_flags = describe_layout(effective_layout, dark_recovery_anchor);
     const auto resolved_virtual_device_id = resolve_virtual_device_id(effective_video_config_, session_);
     const std::string topology_device_id =
       resolved_virtual_device_id && !resolved_virtual_device_id->empty() ? *resolved_virtual_device_id : default_device_id;

--- a/src/platform/windows/display_vgd.cpp
+++ b/src/platform/windows/display_vgd.cpp
@@ -59,6 +59,11 @@ namespace platf::dxgi {
     // both sides bound every acquire).
     constexpr uint64_t kVgdMutexKeyHost = 1;
     constexpr uint32_t kVgdMutexTimeoutMs = 100;
+    // Encoder mailbox textures are host-owned. A free image returned by the
+    // pool should therefore be immediately acquirable; waiting seconds here
+    // would recouple the display producer to a wedged encoder. Drop/reinit on
+    // a short bound instead and leave every VGD ring claim released.
+    constexpr uint32_t kEncoderMailboxMutexTimeoutMs = 100;
 
     /// Circuit breaker: a session whose ring consistently fails to deliver
     /// (texture opens failing, or frames publishing that we can never claim)
@@ -364,6 +369,16 @@ namespace platf::dxgi {
     }
 
     _ring = ring;
+    if (VDISPLAY::vgd::has_worker_ring_target()) {
+      VgdRingStatus opened_status {};
+      if (vgd_ring_status(ring, &opened_status) != 0 || opened_status.state != 1 ||
+          opened_status.generation != target->generation ||
+          opened_status.transport_flags != target->transport_flags) {
+        BOOST_LOG(error) << "Video worker: transferred LuminalVGD ring changed before open; "
+                            "rejecting stale generation/transport.";
+        return -1;
+      }
+    }
     _session_id = target->session_id;
     _ring_slots = target->ring_slots;
     _fence_transport = (target->transport_flags & VGD_CREATE_D3D12_FENCE_TRANSPORT) != 0;
@@ -438,6 +453,10 @@ namespace platf::dxgi {
     BOOST_LOG(info) << "LuminalVGD capture: consuming frame ring of session 0x"
                     << std::hex << _session_id << std::dec << " (" << _ring_slots
                     << " slots) for " << display_name;
+    if (VDISPLAY::vgd::has_worker_ring_target()) {
+      BOOST_LOG(info) << "Video worker: VGD_RING_OPENED session=0x" << std::hex << _session_id
+                      << std::dec << " slots=" << _ring_slots << " display=" << display_name;
+    }
     return 0;
   }
 
@@ -1053,7 +1072,7 @@ namespace platf::dxgi {
           if (complete_img(d3d_img.get(), false)) {
             return capture_e::reinit;
           }
-          const HRESULT dst_acquire = seh_acquire_sync(d3d_img->capture_mutex.get(), 0, 3000);
+          const HRESULT dst_acquire = seh_acquire_sync(d3d_img->capture_mutex.get(), 0, kEncoderMailboxMutexTimeoutMs);
           if (dst_acquire != S_OK && dst_acquire != static_cast<HRESULT>(WAIT_ABANDONED)) {
             BOOST_LOG(warning) << "LuminalVGD capture: pooled texture mutex acquire failed [0x"sv << util::hex(dst_acquire).to_string_view() << "]; reinitializing."sv;
             return capture_e::reinit;
@@ -1184,7 +1203,7 @@ namespace platf::dxgi {
     }
 
     // Pooled textures follow the capture<->encoder key-0 convention.
-    const HRESULT dst_acquire = seh_acquire_sync(d3d_img->capture_mutex.get(), 0, 3000);
+    const HRESULT dst_acquire = seh_acquire_sync(d3d_img->capture_mutex.get(), 0, kEncoderMailboxMutexTimeoutMs);
     if (dst_acquire != S_OK && dst_acquire != static_cast<HRESULT>(WAIT_ABANDONED)) {
       BOOST_LOG(warning) << "LuminalVGD capture: pooled texture mutex acquire failed [0x"sv << util::hex(dst_acquire).to_string_view() << "]; reinitializing."sv;
       return capture_e::reinit;

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -20,6 +20,7 @@ extern "C" {
 #include "display_vram.h"
 #include "misc.h"
 #include "src/config.h"
+#include "src/gpu_recovery_policy.h"
 #include "src/logging.h"
 #include "src/nvenc/nvenc_config.h"
 #include "src/nvenc/nvenc_d3d11_native.h"
@@ -1126,7 +1127,7 @@ namespace platf::dxgi {
       // Prefer the native D3D12 NVENC contract. D3D11On12 lets the proven
       // Sunshine colour-conversion shaders render directly into the D3D12
       // input allocation while NVENC receives explicit fence points.
-      if (pix_fmt != pix_fmt_e::yuv444p16) {
+      if (pix_fmt != pix_fmt_e::yuv444p16 && !gpu_recovery_policy::force_d3d11()) {
         auto native12 = std::make_unique<nvenc::nvenc_d3d12>(adapter_p);
         if (native12->valid() && !base.init(display, adapter_p, pix_fmt,
                                             native12->d3d11_device(), native12->d3d11_context())) {
@@ -1134,6 +1135,10 @@ namespace platf::dxgi {
           nvenc_d3d = std::move(native12);
           BOOST_LOG(info) << "NvEnc: native D3D12 input/output path selected (explicit fences)";
         }
+      }
+      if (pix_fmt != pix_fmt_e::yuv444p16 && gpu_recovery_policy::force_d3d11()) {
+        BOOST_LOG(warning) << "NvEnc: native D3D12 path suppressed by the GPU recovery circuit; "
+                              "selecting D3D11 compatibility transport.";
       }
       if (!nvenc_d3d) {
         if (base.init(display, adapter_p, pix_fmt)) return false;

--- a/src/platform/windows/tdr_lifeboat.cpp
+++ b/src/platform/windows/tdr_lifeboat.cpp
@@ -31,10 +31,12 @@
 // local includes
 #include "src/display_helper_builder.h"
 #include "src/globals.h"
+#include "src/gpu_recovery_policy.h"
 #include "src/logging.h"
 #include "src/platform/windows/display.h"
 #include "src/platform/windows/display_helper_integration.h"
 #include "src/platform/windows/virtual_display.h"
+#include "src/platform/windows/whea_diagnostics.h"
 
 namespace tdr_lifeboat {
   namespace {
@@ -137,6 +139,10 @@ namespace tdr_lifeboat {
     /// block — the shared task pool runs input timers on its single thread.
     void start_attempt(tdr::source_t source) {
       try {
+        if (const auto whea = whea_diagnostics::recent_pcie_aer_summary()) {
+          BOOST_LOG(error) << "GPU recovery correlation: " << *whea
+                           << ". This is a platform PCIe fault, not an encoder-preset verdict.";
+        }
         BOOST_LOG(warning) << "TDR lifeboat: GPU/TDR failure detected (" << tdr::source_label(source)
                            << "); best-effort activating a physical display alongside the virtual display so Windows'"
                            << " TDR recovery has a hardware-backed output to recompose onto. In every observed"
@@ -175,6 +181,7 @@ namespace tdr_lifeboat {
     /// push when the gate opens. Never throws, never blocks.
     void on_tdr_event(tdr::source_t source) noexcept {
       try {
+        (void) gpu_recovery_policy::open_d3d11_circuit();
         {
           std::lock_guard<std::mutex> lk(g_gate_mutex);
           if (!g_gate.should_attempt(source, std::chrono::steady_clock::now())) {

--- a/src/platform/windows/video_worker.cpp
+++ b/src/platform/windows/video_worker.cpp
@@ -1,0 +1,693 @@
+#include "video_worker.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+#include <windows.h>
+#include <bcrypt.h>
+#include <sddl.h>
+
+#include "src/globals.h"
+#include "src/config.h"
+#include "src/display_device.h"
+#include "src/input.h"
+#include "src/logging.h"
+#include "src/platform/windows/display.h"
+#include "src/platform/windows/virtual_display_backend.h"
+#include "src/platform/windows/virtual_display_vgd.h"
+
+using namespace std::literals;
+
+namespace platf::video_worker {
+  namespace {
+    enum class message_e: std::uint32_t {
+      start = 1,
+      shutdown,
+      idr,
+      invalidate,
+      packet,
+      hdr,
+      touch,
+      chroma_downgrade,
+      finished,
+      heartbeat,
+      encoder_ready,
+      capture_ready,
+      startup_error,
+    };
+
+#pragma pack(push, 1)
+    struct header_t {
+      message_e type;
+      std::uint32_t size;
+    };
+    struct packet_header_t {
+      std::int64_t frame_index;
+      std::uint32_t data_size;
+      std::uint8_t idr;
+      std::uint8_t after_rfi;
+    };
+    struct invalidate_t {
+      std::int64_t first;
+      std::int64_t last;
+    };
+    struct start_t {
+      std::uint32_t magic;
+      std::uint32_t protocol_version;
+      video::config_t config;
+      video::encoder_probe_snapshot_t encoder;
+      std::uint8_t direct_vgd;
+      std::uint8_t reserved[7];
+      std::uint64_t vgd_session_id;
+      std::uint32_t vgd_ring_slots;
+      std::uint32_t vgd_transport_flags;
+      std::uint32_t vgd_generation;
+      char vgd_display_name[64];
+    };
+#pragma pack(pop)
+
+    std::string g_child_pipe;
+    std::uint32_t g_parent_pid {};
+    constexpr std::uint32_t kProtocolMagic = 0x4C565750;  // LVWP
+    constexpr std::uint32_t kProtocolVersion = 3;
+    constexpr std::size_t kMaxPacketPayload = 32u * 1024u * 1024u - sizeof(packet_header_t);
+
+    static_assert(std::is_trivially_copyable_v<video::config_t>);
+    static_assert(std::is_trivially_copyable_v<video::encoder_probe_snapshot_t>);
+    static_assert(std::is_trivially_copyable_v<start_t>);
+    static_assert(std::is_trivially_copyable_v<video::hdr_info_raw_t>);
+    static_assert(std::is_trivially_copyable_v<input::touch_port_t>);
+
+    std::vector<std::uint8_t> materialize_packet(video::packet_raw_t &packet) {
+      if (packet.data_size() > kMaxPacketPayload) {
+        return {};
+      }
+      std::vector<std::uint8_t> bytes(packet.data(), packet.data() + packet.data_size());
+      if (!packet.is_idr() || !packet.replacements) {
+        return bytes;
+      }
+      for (const auto &replacement : *packet.replacements) {
+        if (replacement.old.empty()) continue;
+        std::vector<std::uint8_t> rewritten;
+        const auto old_begin = reinterpret_cast<const std::uint8_t *>(replacement.old.data());
+        const auto new_begin = reinterpret_cast<const std::uint8_t *>(replacement._new.data());
+        for (std::size_t offset = 0; offset < bytes.size();) {
+          if (offset + replacement.old.size() <= bytes.size() &&
+              std::equal(old_begin, old_begin + replacement.old.size(), bytes.begin() + offset)) {
+            if (rewritten.size() > kMaxPacketPayload - replacement._new.size()) return {};
+            rewritten.insert(rewritten.end(), new_begin, new_begin + replacement._new.size());
+            offset += replacement.old.size();
+          } else {
+            if (rewritten.size() == kMaxPacketPayload) return {};
+            rewritten.push_back(bytes[offset++]);
+          }
+        }
+        bytes = std::move(rewritten);
+      }
+      return bytes;
+    }
+
+    bool wait_overlapped(HANDLE pipe, OVERLAPPED &overlapped, DWORD timeout, DWORD &transferred) {
+      const DWORD wait = ::WaitForSingleObject(overlapped.hEvent, timeout);
+      if (wait != WAIT_OBJECT_0) {
+        (void) ::CancelIoEx(pipe, &overlapped);
+        // OVERLAPPED and its event are stack-owned. They must remain alive
+        // until cancellation is observed as complete.
+        (void) ::WaitForSingleObject(overlapped.hEvent, INFINITE);
+        DWORD ignored = 0;
+        (void) ::GetOverlappedResult(pipe, &overlapped, &ignored, FALSE);
+        return false;
+      }
+      return ::GetOverlappedResult(pipe, &overlapped, &transferred, FALSE) != FALSE;
+    }
+
+    bool write_exact(HANDLE pipe, const void *data, std::uint32_t size) {
+      const auto *cursor = static_cast<const std::uint8_t *>(data);
+      while (size) {
+        DWORD written = 0;
+        OVERLAPPED overlapped {};
+        overlapped.hEvent = ::CreateEventW(nullptr, TRUE, FALSE, nullptr);
+        if (!overlapped.hEvent) return false;
+        const BOOL started = ::WriteFile(pipe, cursor, size, &written, &overlapped);
+        const DWORD error = started ? ERROR_SUCCESS : ::GetLastError();
+        const bool ok = started || (error == ERROR_IO_PENDING && wait_overlapped(pipe, overlapped, 500, written));
+        ::CloseHandle(overlapped.hEvent);
+        if (!ok || written == 0) {
+          return false;
+        }
+        cursor += written;
+        size -= written;
+      }
+      return true;
+    }
+
+    bool read_exact(HANDLE pipe, void *data, std::uint32_t size, DWORD timeout = INFINITE) {
+      auto *cursor = static_cast<std::uint8_t *>(data);
+      while (size) {
+        DWORD read = 0;
+        OVERLAPPED overlapped {};
+        overlapped.hEvent = ::CreateEventW(nullptr, TRUE, FALSE, nullptr);
+        if (!overlapped.hEvent) return false;
+        const BOOL started = ::ReadFile(pipe, cursor, size, &read, &overlapped);
+        const DWORD error = started ? ERROR_SUCCESS : ::GetLastError();
+        const bool ok = started || (error == ERROR_IO_PENDING && wait_overlapped(pipe, overlapped, timeout, read));
+        ::CloseHandle(overlapped.hEvent);
+        if (!ok || read == 0) {
+          return false;
+        }
+        cursor += read;
+        size -= read;
+      }
+      return true;
+    }
+
+    bool send(HANDLE pipe, message_e type, const void *payload = nullptr, std::uint32_t size = 0) {
+      const header_t header {type, size};
+      return write_exact(pipe, &header, sizeof(header)) && (!size || write_exact(pipe, payload, size));
+    }
+
+    bool receive(HANDLE pipe, header_t &header, std::vector<std::uint8_t> &payload, DWORD timeout = INFINITE) {
+      if (!read_exact(pipe, &header, sizeof(header), timeout)) {
+        return false;
+      }
+      const auto valid_size = [&] {
+        switch (header.type) {
+          case message_e::start: return header.size == sizeof(start_t);
+          case message_e::shutdown:
+          case message_e::idr:
+          case message_e::chroma_downgrade:
+          case message_e::finished:
+          case message_e::heartbeat:
+          case message_e::encoder_ready:
+          case message_e::capture_ready:
+          case message_e::startup_error: return header.size == 0;
+          case message_e::invalidate: return header.size == sizeof(invalidate_t);
+          case message_e::hdr: return header.size == sizeof(video::hdr_info_raw_t);
+          case message_e::touch: return header.size == sizeof(input::touch_port_t);
+          case message_e::packet:
+            return header.size >= sizeof(packet_header_t) && header.size <= 32u * 1024u * 1024u;
+        }
+        return false;
+      }();
+      if (!valid_size) return false;
+      payload.resize(header.size);
+      return !header.size || read_exact(pipe, payload.data(), header.size, timeout);
+    }
+
+    std::wstring executable_path() {
+      std::wstring path(32768, L'\0');
+      const DWORD size = ::GetModuleFileNameW(nullptr, path.data(), static_cast<DWORD>(path.size()));
+      if (!size || size >= path.size()) {
+        return {};
+      }
+      path.resize(size);
+      return path;
+    }
+
+    std::wstring widen_ascii(std::string_view value) {
+      return {value.begin(), value.end()};
+    }
+
+    std::string random_pipe_name() {
+      std::array<std::uint8_t, 16> random {};
+      if (::BCryptGenRandom(nullptr, random.data(), static_cast<ULONG>(random.size()), BCRYPT_USE_SYSTEM_PREFERRED_RNG) < 0) {
+        return {};
+      }
+      constexpr char hex[] = "0123456789abcdef";
+      std::string name = "LuminalShineVideo-";
+      for (const auto byte : random) {
+        name.push_back(hex[byte >> 4]);
+        name.push_back(hex[byte & 0x0f]);
+      }
+      return name;
+    }
+
+    bool make_pipe_security(SECURITY_ATTRIBUTES &attributes, PSECURITY_DESCRIPTOR &descriptor) {
+      HANDLE token = nullptr;
+      if (!::OpenProcessToken(::GetCurrentProcess(), TOKEN_QUERY, &token)) return false;
+      auto close_token = util::fail_guard([&] { ::CloseHandle(token); });
+      DWORD bytes = 0;
+      (void) ::GetTokenInformation(token, TokenUser, nullptr, 0, &bytes);
+      if (!bytes || ::GetLastError() != ERROR_INSUFFICIENT_BUFFER) return false;
+      std::vector<std::uint8_t> storage(bytes);
+      if (!::GetTokenInformation(token, TokenUser, storage.data(), bytes, &bytes)) return false;
+      const auto *token_user = reinterpret_cast<const TOKEN_USER *>(storage.data());
+      LPWSTR sid_text = nullptr;
+      if (!::ConvertSidToStringSidW(token_user->User.Sid, &sid_text)) return false;
+      auto free_sid = util::fail_guard([&] { ::LocalFree(sid_text); });
+      const std::wstring sddl = L"D:P(A;;GA;;;SY)(A;;GA;;;" + std::wstring(sid_text) + L")";
+      if (!::ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl.c_str(), SDDL_REVISION_1, &descriptor, nullptr)) {
+        return false;
+      }
+      attributes = {sizeof(attributes), descriptor, FALSE};
+      return true;
+    }
+
+    struct child_t {
+      HANDLE pipe {INVALID_HANDLE_VALUE};
+      HANDLE process {nullptr};
+      HANDLE job {nullptr};
+      DWORD pid {0};
+
+      ~child_t() {
+        if (pipe != INVALID_HANDLE_VALUE) ::CloseHandle(pipe);
+        if (process) ::CloseHandle(process);
+        if (job) ::CloseHandle(job);
+      }
+    };
+
+    bool launch(child_t &child, const std::string &pipe_name) {
+      const auto exe = executable_path();
+      if (exe.empty()) return false;
+
+      std::wstring command = L"\"" + exe + L"\" --internal-video-worker \"" + widen_ascii(pipe_name) +
+                             L"\" " + std::to_wstring(::GetCurrentProcessId());
+      STARTUPINFOW startup {.cb = sizeof(STARTUPINFOW)};
+      PROCESS_INFORMATION process {};
+      if (!::CreateProcessW(exe.c_str(), command.data(), nullptr, nullptr, FALSE,
+                            CREATE_NO_WINDOW | CREATE_SUSPENDED, nullptr, nullptr, &startup, &process)) {
+        BOOST_LOG(error) << "Video worker: CreateProcess failed (err=" << ::GetLastError() << ')';
+        return false;
+      }
+      child.process = process.hProcess;
+      child.pid = process.dwProcessId;
+
+      child.job = ::CreateJobObjectW(nullptr, nullptr);
+      if (child.job) {
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits {};
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        if (::SetInformationJobObject(child.job, JobObjectExtendedLimitInformation, &limits, sizeof(limits)) &&
+            !::AssignProcessToJobObject(child.job, child.process)) {
+          BOOST_LOG(warning) << "Video worker: job assignment failed (err=" << ::GetLastError()
+                             << "); explicit termination remains armed.";
+        }
+      }
+      if (::ResumeThread(process.hThread) == static_cast<DWORD>(-1)) {
+        BOOST_LOG(error) << "Video worker: ResumeThread failed (err=" << ::GetLastError() << ')';
+        ::TerminateProcess(child.process, 0xE002);
+        ::CloseHandle(process.hThread);
+        return false;
+      }
+      ::CloseHandle(process.hThread);
+      return true;
+    }
+  }
+
+  bool is_child_process() {
+    return !g_child_pipe.empty();
+  }
+
+  void set_child_pipe(std::string pipe_name, std::uint32_t parent_pid) {
+    g_child_pipe = std::move(pipe_name);
+    g_parent_pid = parent_pid;
+  }
+
+  int run_child() {
+    const auto full_name = L"\\\\.\\pipe\\" + widen_ascii(g_child_pipe);
+    HANDLE pipe = INVALID_HANDLE_VALUE;
+    const auto deadline = std::chrono::steady_clock::now() + 10s;
+    do {
+      pipe = ::CreateFileW(full_name.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, nullptr);
+      if (pipe != INVALID_HANDLE_VALUE) break;
+      ::WaitNamedPipeW(full_name.c_str(), 250);
+    } while (std::chrono::steady_clock::now() < deadline);
+    if (pipe == INVALID_HANDLE_VALUE) return 10;
+    auto close_pipe = util::fail_guard([&] { ::CloseHandle(pipe); });
+
+    ULONG server_pid = 0;
+    if (!::GetNamedPipeServerProcessId(pipe, &server_pid) || server_pid != g_parent_pid) {
+      BOOST_LOG(error) << "Video worker: rejected unexpected pipe server pid=" << server_pid
+                       << " expected=" << g_parent_pid;
+      return 15;
+    }
+
+    header_t header {};
+    std::vector<std::uint8_t> payload;
+    if (!receive(pipe, header, payload) || header.type != message_e::start || payload.size() != sizeof(start_t)) {
+      return 11;
+    }
+    start_t start {};
+    std::memcpy(&start, payload.data(), sizeof(start));
+
+    if (start.magic != kProtocolMagic || start.protocol_version != kProtocolVersion) {
+      (void) send(pipe, message_e::startup_error);
+      return 18;
+    }
+
+    if (start.direct_vgd > 1 || std::any_of(std::begin(start.reserved), std::end(start.reserved),
+                                            [](std::uint8_t value) { return value != 0; })) {
+      (void) send(pipe, message_e::startup_error);
+      return 19;
+    }
+    if (start.direct_vgd) {
+      const auto display_end = std::find(std::begin(start.vgd_display_name), std::end(start.vgd_display_name), '\0');
+      if (!start.vgd_session_id ||
+          start.vgd_ring_slots < VDISPLAY::vgd::kMinRingSlots ||
+          start.vgd_ring_slots > VDISPLAY::vgd::kMaxRingSlots ||
+          (start.vgd_transport_flags & ~VDISPLAY::vgd::kAllowedRingTransportFlags) != 0 ||
+          start.vgd_generation == 0 || display_end == std::end(start.vgd_display_name) ||
+          display_end == std::begin(start.vgd_display_name)) {
+        (void) send(pipe, message_e::startup_error);
+        return 20;
+      }
+      const std::string display_name(start.vgd_display_name, display_end);
+      VDISPLAY::vgd::set_worker_ring_target(VDISPLAY::vgd::RingTargetInfo {
+        start.vgd_session_id, start.vgd_ring_slots, start.vgd_transport_flags, start.vgd_generation
+      }, display_name);
+      BOOST_LOG(info) << "Video worker: imported direct LuminalVGD ring target session 0x"
+                      << std::hex << start.vgd_session_id << std::dec
+                      << " generation " << start.vgd_generation
+                      << " (" << start.vgd_ring_slots << " slots) for " << display_name << '.';
+    } else {
+      VDISPLAY::vgd::set_worker_ring_target(std::nullopt);
+    }
+
+    if (!video::import_encoder_probe_snapshot(start.encoder)) {
+      BOOST_LOG(error) << "Video worker: rejected invalid or unavailable encoder capability snapshot.";
+      (void) send(pipe, message_e::startup_error);
+      return 12;
+    }
+    if (start.config.videoFormat < 0 || start.config.videoFormat > 2 ||
+        start.config.dynamicRange < 0 || start.config.dynamicRange > 1 ||
+        start.config.chromaSamplingType < 0 || start.config.chromaSamplingType > 1) {
+      (void) send(pipe, message_e::startup_error);
+      return 16;
+    }
+    const auto codec = static_cast<std::size_t>(start.config.videoFormat);
+    const auto dynamic_range_mask = std::uint32_t {1} << video::encoder_t::DYNAMIC_RANGE;
+    const auto yuv444_mask = std::uint32_t {1} << video::encoder_t::YUV444;
+    if (!start.encoder.supported_codec[codec] ||
+        (start.config.dynamicRange && !(start.encoder.codec_capabilities[codec] & dynamic_range_mask)) ||
+        (start.config.chromaSamplingType && !(start.encoder.codec_capabilities[codec] & yuv444_mask))) {
+      BOOST_LOG(error) << "Video worker: requested stream format is inconsistent with the validated encoder snapshot.";
+      (void) send(pipe, message_e::startup_error);
+      return 17;
+    }
+    if (!send(pipe, message_e::encoder_ready)) {
+      return 14;
+    }
+
+    auto session_mail = std::make_shared<safe::mail_raw_t>();
+    auto shutdown = session_mail->event<bool>(mail::shutdown);
+    std::atomic_bool commands_done {false};
+    std::mutex write_mutex;
+
+    std::thread commands([&] {
+      header_t command {};
+      std::vector<std::uint8_t> body;
+      while (receive(pipe, command, body)) {
+        if (command.type == message_e::shutdown) {
+          shutdown->raise(true);
+          break;
+        } else if (command.type == message_e::idr) {
+          session_mail->event<bool>(mail::idr)->raise(true);
+        } else if (command.type == message_e::invalidate && body.size() == sizeof(invalidate_t)) {
+          invalidate_t wire {};
+          std::memcpy(&wire, body.data(), sizeof(wire));
+          session_mail->event<std::pair<std::int64_t, std::int64_t>>(mail::invalidate_ref_frames)->raise(
+            std::make_pair(wire.first, wire.last)
+          );
+        } else {
+          BOOST_LOG(error) << "Video worker: rejected an out-of-state parent IPC message.";
+          shutdown->raise(true);
+          break;
+        }
+      }
+      commands_done.store(true, std::memory_order_release);
+      shutdown->raise(true);
+    });
+
+    std::thread output([&] {
+      auto packets = mail::man->queue<video::packet_t>(mail::video_packets);
+      auto hdr = session_mail->event<video::hdr_info_t>(mail::hdr);
+      auto touch = session_mail->event<input::touch_port_t>(mail::touch_port);
+      auto chroma = session_mail->event<bool>(mail::chroma_downgrade);
+      bool capture_ready_sent = false;
+      while (!shutdown->peek()) {
+        if (auto packet = packets->pop(20ms)) {
+          auto encoded_bytes = materialize_packet(*packet);
+          if (encoded_bytes.empty()) {
+            BOOST_LOG(error) << "Video worker: encoded packet exceeded the 32 MiB IPC limit.";
+            shutdown->raise(true);
+            break;
+          }
+          packet_header_t packet_header {
+            packet->frame_index(), static_cast<std::uint32_t>(encoded_bytes.size()),
+            static_cast<std::uint8_t>(packet->is_idr()),
+            static_cast<std::uint8_t>(packet->after_ref_frame_invalidation)
+          };
+          std::vector<std::uint8_t> body(sizeof(packet_header) + packet_header.data_size);
+          std::memcpy(body.data(), &packet_header, sizeof(packet_header));
+          std::memcpy(body.data() + sizeof(packet_header), encoded_bytes.data(), packet_header.data_size);
+          std::lock_guard lock(write_mutex);
+          if (!capture_ready_sent) {
+            // This is truthful readiness: display capture, conversion and the
+            // encoder have all succeeded and a valid first packet exists.
+            if (!send(pipe, message_e::capture_ready)) break;
+            capture_ready_sent = true;
+          }
+          if (!send(pipe, message_e::packet, body.data(), static_cast<std::uint32_t>(body.size()))) break;
+        }
+        if (auto value = hdr->pop(0ms)) {
+          std::lock_guard lock(write_mutex);
+          if (!send(pipe, message_e::hdr, value.get(), sizeof(video::hdr_info_raw_t))) break;
+        }
+        if (auto value = touch->pop(0ms)) {
+          std::lock_guard lock(write_mutex);
+          if (!send(pipe, message_e::touch, &*value, sizeof(*value))) break;
+        }
+        if (chroma->pop(0ms)) {
+          std::lock_guard lock(write_mutex);
+          if (!send(pipe, message_e::chroma_downgrade)) break;
+        }
+      }
+    });
+
+    video::capture(session_mail, start.config, nullptr);
+    shutdown->raise(true);
+    {
+      std::lock_guard lock(write_mutex);
+      (void) send(pipe, message_e::finished);
+    }
+    (void) ::CancelIoEx(pipe, nullptr);
+    ::CloseHandle(pipe);
+    close_pipe.disable();
+    if (commands.joinable()) commands.join();
+    if (output.joinable()) output.join();
+    return 0;
+  }
+
+  bool capture(safe::mail_t mail, video::config_t config, void *channel_data) {
+    if (is_child_process()) return false;
+
+    start_t start {};
+    start.magic = kProtocolMagic;
+    start.protocol_version = kProtocolVersion;
+    start.config = config;
+    if (!video::export_encoder_probe_snapshot(start.encoder)) {
+      BOOST_LOG(error) << "Video worker: parent has no validated encoder snapshot; using in-process pipeline.";
+      return false;
+    }
+    const bool direct_vgd = VDISPLAY::is_luminalvgd_active();
+    if (direct_vgd) {
+      const auto display_name = display_device::map_output_name(::config::get_active_output_name());
+      const auto target = VDISPLAY::vgd::ring_target_for_worker_display(display_name);
+      if (!target) {
+        BOOST_LOG(warning) << "Video worker: direct LuminalVGD session has no transferable ring target for '"
+                           << display_name << "'; bypassing worker and using the parent capture pipeline immediately.";
+        return false;
+      }
+      if (display_name.size() >= sizeof(start.vgd_display_name)) {
+        BOOST_LOG(warning) << "Video worker: direct LuminalVGD display name exceeds the IPC limit; "
+                              "using the parent capture pipeline immediately.";
+        return false;
+      }
+      start.direct_vgd = 1;
+      start.vgd_session_id = target->session_id;
+      start.vgd_ring_slots = target->ring_slots;
+      start.vgd_transport_flags = target->transport_flags;
+      start.vgd_generation = target->generation;
+      std::copy(display_name.begin(), display_name.end(), std::begin(start.vgd_display_name));
+    }
+
+    const std::string pipe_name = random_pipe_name();
+    if (pipe_name.empty()) return false;
+    const auto full_name = L"\\\\.\\pipe\\" + widen_ascii(pipe_name);
+    child_t child;
+    SECURITY_ATTRIBUTES pipe_security {};
+    PSECURITY_DESCRIPTOR pipe_descriptor = nullptr;
+    if (!make_pipe_security(pipe_security, pipe_descriptor)) {
+      BOOST_LOG(error) << "Video worker: failed to construct a restricted named-pipe ACL; using in-process pipeline.";
+      return false;
+    }
+    auto free_pipe_descriptor = util::fail_guard([&] { ::LocalFree(pipe_descriptor); });
+    child.pipe = ::CreateNamedPipeW(full_name.c_str(), PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED | FILE_FLAG_FIRST_PIPE_INSTANCE,
+                                    PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+                                    1, 4 * 1024 * 1024, 64 * 1024, 0, &pipe_security);
+    if (child.pipe == INVALID_HANDLE_VALUE || !launch(child, pipe_name)) {
+      BOOST_LOG(error) << "Video worker: failed to establish isolated process; using in-process pipeline.";
+      return false;
+    }
+    OVERLAPPED connect {};
+    connect.hEvent = ::CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    BOOL connected = ::ConnectNamedPipe(child.pipe, &connect);
+    const DWORD connect_error = connected ? ERROR_SUCCESS : ::GetLastError();
+    bool connect_ok = connected || connect_error == ERROR_PIPE_CONNECTED;
+    if (!connect_ok && connect_error == ERROR_IO_PENDING) {
+      HANDLE waits[] {connect.hEvent, child.process};
+      connect_ok = ::WaitForMultipleObjects(2, waits, FALSE, 10000) == WAIT_OBJECT_0;
+      if (connect_ok) {
+        DWORD ignored = 0;
+        connect_ok = ::GetOverlappedResult(child.pipe, &connect, &ignored, FALSE) != FALSE;
+      }
+    }
+    if (!connect_ok) {
+      (void) ::CancelIoEx(child.pipe, &connect);
+      (void) ::WaitForSingleObject(connect.hEvent, INFINITE);
+      DWORD ignored = 0;
+      (void) ::GetOverlappedResult(child.pipe, &connect, &ignored, FALSE);
+      if (connect.hEvent) ::CloseHandle(connect.hEvent);
+      ::TerminateProcess(child.process, 0xE003);
+      (void) ::WaitForSingleObject(child.process, 1000);
+      BOOST_LOG(error) << "Video worker: child did not connect within 10 seconds.";
+      return false;
+    }
+    if (connect.hEvent) ::CloseHandle(connect.hEvent);
+    ULONG client_pid = 0;
+    if (!::GetNamedPipeClientProcessId(child.pipe, &client_pid) || client_pid != child.pid) {
+      BOOST_LOG(error) << "Video worker: rejected unexpected pipe client pid=" << client_pid
+                       << " expected=" << child.pid;
+      ::TerminateProcess(child.process, 0xE004);
+      return false;
+    }
+    BOOST_LOG(info) << "Video worker: isolated capture/encode process started (pid=" << child.pid << ")";
+    if (!send(child.pipe, message_e::start, &start, sizeof(start))) {
+      BOOST_LOG(error) << "Video worker: failed to send startup state; using in-process pipeline.";
+      ::TerminateProcess(child.process, 0xE005);
+      (void) ::WaitForSingleObject(child.process, 1000);
+      return false;
+    }
+
+    // Do not hand the session to a worker that has not accepted the parent's
+    // validated encoder state and completed its capture-only bootstrap. This
+    // deadline deliberately fits inside the client's initial-frame timeout.
+    header_t ready_header {};
+    std::vector<std::uint8_t> ready_payload;
+    const bool encoder_ready = receive(child.pipe, ready_header, ready_payload, 1500) &&
+                               ready_header.type == message_e::encoder_ready;
+    const bool capture_ready = encoder_ready && receive(child.pipe, ready_header, ready_payload, 7000) &&
+                               ready_header.type == message_e::capture_ready;
+    if (!capture_ready) {
+      BOOST_LOG(error) << "Video worker: capture bootstrap did not produce a first encoded packet within its deadline.";
+      (void) ::CancelIoEx(child.pipe, nullptr);
+      ::TerminateProcess(child.process, 0xE006);
+      const bool worker_reaped = ::WaitForSingleObject(child.process, 3000) == WAIT_OBJECT_0;
+      ::DisconnectNamedPipe(child.pipe);
+      if (!worker_reaped) {
+        BOOST_LOG(error) << "Video worker: process remains stuck after termination; refusing unsafe in-process GPU fallback.";
+        return true;
+      }
+      if (!encoder_ready || ready_header.type == message_e::startup_error) {
+        BOOST_LOG(warning) << "Video worker: failure occurred before GPU capture startup; using in-process pipeline.";
+        return false;
+      }
+      const auto health = platf::dxgi::D3D11ProbeDeviceHealth();
+      if (FAILED(health)) {
+        BOOST_LOG(error) << "Video worker: display health probe failed after worker termination (hresult=0x"
+                         << std::hex << health << std::dec << "); refusing unsafe in-process GPU fallback.";
+        return true;
+      }
+      BOOST_LOG(warning) << "Video worker: process exited and display health is good; using in-process pipeline.";
+      return false;
+    }
+    BOOST_LOG(info) << "Video worker: validated encoder snapshot accepted; capture pipeline ready.";
+
+    auto shutdown = mail->event<bool>(mail::shutdown);
+    std::atomic_bool reader_done {false};
+    std::atomic<std::int64_t> last_frame_ms {0};
+    std::atomic_bool first_frame_seen {false};
+    const auto now_ms = [] { return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count(); };
+    last_frame_ms.store(now_ms(), std::memory_order_release);
+
+    std::thread reader([&] {
+      header_t header {};
+      std::vector<std::uint8_t> body;
+      auto packets = mail::man->queue<video::packet_t>(mail::video_packets);
+      while (receive(child.pipe, header, body)) {
+        if (header.type == message_e::finished) break;
+        if (header.type == message_e::packet && body.size() >= sizeof(packet_header_t)) {
+          packet_header_t packet_header {};
+          std::memcpy(&packet_header, body.data(), sizeof(packet_header));
+          if (packet_header.data_size <= body.size() - sizeof(packet_header) &&
+              body.size() - sizeof(packet_header) == packet_header.data_size) {
+            std::vector<std::uint8_t> bytes(packet_header.data_size);
+            std::memcpy(bytes.data(), body.data() + sizeof(packet_header), bytes.size());
+            auto packet = std::make_unique<video::packet_raw_generic>(std::move(bytes), packet_header.frame_index, packet_header.idr != 0);
+            packet->after_ref_frame_invalidation = packet_header.after_rfi != 0;
+            packet->channel_data = channel_data;
+            packets->raise(std::move(packet));
+            first_frame_seen.store(true, std::memory_order_release);
+            last_frame_ms.store(now_ms(), std::memory_order_release);
+          }
+        } else if (header.type == message_e::hdr && body.size() == sizeof(video::hdr_info_raw_t)) {
+          video::hdr_info_raw_t value {false};
+          std::memcpy(&value, body.data(), sizeof(value));
+          mail->event<video::hdr_info_t>(mail::hdr)->raise(std::make_unique<video::hdr_info_raw_t>(value));
+        } else if (header.type == message_e::touch && body.size() == sizeof(input::touch_port_t)) {
+          input::touch_port_t value {};
+          std::memcpy(&value, body.data(), sizeof(value));
+          mail->event<input::touch_port_t>(mail::touch_port)->raise(value);
+        } else if (header.type == message_e::chroma_downgrade) {
+          mail->event<bool>(mail::chroma_downgrade)->raise(true);
+        } else if (header.type != message_e::heartbeat) {
+          BOOST_LOG(error) << "Video worker: rejected an out-of-state child IPC message.";
+          break;
+        }
+      }
+      reader_done.store(true, std::memory_order_release);
+    });
+
+    auto idr = mail->event<bool>(mail::idr);
+    auto invalidate = mail->event<std::pair<std::int64_t, std::int64_t>>(mail::invalidate_ref_frames);
+    bool poisoned = false;
+    while (!shutdown->peek() && !reader_done.load(std::memory_order_acquire)) {
+      if (idr->pop(25ms)) (void) send(child.pipe, message_e::idr);
+      while (auto range = invalidate->pop(0ms)) {
+        const invalidate_t wire {range->first, range->second};
+        (void) send(child.pipe, message_e::invalidate, &wire, sizeof(wire));
+      }
+      const auto silence_ms = now_ms() - last_frame_ms.load(std::memory_order_acquire);
+      const auto deadline_ms = first_frame_seen.load(std::memory_order_acquire) ? 3000 : 7000;
+      if (silence_ms > deadline_ms) {
+        BOOST_LOG(error) << "Video worker: encoded-frame progress stalled for " << silence_ms
+                         << " ms; terminating poisoned GPU worker without blocking the host.";
+        poisoned = true;
+        break;
+      }
+    }
+    if (!poisoned) {
+      (void) send(child.pipe, message_e::shutdown);
+    } else {
+      ::TerminateProcess(child.process, 0xE001);
+    }
+    if (::WaitForSingleObject(child.process, 2000) == WAIT_TIMEOUT) {
+      BOOST_LOG(warning) << "Video worker: bounded shutdown expired; terminating worker process.";
+      ::TerminateProcess(child.process, 0xE001);
+      (void) ::WaitForSingleObject(child.process, 500);
+    }
+    (void) ::CancelIoEx(child.pipe, nullptr);
+    ::DisconnectNamedPipe(child.pipe);
+    if (reader.joinable()) reader.join();
+    BOOST_LOG(info) << "Video worker: isolated capture/encode process ended.";
+    return true;
+  }
+}

--- a/src/platform/windows/video_worker.h
+++ b/src/platform/windows/video_worker.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "src/thread_safe.h"
+#include "src/video.h"
+
+namespace platf::video_worker {
+  bool is_child_process();
+  void set_child_pipe(std::string pipe_name, std::uint32_t parent_pid);
+  int run_child();
+
+  /** Run capture+encode in a crash-isolated child process. */
+  bool capture(safe::mail_t mail, video::config_t config, void *channel_data);
+}

--- a/src/platform/windows/virtual_display_cleanup.cpp
+++ b/src/platform/windows/virtual_display_cleanup.cpp
@@ -115,9 +115,14 @@ namespace platf::virtual_display_cleanup {
 
       result.helper_revert_dispatched = display_helper_integration::revert(prefer_golden_if_current_missing);
       if (result.helper_revert_dispatched) {
-        // REVERT is accepted synchronously but executes after the helper's
-        // reconnect grace period. Observable topology is the completion ACK.
-        result.physical_display_verified = wait_for_physical_display(std::chrono::seconds(12));
+        // A retained OLED recovery anchor is already an active physical
+        // display, so presence is not proof of restoration. The helper exits
+        // only after strict snapshot + layout verification; wait for that
+        // transaction boundary before removing LuminalVGD.
+        const bool restore_completed =
+          display_helper_integration::wait_for_revert_completion(std::chrono::seconds(30));
+        result.physical_display_verified = restore_completed &&
+                                           wait_for_physical_display(std::chrono::seconds(2));
       }
 
       if (!result.physical_display_verified) {
@@ -126,7 +131,10 @@ namespace platf::virtual_display_cleanup {
         if (result.helper_restarted) {
           result.helper_revert_dispatched =
             display_helper_integration::revert(prefer_golden_if_current_missing) || result.helper_revert_dispatched;
-          result.physical_display_verified = wait_for_physical_display(std::chrono::seconds(12));
+          const bool restore_completed =
+            display_helper_integration::wait_for_revert_completion(std::chrono::seconds(30));
+          result.physical_display_verified = restore_completed &&
+                                             wait_for_physical_display(std::chrono::seconds(2));
         }
       }
 

--- a/src/platform/windows/virtual_display_vgd.cpp
+++ b/src/platform/windows/virtual_display_vgd.cpp
@@ -69,6 +69,8 @@ namespace VDISPLAY::vgd {
     VgdDeviceHandle *g_device = nullptr;
     std::optional<VgdCaps> g_caps;
     std::map<GuidKey, TrackedSession> g_sessions;
+    std::optional<RingTargetInfo> g_worker_ring_target;
+    std::string g_worker_ring_display_name;
     std::thread g_ping_thread;
     std::atomic<bool> g_ping_stop {false};
     std::atomic<bool> g_ping_feeding {true};
@@ -633,6 +635,9 @@ namespace VDISPLAY::vgd {
   std::optional<RingTargetInfo> ring_target_for_display(const std::string &display_name) {
     std::wstring wanted(display_name.begin(), display_name.end());
     std::unique_lock lk(g_mutex);
+    if (g_worker_ring_target && !display_name.empty() && display_name == g_worker_ring_display_name) {
+      return g_worker_ring_target;
+    }
     if (g_sessions.empty()) {
       return std::nullopt;
     }
@@ -730,6 +735,57 @@ namespace VDISPLAY::vgd {
     BOOST_LOG(warning) << "LuminalVGD: no tracked session matches display '"
                        << display_name << "' (" << g_sessions.size() << " sessions).";
     return std::nullopt;
+  }
+
+  std::optional<RingTargetInfo> ring_target_for_worker_display(const std::string &display_name) {
+    if (display_name.empty()) return std::nullopt;
+    RingTargetInfo target {};
+    {
+      const std::wstring wanted(display_name.begin(), display_name.end());
+      std::lock_guard lk(g_mutex);
+      const auto found = std::find_if(g_sessions.begin(), g_sessions.end(), [&](const auto &entry) {
+        return !entry.second.display_name.empty() && entry.second.display_name == wanted;
+      });
+      if (found == g_sessions.end()) return std::nullopt;
+      target = {found->second.session_id, found->second.ring_slots, found->second.transport_flags, 0};
+    }
+    if (target.ring_slots < kMinRingSlots || target.ring_slots > kMaxRingSlots ||
+        (target.transport_flags & ~kAllowedRingTransportFlags) != 0) {
+      return std::nullopt;
+    }
+    VgdRingHandle *ring = vgd_ring_open(target.session_id, target.ring_slots);
+    if (!ring) return std::nullopt;
+    VgdRingStatus status {};
+    const auto status_result = vgd_ring_status(ring, &status);
+    vgd_ring_close(ring);
+    if (status_result != 0 || status.state != 1 || status.generation == 0 ||
+        status.latest_sequence == 0 || status.heartbeat_qpc == 0 || status.qpc_frequency == 0 ||
+        (status.transport_flags & ~kAllowedRingTransportFlags) != 0) {
+      return std::nullopt;
+    }
+    LARGE_INTEGER now_qpc {};
+    QueryPerformanceCounter(&now_qpc);
+    if (now_qpc.QuadPart < 0 || static_cast<uint64_t>(now_qpc.QuadPart) < status.heartbeat_qpc ||
+        static_cast<uint64_t>(now_qpc.QuadPart) - status.heartbeat_qpc > status.qpc_frequency * 2ULL) {
+      return std::nullopt;
+    }
+    target.generation = status.generation;
+    // The driver may downgrade the requested fence transport for a live
+    // generation. Hand off what the ring actually selected, not the flags
+    // remembered at monitor creation.
+    target.transport_flags = status.transport_flags;
+    return target;
+  }
+
+  void set_worker_ring_target(std::optional<RingTargetInfo> target, std::string display_name) {
+    std::lock_guard lk(g_mutex);
+    g_worker_ring_target = std::move(target);
+    g_worker_ring_display_name = g_worker_ring_target ? std::move(display_name) : std::string {};
+  }
+
+  bool has_worker_ring_target() {
+    std::lock_guard lk(g_mutex);
+    return g_worker_ring_target.has_value();
   }
 
   std::optional<RingTransitionToken> begin_planned_modeset() {

--- a/src/platform/windows/virtual_display_vgd.h
+++ b/src/platform/windows/virtual_display_vgd.h
@@ -75,13 +75,29 @@ namespace VDISPLAY::vgd {
     uint64_t session_id;
     uint32_t ring_slots;
     uint32_t transport_flags;
+    uint32_t generation {0};
   };
+
+  inline constexpr uint32_t kMinRingSlots = 2;
+  inline constexpr uint32_t kMaxRingSlots = 8;
+  inline constexpr uint32_t kAllowedRingTransportFlags = 4;  // VGD_CREATE_D3D12_FENCE_TRANSPORT
 
   /// Resolve the tracked session whose monitor backs `display_name`
   /// (e.g. "\\\\.\\DISPLAY274"). With a single tracked session (the
   /// common per-client case) that session is returned directly;
   /// otherwise the session whose recorded display name matches wins.
   std::optional<RingTargetInfo> ring_target_for_display(const std::string &display_name);
+
+  /// Strict IPC handoff lookup: unlike ring_target_for_display(), this never
+  /// adopts a sole/unnamed session. It requires an exact active GDI display
+  /// match and snapshots the current ACTIVE ring generation.
+  std::optional<RingTargetInfo> ring_target_for_worker_display(const std::string &display_name);
+
+  /// Install a process-local ring identity imported by an authenticated
+  /// isolated video worker. The worker has no copy of the parent's tracked
+  /// monitor map, but the named ring/fence resources are cross-process.
+  void set_worker_ring_target(std::optional<RingTargetInfo> target, std::string display_name = {});
+  bool has_worker_ring_target();
 
   struct RingTransitionToken {
     uint64_t session_id {0};

--- a/src/platform/windows/whea_diagnostics.cpp
+++ b/src/platform/windows/whea_diagnostics.cpp
@@ -1,0 +1,79 @@
+#include <winsock2.h>
+#include <windows.h>
+#include <winevt.h>
+
+#include "whea_diagnostics.h"
+
+#include <string_view>
+#include <vector>
+
+namespace whea_diagnostics {
+  namespace {
+    std::string utf8(std::wstring_view value) {
+      if (value.empty()) return {};
+      const int bytes = WideCharToMultiByte(CP_UTF8, 0, value.data(), static_cast<int>(value.size()), nullptr, 0, nullptr, nullptr);
+      if (bytes <= 0) return {};
+      std::string out(static_cast<std::size_t>(bytes), '\0');
+      WideCharToMultiByte(CP_UTF8, 0, value.data(), static_cast<int>(value.size()), out.data(), bytes, nullptr, nullptr);
+      return out;
+    }
+
+    std::string xml_data(std::string_view xml, std::string_view name) {
+      const std::string needle = "<Data Name='" + std::string(name) + "'>";
+      auto begin = xml.find(needle);
+      if (begin == std::string_view::npos) {
+        const std::string double_needle = "<Data Name=\"" + std::string(name) + "\">";
+        begin = xml.find(double_needle);
+        if (begin == std::string_view::npos) return {};
+        begin += double_needle.size();
+      } else {
+        begin += needle.size();
+      }
+      const auto end = xml.find("</Data>", begin);
+      return end == std::string_view::npos ? std::string {} : std::string(xml.substr(begin, end - begin));
+    }
+  }
+
+  std::optional<std::string> recent_pcie_aer_summary(std::chrono::milliseconds maximum_age) noexcept {
+    try {
+      const auto query_text = std::wstring(
+        L"*[System[Provider[@Name='Microsoft-Windows-WHEA-Logger'] and EventID=17 and "
+        L"TimeCreated[timediff(@SystemTime) <= "
+      ) + std::to_wstring(maximum_age.count()) + L"]]]";
+      EVT_HANDLE query = EvtQuery(nullptr, L"System", query_text.c_str(), EvtQueryChannelPath | EvtQueryReverseDirection);
+      if (!query) return std::nullopt;
+
+      EVT_HANDLE event = nullptr;
+      DWORD returned = 0;
+      const BOOL next_ok = EvtNext(query, 1, &event, 0, 0, &returned);
+      EvtClose(query);
+      if (!next_ok || returned == 0 || !event) return std::nullopt;
+
+      DWORD bytes = 0;
+      DWORD properties = 0;
+      (void) EvtRender(nullptr, event, EvtRenderEventXml, 0, nullptr, &bytes, &properties);
+      if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || bytes == 0) {
+        EvtClose(event);
+        return std::nullopt;
+      }
+      std::vector<wchar_t> buffer((bytes / sizeof(wchar_t)) + 1);
+      if (!EvtRender(nullptr, event, EvtRenderEventXml, bytes, buffer.data(), &bytes, &properties)) {
+        EvtClose(event);
+        return std::nullopt;
+      }
+      EvtClose(event);
+
+      const auto xml = utf8(buffer.data());
+      const auto device = xml_data(xml, "PrimaryDeviceName");
+      const auto uncorrectable = xml_data(xml, "UncorrectableErrorStatus");
+      const auto correctable = xml_data(xml, "CorrectableErrorStatus");
+      std::string summary = "recent WHEA-Logger event 17 (PCIe AER)";
+      if (!device.empty()) summary += "; root_port=" + device;
+      if (!uncorrectable.empty()) summary += "; uncorrectable_status=" + uncorrectable;
+      if (!correctable.empty()) summary += "; correctable_status=" + correctable;
+      return summary;
+    } catch (...) {
+      return std::nullopt;
+    }
+  }
+}

--- a/src/platform/windows/whea_diagnostics.h
+++ b/src/platform/windows/whea_diagnostics.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <chrono>
+#include <optional>
+#include <string>
+
+namespace whea_diagnostics {
+  std::optional<std::string> recent_pcie_aer_summary(
+    std::chrono::milliseconds maximum_age = std::chrono::minutes(2)
+  ) noexcept;
+}

--- a/src/requested_display_mode.h
+++ b/src/requested_display_mode.h
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace display_mode_policy {
+  struct Mode {
+    int width {0};
+    int height {0};
+    int fps {0};
+
+    [[nodiscard]] constexpr bool valid() const noexcept {
+      return width > 0 && height > 0 && fps > 0;
+    }
+
+    constexpr bool operator==(const Mode &) const noexcept = default;
+  };
+
+  [[nodiscard]] constexpr bool should_reconcile(
+    bool virtual_display,
+    bool explicit_per_client_override,
+    Mode launch_mode,
+    Mode rtsp_mode
+  ) noexcept {
+    return virtual_display && !explicit_per_client_override &&
+           rtsp_mode.valid() && launch_mode != rtsp_mode;
+  }
+}  // namespace display_mode_policy

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -29,10 +29,17 @@ extern "C" {
 #include "logging.h"
 #include "network.h"
 #include "nvhttp.h"
+#include "requested_display_mode.h"
 #include "rtsp.h"
 #include "stream.h"
 #include "sync.h"
 #include "video.h"
+
+#ifdef _WIN32
+  #include "src/platform/windows/display_helper_integration.h"
+  #include "src/platform/windows/display_helper_request_helpers.h"
+  #include "src/platform/windows/virtual_display.h"
+#endif
 
 namespace asio = boost::asio;
 
@@ -42,6 +49,82 @@ using asio::ip::udp;
 using namespace std::literals;
 
 namespace rtsp_stream {
+#ifdef _WIN32
+  namespace {
+    bool reconcile_virtual_display_mode(
+      launch_session_t &session,
+      int width,
+      int height,
+      int fps
+    ) {
+      const display_mode_policy::Mode launch_mode {session.width, session.height, session.fps};
+      const display_mode_policy::Mode rtsp_mode {width, height, fps};
+      if (!display_mode_policy::should_reconcile(
+            session.virtual_display,
+            session.client_display_mode_override,
+            launch_mode,
+            rtsp_mode)) {
+        if (session.virtual_display && !session.client_display_mode_override &&
+            launch_mode == rtsp_mode) {
+          BOOST_LOG(info) << "Requested display mode reconciled: HTTP and RTSP agree at "
+                          << width << 'x' << height << '@' << fps << "Hz.";
+        }
+        return true;
+      }
+
+      BOOST_LOG(warning) << "Requested display mode changed between HTTP launch ("
+                         << session.width << 'x' << session.height << '@' << session.fps
+                         << "Hz) and RTSP ANNOUNCE (" << width << 'x' << height << '@' << fps
+                         << "Hz); rebuilding LuminalVGD once before capture admission.";
+
+      GUID guid {};
+      static_assert(sizeof(guid) == 16);
+      std::memcpy(&guid, session.virtual_display_guid_bytes.data(), sizeof(guid));
+      if (!VDISPLAY::removeVirtualDisplay(guid)) {
+        BOOST_LOG(error) << "RTSP mode reconciliation could not remove the pre-launch virtual display.";
+        return false;
+      }
+
+      const std::string identity = !session.client_uuid.empty() ? session.client_uuid : session.unique_id;
+      const std::string label = !session.client_name.empty() ? session.client_name : session.device_name;
+      const auto fps_millihz = static_cast<uint32_t>(fps) * 1000u;
+      VDISPLAY::setWatchdogFeedingEnabled(true);
+      auto created = VDISPLAY::createVirtualDisplay(
+        identity.c_str(),
+        label.c_str(),
+        session.hdr_profile ? session.hdr_profile->c_str() : nullptr,
+        static_cast<uint32_t>(width),
+        static_cast<uint32_t>(height),
+        fps_millihz,
+        guid,
+        fps_millihz,
+        false,
+        session.enable_hdr
+      );
+      if (!created) {
+        BOOST_LOG(error) << "RTSP mode reconciliation failed to recreate LuminalVGD at the authoritative client mode.";
+        session.virtual_display_failed = true;
+        return false;
+      }
+
+      session.width = width;
+      session.height = height;
+      session.fps = fps;
+      session.requested_display_mode_source = "client_rtsp";
+      session.virtual_display_ready_since = created->ready_since;
+      session.virtual_display_device_id = created->device_id.value_or(std::string {});
+      auto request = display_helper_integration::helpers::build_request_from_session(config::video, session);
+      if (!request || !display_helper_integration::apply(*request)) {
+        BOOST_LOG(error) << "RTSP mode reconciliation recreated the monitor but failed its display-helper APPLY.";
+        return false;
+      }
+      BOOST_LOG(info) << "Requested display mode committed from client_rtsp: "
+                      << width << 'x' << height << '@' << fps << "Hz.";
+      return true;
+    }
+  }  // namespace
+#endif
+
   void free_msg(PRTSP_MESSAGE msg) {
     freeMessage(msg);
 
@@ -1127,6 +1210,16 @@ namespace rtsp_stream {
       respond(sock, session, &option, 400, "BAD REQUEST", req->sequenceNumber, {});
       return;
     }
+
+#ifdef _WIN32
+    const int rtsp_fps = config.monitor.framerateX100 > 0 ?
+                           static_cast<int>(std::lround(config.monitor.framerateX100 / 100.0)) :
+                           config.monitor.framerate;
+    if (!reconcile_virtual_display_mode(session, config.monitor.width, config.monitor.height, rtsp_fps)) {
+      respond(sock, session, &option, 503, "Virtual display mode reconciliation failed", req->sequenceNumber, {});
+      return;
+    }
+#endif
 
     // Validate the client-supplied video packet size. It is used downstream in stream.cpp
     // both as a modulus divisor (packetsize - sizeof(NV_VIDEO_PACKET)) and to size RTP block

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -41,6 +41,7 @@ namespace rtsp_stream {
     int width;
     int height;
     int fps;
+    std::string requested_display_mode_source;
     int gcmap;
     int appid;
 

--- a/src/state_storage.cpp
+++ b/src/state_storage.cpp
@@ -6,8 +6,13 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <filesystem>
+#include <fstream>
 #include <mutex>
+#include <atomic>
+#include <algorithm>
+#include <ranges>
 #include <string>
+#include <vector>
 
 #ifdef _WIN32
   #include <windows.h>
@@ -25,6 +30,60 @@ namespace statefile {
     namespace pt = boost::property_tree;
 
     std::once_flag migration_once;
+    std::atomic<std::uint64_t> temp_sequence {0};
+
+    fs::path unique_temp_path(const fs::path &path, std::string_view role = "tmp") {
+      fs::path candidate = path;
+      candidate += ".";
+      candidate += role;
+#ifdef _WIN32
+      candidate += "." + std::to_string(::GetCurrentProcessId());
+#else
+      candidate += "." + std::to_string(::getpid());
+#endif
+      candidate += "." + std::to_string(temp_sequence.fetch_add(1, std::memory_order_relaxed));
+      return candidate;
+    }
+
+    bool read_json_candidate(const fs::path &path, pt::ptree &out) {
+      try {
+        pt::ptree candidate;
+        pt::read_json(path.string(), candidate);
+        out = std::move(candidate);
+        return true;
+      } catch (const std::exception &) {
+        return false;
+      }
+    }
+
+    std::vector<fs::path> recovery_temp_candidates(const fs::path &path) {
+      std::vector<fs::path> candidates;
+      fs::path legacy = path;
+      legacy += ".tmp";
+      std::error_code ec;
+      if (fs::is_regular_file(legacy, ec)) {
+        candidates.push_back(legacy);
+      }
+
+      const auto dir = path.parent_path().empty() ? fs::path {"."} : path.parent_path();
+      const auto prefix = path.filename().string() + ".tmp.";
+      for (fs::directory_iterator it(dir, fs::directory_options::skip_permission_denied, ec), end;
+           !ec && it != end; it.increment(ec)) {
+        if (!it->is_regular_file(ec)) {
+          ec.clear();
+          continue;
+        }
+        const auto name = it->path().filename().string();
+        if (name.starts_with(prefix)) {
+          candidates.push_back(it->path());
+        }
+      }
+      std::ranges::sort(candidates, [](const fs::path &lhs, const fs::path &rhs) {
+        std::error_code lhs_ec, rhs_ec;
+        return fs::last_write_time(lhs, lhs_ec) > fs::last_write_time(rhs, rhs_ec);
+      });
+      return candidates;
+    }
 
     pt::ptree &ensure_root(pt::ptree &tree) {
       auto it = tree.find("root");
@@ -44,10 +103,10 @@ namespace statefile {
       return load_or_recover(path, out);
     }
 
-    void write_tree(const fs::path &path, const pt::ptree &tree) {
+    bool write_tree(const fs::path &path, const pt::ptree &tree) {
       // Route through the atomic helper so callers in this file get the same
       // crash-safety guarantee as external callers.
-      atomic_write_json(path, tree);
+      return atomic_write_json(path, tree);
     }
 
     // Force the file's bytes (and Windows metadata) to physical storage. Closes
@@ -103,8 +162,7 @@ namespace statefile {
     void update_backup(const fs::path &path) {
       fs::path bak_path = path;
       bak_path += ".bak";
-      fs::path bak_temp = path;
-      bak_temp += ".bak.tmp";
+      const fs::path bak_temp = unique_temp_path(path, "bak.tmp");
 
       std::error_code copy_ec;
       fs::copy_file(path, bak_temp, fs::copy_options::overwrite_existing, copy_ec);
@@ -149,8 +207,7 @@ namespace statefile {
     // Sibling temp file in the same directory keeps the eventual rename on a
     // single filesystem volume — required for the OS-level rename to be
     // atomic. On Windows this maps to MoveFileExW(MOVEFILE_REPLACE_EXISTING).
-    fs::path temp_path = path;
-    temp_path += ".tmp";
+    const fs::path temp_path = unique_temp_path(path);
 
     try {
       pt::write_json(temp_path.string(), tree);
@@ -167,7 +224,13 @@ namespace statefile {
     (void) fsync_path(temp_path);
 
     std::error_code mv_ec;
+#ifdef _WIN32
+    if (!::MoveFileExW(temp_path.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+      mv_ec = std::error_code(static_cast<int>(::GetLastError()), std::system_category());
+    }
+#else
     fs::rename(temp_path, path, mv_ec);
+#endif
     if (mv_ec) {
       BOOST_LOG(error) << "statefile: atomic rename "sv << temp_path.string() << " -> "sv << path.string()
                        << " failed: "sv << mv_ec.message();
@@ -201,6 +264,23 @@ namespace statefile {
                            << " ("sv << e.what() << "); attempting recovery from .bak"sv;
         out.clear();
       }
+    }
+
+    // An interrupted atomic write can leave a complete temporary file. It is
+    // newer than the backup and was never exposed as the primary, so validate
+    // it before discarding user state. This also recovers the fixed-name .tmp
+    // files produced by releases before unique writer temp names were added.
+    for (const auto &temp_path : recovery_temp_candidates(path)) {
+      if (!read_json_candidate(temp_path, out)) {
+        continue;
+      }
+      BOOST_LOG(warning) << "statefile: recovered "sv << path.string() << " from committed temporary candidate "sv
+                         << temp_path.string() << "; restoring primary"sv;
+      if (atomic_write_json(path, out)) {
+        std::error_code rm_ec;
+        fs::remove(temp_path, rm_ec);
+      }
+      return true;
     }
 
     fs::path bak_path = path;
@@ -299,10 +379,10 @@ namespace statefile {
       }
 
       if (new_modified) {
-        write_tree(new_path, new_tree);
+        (void) write_tree(new_path, new_tree);
       }
       if (old_modified) {
-        write_tree(old_path, old_tree);
+        (void) write_tree(old_path, old_tree);
       }
     });
   }
@@ -334,8 +414,11 @@ namespace statefile {
     auto &root_node = ensure_root(root);
     root_node.put_child("snapshot_exclude_devices", exclusions_pt);
 
-    write_tree(path, root);
-    BOOST_LOG(info) << "statefile: persisted " << devices.size() << " snapshot exclusion device(s) to luminalshine state";
+    if (write_tree(path, root)) {
+      BOOST_LOG(info) << "statefile: persisted " << devices.size() << " snapshot exclusion device(s) to luminalshine state";
+    } else {
+      BOOST_LOG(warning) << "statefile: snapshot exclusions were not persisted because the state path is not writable";
+    }
   }
 
   std::vector<std::string> load_snapshot_exclude_devices() {

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -2470,6 +2470,7 @@ namespace stream {
         done = 6,
       };
       auto phase = std::make_shared<std::atomic<int>>(static_cast<int>(join_phase_e::starting));
+      auto phase_deadline_seconds = std::make_shared<std::atomic<int>>(10);
       auto phase_name = [](int p) -> const char * {
         switch (static_cast<join_phase_e>(p)) {
           case join_phase_e::starting:        return "starting";
@@ -2483,9 +2484,11 @@ namespace stream {
         return "unknown";
       };
 
-      auto task = [phase, phase_name]() {
+      auto task = [phase, phase_deadline_seconds, phase_name]() {
         const int p = phase->load(std::memory_order_acquire);
-        BOOST_LOG(fatal) << "Hang detected! Session failed to terminate in 10 seconds. Wedged in phase: "
+        BOOST_LOG(fatal) << "Hang detected! Session teardown phase made no progress for "
+                         << phase_deadline_seconds->load(std::memory_order_acquire)
+                         << " seconds. Wedged in phase: "
                          << phase_name(p) << " (" << p << ")"sv;
 #ifdef _WIN32
         // Best-effort: ask the display helper to restore monitor topology immediately. We don't
@@ -2521,20 +2524,30 @@ namespace stream {
         task_pool.cancel(force_kill);
       });
 
-      phase->store(static_cast<int>(join_phase_e::waiting_video), std::memory_order_release);
+      auto advance_phase = [&](join_phase_e next, std::chrono::seconds deadline) {
+        task_pool.cancel(force_kill);
+        phase->store(static_cast<int>(next), std::memory_order_release);
+        phase_deadline_seconds->store(static_cast<int>(deadline.count()), std::memory_order_release);
+        force_kill = task_pool.pushDelayed(task, deadline).task_id;
+      };
+
+      advance_phase(join_phase_e::waiting_video, 10s);
       BOOST_LOG(debug) << "Waiting for video to end..."sv;
       session.videoThread.join();
-      phase->store(static_cast<int>(join_phase_e::waiting_audio), std::memory_order_release);
+      advance_phase(join_phase_e::waiting_audio, 10s);
       BOOST_LOG(debug) << "Waiting for audio to end..."sv;
       session.audioThread.join();
-      phase->store(static_cast<int>(join_phase_e::waiting_control), std::memory_order_release);
+      advance_phase(join_phase_e::waiting_control, 10s);
       BOOST_LOG(debug) << "Waiting for control to end..."sv;
       session.controlEnd.view();
-      phase->store(static_cast<int>(join_phase_e::resetting_input), std::memory_order_release);
+      advance_phase(join_phase_e::resetting_input, 10s);
       // Reset input on session stop to avoid stuck repeated keys
       BOOST_LOG(debug) << "Resetting Input..."sv;
       input::reset(session.input);
-      phase->store(static_cast<int>(join_phase_e::cleanup), std::memory_order_release);
+      // Worker teardown and staged physical-display restoration legitimately
+      // take longer than a thread join. Give cleanup its own deadline instead
+      // of inheriting the nearly-expired 10-second video-join timer.
+      advance_phase(join_phase_e::cleanup, 30s);
 
       // If this is the last session, invoke the platform callbacks
       if (--running_sessions == 0) {
@@ -2614,8 +2627,7 @@ namespace stream {
         // undo files as a crash backstop. Re-arm the hang watchdog with a
         // longer bound for this stage so we don't _Exit() out from under a
         // driver call that would complete on its own.
-        task_pool.cancel(force_kill);
-        force_kill = task_pool.pushDelayed(task, 60s).task_id;
+        advance_phase(join_phase_e::cleanup, 60s);
         BOOST_LOG(debug) << "Restoring frame limiter / NVIDIA Control Panel state..."sv;
         platf::frame_limiter_streaming_stop();
 #endif

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -56,6 +56,7 @@ extern "C" {
   #include "src/platform/windows/display.h"
   #include "src/platform/windows/display_vram.h"
   #include "src/platform/windows/misc.h"
+  #include "src/platform/windows/video_worker.h"
   #include "src/platform/windows/virtual_display.h"
   #include "uuid.h"
 
@@ -1459,6 +1460,91 @@ namespace video {
 
   bool has_attempted_encoder_probe() {
     return encoder_probe_attempted.load(std::memory_order_acquire);
+  }
+
+  bool export_encoder_probe_snapshot(encoder_probe_snapshot_t &snapshot) {
+    std::lock_guard lock(encoder_probe_mutex);
+    if (!chosen_encoder || !encoder_probe_attempted.load(std::memory_order_acquire)) {
+      return false;
+    }
+
+    snapshot = {};
+    snapshot.version = encoder_probe_snapshot_t::wire_version;
+    if (chosen_encoder->name.size() >= snapshot.encoder_name.size()) {
+      return false;
+    }
+    std::copy(chosen_encoder->name.begin(), chosen_encoder->name.end(), snapshot.encoder_name.begin());
+    snapshot.active_hevc_mode = active_hevc_mode;
+    snapshot.active_av1_mode = active_av1_mode;
+    snapshot.codec_capabilities = {
+      static_cast<std::uint32_t>(chosen_encoder->h264.capabilities.to_ulong()),
+      static_cast<std::uint32_t>(chosen_encoder->hevc.capabilities.to_ulong()),
+      static_cast<std::uint32_t>(chosen_encoder->av1.capabilities.to_ulong()),
+    };
+    snapshot.ref_frames_invalidation = last_encoder_probe_supported_ref_frames_invalidation;
+    for (std::size_t i = 0; i < snapshot.yuv444_for_codec.size(); ++i) {
+      snapshot.yuv444_for_codec[i] = last_encoder_probe_supported_yuv444_for_codec[i];
+      snapshot.supported_codec[i] = last_encoder_probe_supported_codec[i];
+    }
+    return true;
+  }
+
+  bool import_encoder_probe_snapshot(const encoder_probe_snapshot_t &snapshot) {
+    if (snapshot.version != encoder_probe_snapshot_t::wire_version) {
+      return false;
+    }
+    if (snapshot.active_hevc_mode < 0 || snapshot.active_hevc_mode > 3 ||
+        snapshot.active_av1_mode < 0 || snapshot.active_av1_mode > 3) {
+      return false;
+    }
+    const auto valid_wire_bool = [](std::uint8_t value) { return value <= 1; };
+    if (!valid_wire_bool(snapshot.ref_frames_invalidation) ||
+        !std::all_of(snapshot.yuv444_for_codec.begin(), snapshot.yuv444_for_codec.end(), valid_wire_bool) ||
+        !std::all_of(snapshot.supported_codec.begin(), snapshot.supported_codec.end(), valid_wire_bool)) {
+      return false;
+    }
+    const auto terminator = std::find(snapshot.encoder_name.begin(), snapshot.encoder_name.end(), '\0');
+    if (terminator == snapshot.encoder_name.end()) {
+      return false;
+    }
+    const std::string_view encoder_name(snapshot.encoder_name.data(),
+                                        static_cast<std::size_t>(terminator - snapshot.encoder_name.begin()));
+    const auto selected = std::find_if(encoders.begin(), encoders.end(), [&](const encoder_t *encoder) {
+      return encoder && encoder->name == encoder_name;
+    });
+    if (selected == encoders.end()) {
+      return false;
+    }
+
+    auto *encoder = *selected;
+    const auto allowed_capabilities = (std::uint32_t {1} << encoder_t::MAX_FLAGS) - 1;
+    if (std::any_of(snapshot.codec_capabilities.begin(), snapshot.codec_capabilities.end(),
+                    [&](std::uint32_t value) { return (value & ~allowed_capabilities) != 0; })) {
+      return false;
+    }
+    const auto passed_mask = std::uint32_t {1} << encoder_t::PASSED;
+    const auto yuv444_mask = std::uint32_t {1} << encoder_t::YUV444;
+    for (std::size_t i = 0; i < snapshot.codec_capabilities.size(); ++i) {
+      if ((snapshot.supported_codec[i] != 0) != ((snapshot.codec_capabilities[i] & passed_mask) != 0) ||
+          (snapshot.yuv444_for_codec[i] != 0) != ((snapshot.codec_capabilities[i] & yuv444_mask) != 0)) {
+        return false;
+      }
+    }
+    encoder->h264.capabilities = snapshot.codec_capabilities[0];
+    encoder->hevc.capabilities = snapshot.codec_capabilities[1];
+    encoder->av1.capabilities = snapshot.codec_capabilities[2];
+    active_hevc_mode = snapshot.active_hevc_mode;
+    active_av1_mode = snapshot.active_av1_mode;
+    last_encoder_probe_supported_ref_frames_invalidation = snapshot.ref_frames_invalidation != 0;
+    for (std::size_t i = 0; i < last_encoder_probe_supported_yuv444_for_codec.size(); ++i) {
+      last_encoder_probe_supported_yuv444_for_codec[i] = snapshot.yuv444_for_codec[i] != 0;
+      last_encoder_probe_supported_codec[i] = snapshot.supported_codec[i] != 0;
+    }
+    chosen_encoder = encoder;
+    encoder_probe_attempted.store(true, std::memory_order_release);
+    BOOST_LOG(info) << "Video worker: imported validated encoder [" << encoder->name
+                    << "] without re-running the capability probe.";
+    return true;
   }
 
   void reset_display(std::shared_ptr<platf::display_t> &disp, const platf::mem_type_e &type, const std::string &display_name, const config_t &config) {
@@ -3515,6 +3601,11 @@ namespace video {
     config_t config,
     void *channel_data
   ) {
+#ifdef _WIN32
+    if (platf::video_worker::capture(mail, config, channel_data)) {
+      return;
+    }
+#endif
     // Snapshot the encoder pointer to avoid races with concurrent probe_encoders() calls
     auto *encoder = chosen_encoder;
     if (!encoder) {

--- a/src/video.h
+++ b/src/video.h
@@ -362,6 +362,23 @@ namespace video {
   // encoder probe of its own.
   extern std::array<bool, 3> last_encoder_probe_supported_codec;  // 0 - H.264, 1 - HEVC, 2 - AV1
 
+  struct encoder_probe_snapshot_t {
+    static constexpr std::uint32_t wire_version = 1;
+
+    std::uint32_t version {wire_version};
+    std::array<char, 32> encoder_name {};
+    std::int32_t active_hevc_mode {};
+    std::int32_t active_av1_mode {};
+    std::array<std::uint32_t, 3> codec_capabilities {};
+    std::uint8_t ref_frames_invalidation {};
+    std::array<std::uint8_t, 3> yuv444_for_codec {};
+    std::array<std::uint8_t, 3> supported_codec {};
+  };
+
+  /** Export/import the already-validated encoder selection for an isolated worker. */
+  bool export_encoder_probe_snapshot(encoder_probe_snapshot_t &snapshot);
+  bool import_encoder_probe_snapshot(const encoder_probe_snapshot_t &snapshot);
+
   bool has_attempted_encoder_probe();
 
   void capture(

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayDeviceOptions.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayDeviceOptions.vue
@@ -662,6 +662,18 @@ function clearSnapshotHotkey(): void {
             </div>
 
             <div
+              v-if="usingVirtualDisplay && config.virtual_display_layout === 'exclusive'"
+              class="mt-4 border-l-2 border-dark/10 dark:border-light/10 pl-3"
+            >
+              <Checkbox
+                id="dd_dark_recovery_anchor"
+                v-model="config.dd_dark_recovery_anchor"
+                locale-prefix="config"
+                default="true"
+              />
+            </div>
+
+            <div
               v-if="usingVirtualDisplay && config.dd_configuration_option !== 'disabled'"
               class="mt-4 rounded-lg border border-dark/10 dark:border-light/10 p-3 space-y-2"
             >

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -233,6 +233,8 @@
     "dd_config_revert_delay_desc": "Additional delay in milliseconds to wait before reverting configuration when the app has been closed or the last session terminated. Main purpose is to provide a smoother transition when quickly switching between apps.",
     "dd_config_revert_on_disconnect": "Config revert on disconnect",
     "dd_config_revert_on_disconnect_desc": "Revert configuration upon disconnect of all clients instead of app close or last session termination.",
+    "dd_dark_recovery_anchor": "OLED-safe physical recovery anchor",
+    "dd_dark_recovery_anchor_desc": "During exclusive virtual-display streaming, keep one physical display active but isolated and covered with pure black. This gives Windows a hardware scan-out path for GPU recovery without showing static OLED content.",
     "dd_paused_virtual_display_timeout_secs": "Paused session virtual display timeout (seconds)",
     "dd_paused_virtual_display_timeout_secs_desc": "Optional grace delay before removing virtual displays while a session is paused and revert-on-disconnect is disabled. 0 keeps the virtual display alive until resume or app exit.",
     "dd_paused_virtual_display_timeout_secs_warning": "Removing a virtual display while a game is still running can cause crashes regardless of trigger (timeout, hotkey, or manual restore). This option helps prevent returning to a stuck virtual screen after inactivity.",

--- a/src_assets/common/assets/web/stores/config.ts
+++ b/src_assets/common/assets/web/stores/config.ts
@@ -167,6 +167,7 @@ const defaultGroups = [
       dd_config_revert_on_disconnect: 'enabled',
       dd_paused_virtual_display_timeout_secs: 0,
       dd_always_restore_from_golden: false,
+      dd_dark_recovery_anchor: true,
       dd_snapshot_exclude_devices: [] as Array<string>,
       dd_snapshot_restore_hotkey: '',
       dd_snapshot_restore_hotkey_modifiers: 'ctrl+alt+shift',

--- a/tests/unit/test_credentials_persistence.cpp
+++ b/tests/unit/test_credentials_persistence.cpp
@@ -207,6 +207,38 @@ TEST_F(CredentialsPersistenceTest, LoadOrRecoverReadsPrimaryWhenValid) {
   ASSERT_EQ(out.get<std::string>("root.uniqueid"), "uuid-primary");
 }
 
+TEST_F(CredentialsPersistenceTest, LoadOrRecoverPromotesLegacyTemporaryFile) {
+  const auto file = scratch / "state.json";
+  fs::path temp = file;
+  temp += ".tmp";
+
+  pt::ptree expected;
+  expected.put("root.uniqueid", "uuid-from-temp");
+  pt::write_json(temp.string(), expected);
+
+  pt::ptree out;
+  ASSERT_TRUE(statefile::load_or_recover(file, out));
+  EXPECT_EQ(out.get<std::string>("root.uniqueid"), "uuid-from-temp");
+  EXPECT_TRUE(fs::exists(file));
+  EXPECT_FALSE(fs::exists(temp));
+}
+
+TEST_F(CredentialsPersistenceTest, LoadOrRecoverPromotesUniqueWriterTemporaryFile) {
+  const auto file = scratch / "state.json";
+  fs::path temp = file;
+  temp += ".tmp.4242.7";
+
+  pt::ptree expected;
+  expected.put("root.uniqueid", "uuid-from-unique-temp");
+  pt::write_json(temp.string(), expected);
+
+  pt::ptree out;
+  ASSERT_TRUE(statefile::load_or_recover(file, out));
+  EXPECT_EQ(out.get<std::string>("root.uniqueid"), "uuid-from-unique-temp");
+  EXPECT_TRUE(fs::exists(file));
+  EXPECT_FALSE(fs::exists(temp));
+}
+
 TEST_F(CredentialsPersistenceTest, LoadOrRecoverRestoresFromBackupWhenPrimaryCorrupt) {
   // Simulate the canonical "Windows servicing zero-byte file" failure mode:
   // the primary exists but parses to nothing, while the .bak written by the

--- a/tests/unit/test_requested_display_mode.cpp
+++ b/tests/unit/test_requested_display_mode.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+
+#include "src/requested_display_mode.h"
+
+namespace {
+  using display_mode_policy::Mode;
+  using display_mode_policy::should_reconcile;
+
+  TEST(RequestedDisplayMode, RtspCorrectsAStaleHttpModeForVgd) {
+    EXPECT_TRUE(should_reconcile(true, false, Mode {1280, 720, 60}, Mode {3840, 2160, 120}));
+  }
+
+  TEST(RequestedDisplayMode, ExplicitPerClientOverrideRemainsAuthoritative) {
+    EXPECT_FALSE(should_reconcile(true, true, Mode {1280, 720, 60}, Mode {3840, 2160, 120}));
+  }
+
+  TEST(RequestedDisplayMode, MatchingModesDoNotCycleTheMonitor) {
+    EXPECT_FALSE(should_reconcile(true, false, Mode {3840, 2160, 120}, Mode {3840, 2160, 120}));
+  }
+
+  TEST(RequestedDisplayMode, InvalidLateModeCannotReplaceAValidLaunchMode) {
+    EXPECT_FALSE(should_reconcile(true, false, Mode {3840, 2160, 120}, Mode {}));
+  }
+}

--- a/tests/unit/test_vgd_transition.cpp
+++ b/tests/unit/test_vgd_transition.cpp
@@ -21,8 +21,24 @@
   // local includes
   #include "../tests_common.h"
   #include "src/platform/windows/vgd_transition.h"
+  #include "src/platform/windows/virtual_display_vgd.h"
 
 namespace {
+
+  TEST(VgdWorkerRingTarget, ImportedTargetOverridesTheEmptyChildSessionMap) {
+    const VDISPLAY::vgd::RingTargetInfo imported {0x123456789abcdef0ULL, 3, 0x4, 7};
+    VDISPLAY::vgd::set_worker_ring_target(imported, "\\\\.\\DISPLAY77");
+    ASSERT_TRUE(VDISPLAY::vgd::has_worker_ring_target());
+    const auto resolved = VDISPLAY::vgd::ring_target_for_display("\\\\.\\DISPLAY77");
+    ASSERT_TRUE(resolved.has_value());
+    EXPECT_EQ(resolved->session_id, imported.session_id);
+    EXPECT_EQ(resolved->ring_slots, imported.ring_slots);
+    EXPECT_EQ(resolved->transport_flags, imported.transport_flags);
+    EXPECT_EQ(resolved->generation, imported.generation);
+    EXPECT_FALSE(VDISPLAY::vgd::ring_target_for_display("\\\\.\\DISPLAY78").has_value());
+    VDISPLAY::vgd::set_worker_ring_target(std::nullopt);
+    EXPECT_FALSE(VDISPLAY::vgd::has_worker_ring_target());
+  }
 
   TEST(VgdTransitionCaptureNote, RecordsKindDisplayAndBumpsSequence) {
     const auto before = platf::vgd_transition::last_capture_note();

--- a/tools/display_settings_helper.cpp
+++ b/tools/display_settings_helper.cpp
@@ -2335,6 +2335,225 @@ namespace {
   bool create_restore_scheduled_task();
   bool delete_restore_scheduled_task();
 
+  /**
+   * Keeps every non-primary scan-out surface solid black while the VGD target
+   * is primary. This runs in the interactive helper (not the SYSTEM service),
+   * so the windows are composed onto the user's actual desktop. OLED pixels
+   * receive RGB zero while the physical VidPn path remains active for WDDM
+   * recovery.
+   */
+  class DarkRecoveryAnchor {
+  public:
+    DarkRecoveryAnchor(): worker_([this](std::stop_token st) { run(st); }) {}
+
+    ~DarkRecoveryAnchor() {
+      worker_.request_stop();
+      enabled_.store(false, std::memory_order_release);
+    }
+
+    void enable(bool enabled) noexcept {
+      enabled_.store(enabled, std::memory_order_release);
+      generation_.fetch_add(1, std::memory_order_acq_rel);
+    }
+
+  private:
+    static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
+      if (msg == WM_ERASEBKGND) {
+        RECT rc {};
+        GetClientRect(hwnd, &rc);
+        FillRect(reinterpret_cast<HDC>(wparam), &rc, static_cast<HBRUSH>(GetStockObject(BLACK_BRUSH)));
+        return 1;
+      }
+      if (msg == WM_PAINT) {
+        PAINTSTRUCT ps {};
+        HDC dc = BeginPaint(hwnd, &ps);
+        FillRect(dc, &ps.rcPaint, static_cast<HBRUSH>(GetStockObject(BLACK_BRUSH)));
+        EndPaint(hwnd, &ps);
+        return 0;
+      }
+      return DefWindowProcW(hwnd, msg, wparam, lparam);
+    }
+
+    static BOOL CALLBACK collect_monitor(HMONITOR monitor, HDC, LPRECT, LPARAM context) {
+      auto *rects = reinterpret_cast<std::vector<RECT> *>(context);
+      MONITORINFO info {.cbSize = sizeof(MONITORINFO)};
+      if (GetMonitorInfoW(monitor, &info) && (info.dwFlags & MONITORINFOF_PRIMARY) == 0) {
+        rects->push_back(info.rcMonitor);
+      }
+      return TRUE;
+    }
+
+    static bool same_rects(const std::vector<RECT> &a, const std::vector<RECT> &b) {
+      if (a.size() != b.size()) return false;
+      for (std::size_t i = 0; i < a.size(); ++i) {
+        if (a[i].left != b[i].left || a[i].top != b[i].top ||
+            a[i].right != b[i].right || a[i].bottom != b[i].bottom) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    void destroy_windows() {
+      for (HWND hwnd : windows_) {
+        if (hwnd) DestroyWindow(hwnd);
+      }
+      windows_.clear();
+      covered_rects_.clear();
+    }
+
+    void refresh_windows(HINSTANCE instance, const wchar_t *klass) {
+      std::vector<RECT> rects;
+      EnumDisplayMonitors(nullptr, nullptr, &collect_monitor, reinterpret_cast<LPARAM>(&rects));
+      if (same_rects(rects, covered_rects_) && windows_.size() == rects.size()) return;
+
+      destroy_windows();
+      covered_rects_ = rects;
+      for (const auto &rect : rects) {
+        HWND hwnd = CreateWindowExW(
+          WS_EX_TOPMOST | WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
+          klass,
+          L"LuminalShine OLED-safe recovery anchor",
+          WS_POPUP,
+          rect.left,
+          rect.top,
+          rect.right - rect.left,
+          rect.bottom - rect.top,
+          nullptr,
+          nullptr,
+          instance,
+          nullptr
+        );
+        if (!hwnd) continue;
+        SetWindowPos(hwnd, HWND_TOPMOST, rect.left, rect.top, rect.right - rect.left,
+                     rect.bottom - rect.top, SWP_NOACTIVATE | SWP_SHOWWINDOW);
+        windows_.push_back(hwnd);
+      }
+    }
+
+    struct ContainmentContext {
+      RECT primary {};
+      HMONITOR primary_monitor {nullptr};
+      DWORD helper_pid {0};
+    };
+
+    static bool excluded_window(HWND hwnd, DWORD helper_pid) {
+      if (!IsWindowVisible(hwnd) || IsIconic(hwnd) || GetAncestor(hwnd, GA_ROOT) != hwnd) return true;
+      const auto exstyle = static_cast<DWORD>(GetWindowLongPtrW(hwnd, GWL_EXSTYLE));
+      if (exstyle & (WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE)) return true;
+      DWORD pid = 0;
+      GetWindowThreadProcessId(hwnd, &pid);
+      if (pid == 0 || pid == helper_pid) return true;
+      wchar_t klass[128] {};
+      GetClassNameW(hwnd, klass, static_cast<int>(std::size(klass)));
+      return _wcsicmp(klass, L"Progman") == 0 ||
+             _wcsicmp(klass, L"WorkerW") == 0 ||
+             _wcsicmp(klass, L"Shell_TrayWnd") == 0 ||
+             _wcsicmp(klass, L"Shell_SecondaryTrayWnd") == 0;
+    }
+
+    static BOOL CALLBACK contain_window(HWND hwnd, LPARAM parameter) {
+      auto &ctx = *reinterpret_cast<ContainmentContext *>(parameter);
+      if (excluded_window(hwnd, ctx.helper_pid)) return TRUE;
+      const HMONITOR current = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+      if (!current || current == ctx.primary_monitor) return TRUE;
+
+      RECT current_monitor {};
+      MONITORINFO current_info {.cbSize = sizeof(MONITORINFO)};
+      if (!GetMonitorInfoW(current, &current_info)) return TRUE;
+      current_monitor = current_info.rcMonitor;
+
+      WINDOWPLACEMENT placement {.length = sizeof(WINDOWPLACEMENT)};
+      RECT window_rect {};
+      if (!GetWindowPlacement(hwnd, &placement) || !GetWindowRect(hwnd, &window_rect)) return TRUE;
+
+      const int primary_width = ctx.primary.right - ctx.primary.left;
+      const int primary_height = ctx.primary.bottom - ctx.primary.top;
+      const int width = std::max(1L, window_rect.right - window_rect.left);
+      const int height = std::max(1L, window_rect.bottom - window_rect.top);
+      const bool fullscreen = width >= (current_monitor.right - current_monitor.left - 2) &&
+                              height >= (current_monitor.bottom - current_monitor.top - 2);
+      const int target_width = fullscreen ? primary_width : std::min(width, primary_width);
+      const int target_height = fullscreen ? primary_height : std::min(height, primary_height);
+      const int relative_x = window_rect.left - current_monitor.left;
+      const int relative_y = window_rect.top - current_monitor.top;
+      const int target_x = fullscreen ? ctx.primary.left :
+        std::clamp(ctx.primary.left + relative_x, ctx.primary.left, ctx.primary.right - target_width);
+      const int target_y = fullscreen ? ctx.primary.top :
+        std::clamp(ctx.primary.top + relative_y, ctx.primary.top, ctx.primary.bottom - target_height);
+
+      if (placement.showCmd == SW_SHOWMAXIMIZED) {
+        placement.rcNormalPosition = {target_x, target_y, target_x + target_width, target_y + target_height};
+        SetWindowPlacement(hwnd, &placement);
+      } else {
+        SetWindowPos(hwnd, nullptr, target_x, target_y, target_width, target_height,
+                     SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOZORDER);
+      }
+      DWORD pid = 0;
+      GetWindowThreadProcessId(hwnd, &pid);
+      BOOST_LOG(info) << "Virtual-display containment: moved top-level window pid=" << pid
+                      << " from a physical recovery anchor to the primary LuminalVGD desktop.";
+      return TRUE;
+    }
+
+    void contain_applications_on_primary() {
+      POINT origin {0, 0};
+      const HMONITOR primary = MonitorFromPoint(origin, MONITOR_DEFAULTTOPRIMARY);
+      MONITORINFO info {.cbSize = sizeof(MONITORINFO)};
+      if (!primary || !GetMonitorInfoW(primary, &info) || (info.dwFlags & MONITORINFOF_PRIMARY) == 0) return;
+      ContainmentContext context {info.rcWork, primary, GetCurrentProcessId()};
+      EnumWindows(&contain_window, reinterpret_cast<LPARAM>(&context));
+    }
+
+    void run(std::stop_token st) {
+      const auto instance = GetModuleHandleW(nullptr);
+      const wchar_t *klass = L"LuminalShineDarkRecoveryAnchor";
+      WNDCLASSEXW wc {.cbSize = sizeof(WNDCLASSEXW)};
+      wc.lpfnWndProc = &wnd_proc;
+      wc.hInstance = instance;
+      wc.hbrBackground = static_cast<HBRUSH>(GetStockObject(BLACK_BRUSH));
+      wc.lpszClassName = klass;
+      RegisterClassExW(&wc);
+
+      std::uint64_t observed_generation = 0;
+      while (!st.stop_requested()) {
+        MSG msg {};
+        while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+          TranslateMessage(&msg);
+          DispatchMessageW(&msg);
+        }
+
+        const auto generation = generation_.load(std::memory_order_acquire);
+        if (!enabled_.load(std::memory_order_acquire)) {
+          if (!windows_.empty()) destroy_windows();
+        } else if (generation != observed_generation || windows_.empty()) {
+          refresh_windows(instance, klass);
+        } else {
+          // Re-enumerate periodically so a DWM reset or hotplug cannot expose
+          // a static desktop on the OLED anchor.
+          refresh_windows(instance, klass);
+        }
+        if (enabled_.load(std::memory_order_acquire)) {
+          // Primary is LuminalVGD in anchored-exclusive mode. Re-run this
+          // inexpensive sweep because launchers commonly restore a saved
+          // physical-monitor position and move the game again after creation.
+          contain_applications_on_primary();
+        }
+        observed_generation = generation;
+        std::this_thread::sleep_for(500ms);
+      }
+
+      destroy_windows();
+      UnregisterClassW(klass, instance);
+    }
+
+    std::jthread worker_;
+    std::atomic<bool> enabled_ {false};
+    std::atomic<std::uint64_t> generation_ {0};
+    std::vector<HWND> windows_;
+    std::vector<RECT> covered_rects_;
+  };
+
   struct ServiceState {
     enum class RestoreWindow {
       Primary,
@@ -2342,6 +2561,7 @@ namespace {
     };
 
     DisplayController controller;
+    DarkRecoveryAnchor dark_recovery_anchor;
     DisplayEventPump event_pump;
     std::atomic<bool> event_pump_running {false};
     std::mutex restore_event_mutex;
@@ -4854,6 +5074,19 @@ namespace {
     }
   }
 
+  bool parse_clean_session_revert_payload(std::span<const uint8_t> payload) {
+    if (payload.empty()) return false;
+    try {
+      std::string raw(reinterpret_cast<const char *>(payload.data()), payload.size());
+      auto j = nlohmann::json::parse(raw, nullptr, false);
+      if (!j.is_object()) return false;
+      const auto it = j.find("sunshine_clean_session_revert");
+      return it != j.end() && it->is_boolean() && it->get<bool>();
+    } catch (...) {
+      return false;
+    }
+  }
+
   /**
    * @brief Load snapshot exclusion devices from luminalshine_state.json.
    *
@@ -4870,12 +5103,12 @@ namespace {
     if (path.empty()) {
       return false;
     }
-    std::error_code ec;
-    if (!std::filesystem::exists(path, ec) || ec) {
-      return false;
-    }
-    try {
-      FILE *f = _wfopen(path.wstring().c_str(), L"rb");
+    const auto read_candidate = [&](const std::filesystem::path &candidate) {
+      std::error_code exists_ec;
+      if (!std::filesystem::is_regular_file(candidate, exists_ec) || exists_ec) {
+        return false;
+      }
+      FILE *f = _wfopen(candidate.wstring().c_str(), L"rb");
       if (!f) {
         return false;
       }
@@ -4897,9 +5130,55 @@ namespace {
           return !ids_out.empty() || root["snapshot_exclude_devices"].is_array();
         }
       }
-    } catch (const std::exception &e) {
-      BOOST_LOG(warning) << "Failed to parse luminalshine_state.json for snapshot exclusions: " << e.what();
-    } catch (...) {
+      return false;
+    };
+
+    // The helper is a separate process and can observe the small interval
+    // between a state write and its atomic rename. Prefer the committed file,
+    // then accept any complete writer temp (including the legacy fixed .tmp),
+    // and finally the durable backup. This mirrors statefile::load_or_recover
+    // without linking the service's configuration module into this helper.
+    std::vector<std::filesystem::path> candidates {path};
+    std::filesystem::path legacy_tmp = path;
+    legacy_tmp += L".tmp";
+    candidates.push_back(legacy_tmp);
+
+    std::error_code ec;
+    const auto dir = path.parent_path().empty() ? std::filesystem::path {L"."} : path.parent_path();
+    const auto prefix = path.filename().wstring() + L".tmp.";
+    std::vector<std::filesystem::path> unique_temps;
+    for (std::filesystem::directory_iterator it(dir, std::filesystem::directory_options::skip_permission_denied, ec), end;
+         !ec && it != end; it.increment(ec)) {
+      const auto name = it->path().filename().wstring();
+      if (name.starts_with(prefix)) {
+        unique_temps.push_back(it->path());
+      }
+    }
+    std::ranges::sort(unique_temps, [](const auto &lhs, const auto &rhs) {
+      std::error_code lhs_ec, rhs_ec;
+      return std::filesystem::last_write_time(lhs, lhs_ec) > std::filesystem::last_write_time(rhs, rhs_ec);
+    });
+    candidates.insert(candidates.end(), unique_temps.begin(), unique_temps.end());
+    std::filesystem::path backup = path;
+    backup += L".bak";
+    candidates.push_back(backup);
+
+    for (const auto &candidate : candidates) {
+      try {
+        if (read_candidate(candidate)) {
+          if (candidate != path) {
+            BOOST_LOG(info) << "Loaded LuminalShine snapshot exclusions from recovery state candidate: "
+                            << candidate.string();
+          }
+          return true;
+        }
+      } catch (const std::exception &e) {
+        BOOST_LOG(debug) << "Could not parse LuminalShine state candidate " << candidate.string()
+                         << ": " << e.what();
+        ids_out.clear();
+      } catch (...) {
+        ids_out.clear();
+      }
     }
     return false;
   }
@@ -4915,6 +5194,7 @@ namespace {
     std::string json(reinterpret_cast<const char *>(payload.data()), payload.size());
     bool wa_hdr_toggle = false;
     bool transitional_apply = false;
+    bool dark_recovery_anchor = false;
     std::optional<std::string> requested_virtual_layout;
     std::vector<std::pair<std::string, display_device::Point>> monitor_position_overrides;
     std::vector<std::pair<std::string, std::pair<unsigned int, unsigned int>>> refresh_rate_overrides;
@@ -4931,6 +5211,10 @@ namespace {
         if (j.contains("sunshine_transitional_apply") && j["sunshine_transitional_apply"].is_boolean()) {
           transitional_apply = j["sunshine_transitional_apply"].get<bool>();
           j.erase("sunshine_transitional_apply");
+        }
+        if (j.contains("sunshine_dark_recovery_anchor") && j["sunshine_dark_recovery_anchor"].is_boolean()) {
+          dark_recovery_anchor = j["sunshine_dark_recovery_anchor"].get<bool>();
+          j.erase("sunshine_dark_recovery_anchor");
         }
         if (j.contains("sunshine_virtual_layout") && j["sunshine_virtual_layout"].is_string()) {
           requested_virtual_layout = j["sunshine_virtual_layout"].get<std::string>();
@@ -5110,6 +5394,9 @@ namespace {
 
       state.retry_apply_on_topology.store(false, std::memory_order_release);
       if (!transitional_apply) {
+        state.dark_recovery_anchor.enable(dark_recovery_anchor);
+        BOOST_LOG(info) << "Display helper: OLED-safe dark recovery anchor "
+                        << (dark_recovery_anchor ? "enabled" : "disabled") << ".";
         state.schedule_post_apply_tasks(
           apply_generation,
           false,
@@ -5135,8 +5422,13 @@ namespace {
 
   void handle_revert(ServiceState &state, std::atomic<bool> &running, std::span<const uint8_t> payload) {
     const bool prefer_golden_if_current_missing = parse_revert_prefer_golden_payload(payload);
+    const bool clean_session_revert = parse_clean_session_revert_payload(payload);
     BOOST_LOG(info) << "REVERT command received - initiating display settings restoration"
                     << (prefer_golden_if_current_missing ? " (prefer golden if current missing)." : ".");
+    if (clean_session_revert) {
+      state.always_restore_from_golden.store(false, std::memory_order_release);
+      BOOST_LOG(info) << "REVERT policy: clean session shutdown; restoring the current pre-session snapshot before golden fallback.";
+    }
     state.retry_apply_on_topology.store(false, std::memory_order_release);
     state.cancel_delayed_reapply();
     state.cancel_post_apply_tasks();


### PR DESCRIPTION
## Summary

- decouple LuminalVGD ring surfaces from NVENC-owned lifetimes using host-owned mailbox textures
- isolate capture and encoding in an authenticated, watchdog-controlled worker process
- transfer the exact active VGD ring identity and validated encoder capabilities into the worker
- preserve direct VGD capture across process boundaries without silently substituting WGC or DDA
- make client resolution and refresh-rate selection authoritative for direct VGD sessions
- harden virtual-display staging, cleanup, GPU recovery diagnostics, and requested-mode handling
- repair state-file atomic writes and recovery from legacy, unique temporary, and backup files

## Root cause

Direct LuminalVGD capture, NVENC teardown, and virtual-display topology changes could become coupled through shared GPU-resource lifetimes. A stalled encoder could block ring progress and eventually wedge the host. Initial process isolation also exposed two startup defects: the child repeated the full encoder probe and lacked the parent's process-local VGD session map, causing client first-frame timeouts and an unintended WGC fallback.

This change copies claimed VGD frames into LuminalShine-owned textures before releasing the driver slot, moves capture/encoding into a bounded worker, transfers the parent's already-validated encoder state, and binds the worker to the exact ACTIVE VGD session, display, generation, slot count, and live transport. The worker confirms a real first encoded packet before readiness and fails closed on stale or mismatched ring state.

## User impact

- direct VGD sessions retain negotiated resolution, refresh, HDR, and 4:4:4 behavior
- capture or NVENC failures no longer permanently wedge the main LuminalShine server process
- clients do not wait through a redundant per-session encoder capability probe
- direct VGD workers cannot silently capture through WGC
- display restoration receives phase-specific teardown deadlines instead of triggering a false ten-second fatal hang
- state and temporary files recover reliably after interrupted or concurrent writes

## Validation

- Windows UCRT build completed for `luminalshine.exe` and `test_sunshine.exe`
- 67 focused VGD ring, worker-target, display-helper, requested-mode, state-storage, and identity tests passed
- worker startup failure path exits within its bounded deadline
- staged diff and whitespace validation passed
- security review covered pipe ACLs and PID authentication, IPC bounds, ring identity binding, generation/state validation, transport downgrade handling, and fallback safety

No binaries, signed driver packages, certificates, or other signed artifacts are included.
