### PR TITLE
Advance MSI compatibility baseline to 26.08.1

### DIFF
--- a/tests/fixtures/msi_golden/msi_baseline.txt
+++ b/tests/fixtures/msi_golden/msi_baseline.txt
@@ -25,8 +25,8 @@ Property=WIXUI_INSTALLDIR|Value=INSTALL_ROOT
 Property=WixUIRMOption|Value=UseRM
 
 ## TABLE: Upgrade
-UpgradeCode={C2C36624-2D9C-4AFD-9C79-6B7861AE4A0D}|VersionMin=26.08.0.0|VersionMax=|Language=|Attributes=2|Remove=|ActionProperty=WIX_DOWNGRADE_DETECTED
-UpgradeCode={C2C36624-2D9C-4AFD-9C79-6B7861AE4A0D}|VersionMin=|VersionMax=26.08.0.0|Language=|Attributes=513|Remove=|ActionProperty=WIX_UPGRADE_DETECTED
+UpgradeCode={C2C36624-2D9C-4AFD-9C79-6B7861AE4A0D}|VersionMin=26.08.1.0|VersionMax=|Language=|Attributes=2|Remove=|ActionProperty=WIX_DOWNGRADE_DETECTED
+UpgradeCode={C2C36624-2D9C-4AFD-9C79-6B7861AE4A0D}|VersionMin=|VersionMax=26.08.1.0|Language=|Attributes=513|Remove=|ActionProperty=WIX_UPGRADE_DETECTED
 
 ## TABLE: Component
 Component=ArpCustomUninstallEntry|ComponentId={7843F978-AC8D-508C-8973-17EA02CAE565}|Directory_=INSTALL_ROOT|Attributes=260|Condition=|KeyPath=regKWKE1syhS2LUr3ZQtpKBQsQSUlQ


### PR DESCRIPTION
## Summary

- advance the two MSI Upgrade-table release thresholds from 26.08.0.0 to 26.08.1.0
- retain the stable UpgradeCode, component identities, service configuration, and package structure
- unblock the 26.08.1 stable release compatibility gate

## Context

Release run [30953811074](https://github.com/NortheBridge/luminalshine/actions/runs/30953811074) built and signed the Windows artifacts successfully, then stopped because the moving MSI baseline still represented 26.08.0. The candidate contained only the expected old-threshold removal and new-threshold addition.

## Validation

- `python scripts/diff_msi_tables.py --selftest` (7 cases pass)
- `git diff --check`