### PR TITLE
Isolate immutable direct-display capture

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -709,9 +709,9 @@ namespace platf::dxgi {
     /// a claimed slot before releasing it to the driver.
     bool prepare_fence_transport(uint32_t generation);
 
-    /// Adopt the transport selected by Build 23 for the claimed generation.
-    /// The driver can downgrade a rejected D3D12 fence ring to keyed mutexes
-    /// without recreating the monitor.
+    /// Validate the transport selected for the claimed generation. Build 24
+    /// fence-required rings may never change synchronization contracts in
+    /// place; a violation forces isolated safe-capture recovery.
     bool refresh_transport();
 
     /// Wait for this consumer's copy to leave the source slot. The wait is
@@ -743,6 +743,8 @@ namespace platf::dxgi {
     uint64_t _session_id = 0;
     uint32_t _ring_slots = 0;
     bool _fence_transport = false;
+    bool _fence_required = false;
+    uint32_t _transport_generation = 0;
     uint32_t _fence_generation = 0;
     fence11_t _producer_fence;
     fence11_t _consumer_fence;

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -2042,7 +2042,9 @@ namespace platf {
     const bool wgc_requested = capture_mode.starts_with("wgc");
     const bool vgd_requested = capture_mode == "vgd";
     const bool worker_vgd_target = VDISPLAY::vgd::has_worker_ring_target();
-    const bool prefer_wgc_backend = !user_requested_ddx && !vgd_requested && (wgc_requested || default_to_wgc);
+    const bool worker_safe_capture = VDISPLAY::vgd::worker_safe_capture_requested();
+    const bool prefer_wgc_backend = worker_safe_capture ||
+                                    (!user_requested_ddx && !vgd_requested && (wgc_requested || default_to_wgc));
 
     if (hwdevice_type == mem_type_e::dxgi) {
       // A LuminalVGD virtual monitor carries its own frame ring — consume it
@@ -2050,9 +2052,9 @@ namespace platf {
       // for non-VGD displays (or if the ring can't be mapped), falling back
       // to WGC/DDA below; explicit capture=vgd also degrades rather than
       // failing the stream.
-      if (worker_vgd_target ||
+      if (!worker_safe_capture && (worker_vgd_target ||
           (!user_requested_ddx && !wgc_requested &&
-           (vgd_requested || VDISPLAY::is_luminalvgd_active()))) {
+           (vgd_requested || VDISPLAY::is_luminalvgd_active())))) {
         if (auto disp = dxgi::display_vgd_vram_t::create(config, display_name)) {
           vgd_transition::note_capture_backend(vgd_transition::kCaptureKindVgdRing, display_name);
           return disp;

--- a/src/platform/windows/display_vgd.cpp
+++ b/src/platform/windows/display_vgd.cpp
@@ -382,6 +382,8 @@ namespace platf::dxgi {
     _session_id = target->session_id;
     _ring_slots = target->ring_slots;
     _fence_transport = (target->transport_flags & VGD_CREATE_D3D12_FENCE_TRANSPORT) != 0;
+    _fence_required = (target->transport_flags & VGD_CREATE_FENCE_TRANSPORT_REQUIRED) != 0;
+    _transport_generation = target->generation;
     _display_name = display_name;
     _tdr_marks_at_open = tdr::event_count();
     _first_frame_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
@@ -764,7 +766,15 @@ namespace platf::dxgi {
       return false;
     }
     const bool fence = (status.transport_flags & VGD_CREATE_D3D12_FENCE_TRANSPORT) != 0;
+    const bool required = (status.transport_flags & VGD_CREATE_FENCE_TRANSPORT_REQUIRED) != 0;
+    if ((_fence_required && (!fence || !required)) ||
+        (status.generation == _transport_generation && fence != _fence_transport)) {
+      BOOST_LOG(error) << "LuminalVGD capture: synchronization contract changed inside ring generation "
+                       << status.generation << "; rejecting the generation.";
+      return false;
+    }
     if (fence == _fence_transport) {
+      _transport_generation = status.generation;
       return true;
     }
 
@@ -772,6 +782,8 @@ namespace platf::dxgi {
                     << (fence ? "shared timeline-fence" : "legacy keyed-mutex")
                     << " transport for ring generation " << status.generation << '.';
     _fence_transport = fence;
+    _fence_required = required;
+    _transport_generation = status.generation;
     _slot_textures.clear();
     _texture_generation = 0;
     _producer_fence.reset();

--- a/src/platform/windows/video_worker.cpp
+++ b/src/platform/windows/video_worker.cpp
@@ -65,7 +65,8 @@ namespace platf::video_worker {
       video::config_t config;
       video::encoder_probe_snapshot_t encoder;
       std::uint8_t direct_vgd;
-      std::uint8_t reserved[7];
+      std::uint8_t safe_capture;
+      std::uint8_t reserved[6];
       std::uint64_t vgd_session_id;
       std::uint32_t vgd_ring_slots;
       std::uint32_t vgd_transport_flags;
@@ -77,7 +78,7 @@ namespace platf::video_worker {
     std::string g_child_pipe;
     std::uint32_t g_parent_pid {};
     constexpr std::uint32_t kProtocolMagic = 0x4C565750;  // LVWP
-    constexpr std::uint32_t kProtocolVersion = 3;
+    constexpr std::uint32_t kProtocolVersion = 4;
     constexpr std::size_t kMaxPacketPayload = 32u * 1024u * 1024u - sizeof(packet_header_t);
 
     static_assert(std::is_trivially_copyable_v<video::config_t>);
@@ -343,7 +344,8 @@ namespace platf::video_worker {
       return 18;
     }
 
-    if (start.direct_vgd > 1 || std::any_of(std::begin(start.reserved), std::end(start.reserved),
+    if (start.direct_vgd > 1 || start.safe_capture > 1 || (start.direct_vgd && start.safe_capture) ||
+        std::any_of(std::begin(start.reserved), std::end(start.reserved),
                                             [](std::uint8_t value) { return value != 0; })) {
       (void) send(pipe, message_e::startup_error);
       return 19;
@@ -370,6 +372,7 @@ namespace platf::video_worker {
     } else {
       VDISPLAY::vgd::set_worker_ring_target(std::nullopt);
     }
+    VDISPLAY::vgd::set_worker_safe_capture(start.safe_capture != 0);
 
     if (!video::import_encoder_probe_snapshot(start.encoder)) {
       BOOST_LOG(error) << "Video worker: rejected invalid or unavailable encoder capability snapshot.";
@@ -489,45 +492,47 @@ namespace platf::video_worker {
   bool capture(safe::mail_t mail, video::config_t config, void *channel_data) {
     if (is_child_process()) return false;
 
+    const bool direct_vgd = VDISPLAY::is_luminalvgd_active();
     start_t start {};
     start.magic = kProtocolMagic;
     start.protocol_version = kProtocolVersion;
     start.config = config;
     if (!video::export_encoder_probe_snapshot(start.encoder)) {
       BOOST_LOG(error) << "Video worker: parent has no validated encoder snapshot; using in-process pipeline.";
-      return false;
+      return direct_vgd;
     }
-    const bool direct_vgd = VDISPLAY::is_luminalvgd_active();
     if (direct_vgd) {
       const auto display_name = display_device::map_output_name(::config::get_active_output_name());
       const auto target = VDISPLAY::vgd::ring_target_for_worker_display(display_name);
       if (!target) {
         BOOST_LOG(warning) << "Video worker: direct LuminalVGD session has no transferable ring target for '"
-                           << display_name << "'; bypassing worker and using the parent capture pipeline immediately.";
-        return false;
+                           << display_name << "'; starting isolated WGC safe-capture instead.";
+        start.safe_capture = 1;
+      } else {
+        if (display_name.size() >= sizeof(start.vgd_display_name)) {
+          BOOST_LOG(warning) << "Video worker: direct LuminalVGD display name exceeds the IPC limit; "
+                                "starting isolated WGC safe-capture instead.";
+          start.safe_capture = 1;
+        } else {
+          start.direct_vgd = 1;
+          start.vgd_session_id = target->session_id;
+          start.vgd_ring_slots = target->ring_slots;
+          start.vgd_transport_flags = target->transport_flags;
+          start.vgd_generation = target->generation;
+          std::copy(display_name.begin(), display_name.end(), std::begin(start.vgd_display_name));
+        }
       }
-      if (display_name.size() >= sizeof(start.vgd_display_name)) {
-        BOOST_LOG(warning) << "Video worker: direct LuminalVGD display name exceeds the IPC limit; "
-                              "using the parent capture pipeline immediately.";
-        return false;
-      }
-      start.direct_vgd = 1;
-      start.vgd_session_id = target->session_id;
-      start.vgd_ring_slots = target->ring_slots;
-      start.vgd_transport_flags = target->transport_flags;
-      start.vgd_generation = target->generation;
-      std::copy(display_name.begin(), display_name.end(), std::begin(start.vgd_display_name));
     }
 
     const std::string pipe_name = random_pipe_name();
-    if (pipe_name.empty()) return false;
+    if (pipe_name.empty()) return direct_vgd;
     const auto full_name = L"\\\\.\\pipe\\" + widen_ascii(pipe_name);
     child_t child;
     SECURITY_ATTRIBUTES pipe_security {};
     PSECURITY_DESCRIPTOR pipe_descriptor = nullptr;
     if (!make_pipe_security(pipe_security, pipe_descriptor)) {
       BOOST_LOG(error) << "Video worker: failed to construct a restricted named-pipe ACL; using in-process pipeline.";
-      return false;
+      return direct_vgd;
     }
     auto free_pipe_descriptor = util::fail_guard([&] { ::LocalFree(pipe_descriptor); });
     child.pipe = ::CreateNamedPipeW(full_name.c_str(), PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED | FILE_FLAG_FIRST_PIPE_INSTANCE,
@@ -535,7 +540,7 @@ namespace platf::video_worker {
                                     1, 4 * 1024 * 1024, 64 * 1024, 0, &pipe_security);
     if (child.pipe == INVALID_HANDLE_VALUE || !launch(child, pipe_name)) {
       BOOST_LOG(error) << "Video worker: failed to establish isolated process; using in-process pipeline.";
-      return false;
+      return direct_vgd;
     }
     OVERLAPPED connect {};
     connect.hEvent = ::CreateEventW(nullptr, TRUE, FALSE, nullptr);
@@ -559,7 +564,7 @@ namespace platf::video_worker {
       ::TerminateProcess(child.process, 0xE003);
       (void) ::WaitForSingleObject(child.process, 1000);
       BOOST_LOG(error) << "Video worker: child did not connect within 10 seconds.";
-      return false;
+      return direct_vgd;
     }
     if (connect.hEvent) ::CloseHandle(connect.hEvent);
     ULONG client_pid = 0;
@@ -567,7 +572,7 @@ namespace platf::video_worker {
       BOOST_LOG(error) << "Video worker: rejected unexpected pipe client pid=" << client_pid
                        << " expected=" << child.pid;
       ::TerminateProcess(child.process, 0xE004);
-      return false;
+      return direct_vgd;
     }
     BOOST_LOG(info) << "Video worker: isolated capture/encode process started (pid=" << child.pid << ")";
     if (!send(child.pipe, message_e::start, &start, sizeof(start))) {
@@ -598,7 +603,7 @@ namespace platf::video_worker {
       }
       if (!encoder_ready || ready_header.type == message_e::startup_error) {
         BOOST_LOG(warning) << "Video worker: failure occurred before GPU capture startup; using in-process pipeline.";
-        return false;
+        return direct_vgd;
       }
       const auto health = platf::dxgi::D3D11ProbeDeviceHealth();
       if (FAILED(health)) {
@@ -607,7 +612,7 @@ namespace platf::video_worker {
         return true;
       }
       BOOST_LOG(warning) << "Video worker: process exited and display health is good; using in-process pipeline.";
-      return false;
+      return direct_vgd;
     }
     BOOST_LOG(info) << "Video worker: validated encoder snapshot accepted; capture pipeline ready.";
 

--- a/src/platform/windows/virtual_display_vgd.cpp
+++ b/src/platform/windows/virtual_display_vgd.cpp
@@ -71,6 +71,7 @@ namespace VDISPLAY::vgd {
     std::map<GuidKey, TrackedSession> g_sessions;
     std::optional<RingTargetInfo> g_worker_ring_target;
     std::string g_worker_ring_display_name;
+    bool g_worker_safe_capture = false;
     std::thread g_ping_thread;
     std::atomic<bool> g_ping_stop {false};
     std::atomic<bool> g_ping_feeding {true};
@@ -395,6 +396,9 @@ namespace VDISPLAY::vgd {
     // older drivers retain their keyed-mutex transport unchanged.
     req.flags = (g_caps && (g_caps->caps & VGD_CAP_D3D12_FENCE_TRANSPORT)) ?
                   VGD_CREATE_D3D12_FENCE_TRANSPORT : 0;
+    if (g_caps && (g_caps->caps & VGD_CAP_FENCE_TRANSPORT_REQUIRED)) {
+      req.flags |= VGD_CREATE_FENCE_TRANSPORT_REQUIRED;
+    }
     req.mode_count = 1;
     // Callers pass millihertz (nvhttp/webrtc normalize Hz → mHz before the
     // call); the spec below must NOT rescale it again.
@@ -739,42 +743,52 @@ namespace VDISPLAY::vgd {
 
   std::optional<RingTargetInfo> ring_target_for_worker_display(const std::string &display_name) {
     if (display_name.empty()) return std::nullopt;
-    RingTargetInfo target {};
-    {
-      const std::wstring wanted(display_name.begin(), display_name.end());
-      std::lock_guard lk(g_mutex);
-      const auto found = std::find_if(g_sessions.begin(), g_sessions.end(), [&](const auto &entry) {
-        return !entry.second.display_name.empty() && entry.second.display_name == wanted;
-      });
-      if (found == g_sessions.end()) return std::nullopt;
-      target = {found->second.session_id, found->second.ring_slots, found->second.transport_flags, 0};
-    }
-    if (target.ring_slots < kMinRingSlots || target.ring_slots > kMaxRingSlots ||
-        (target.transport_flags & ~kAllowedRingTransportFlags) != 0) {
-      return std::nullopt;
-    }
-    VgdRingHandle *ring = vgd_ring_open(target.session_id, target.ring_slots);
-    if (!ring) return std::nullopt;
-    VgdRingStatus status {};
-    const auto status_result = vgd_ring_status(ring, &status);
-    vgd_ring_close(ring);
-    if (status_result != 0 || status.state != 1 || status.generation == 0 ||
-        status.latest_sequence == 0 || status.heartbeat_qpc == 0 || status.qpc_frequency == 0 ||
-        (status.transport_flags & ~kAllowedRingTransportFlags) != 0) {
-      return std::nullopt;
-    }
-    LARGE_INTEGER now_qpc {};
-    QueryPerformanceCounter(&now_qpc);
-    if (now_qpc.QuadPart < 0 || static_cast<uint64_t>(now_qpc.QuadPart) < status.heartbeat_qpc ||
-        static_cast<uint64_t>(now_qpc.QuadPart) - status.heartbeat_qpc > status.qpc_frequency * 2ULL) {
-      return std::nullopt;
-    }
-    target.generation = status.generation;
-    // The driver may downgrade the requested fence transport for a live
-    // generation. Hand off what the ring actually selected, not the flags
-    // remembered at monitor creation.
-    target.transport_flags = status.transport_flags;
-    return target;
+    const std::wstring wanted(display_name.begin(), display_name.end());
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(6);
+    do {
+      RingTargetInfo target {};
+      {
+        // Never hold the session-map lock while opening or polling a driver
+        // object. Monitor activation and ring publication advance on other
+        // threads during this bounded admission window.
+        std::lock_guard lk(g_mutex);
+        const auto found = std::find_if(g_sessions.begin(), g_sessions.end(), [&](const auto &entry) {
+          return !entry.second.display_name.empty() && entry.second.display_name == wanted;
+        });
+        if (found != g_sessions.end()) {
+          target = {found->second.session_id, found->second.ring_slots, found->second.transport_flags, 0};
+        }
+      }
+      if (target.session_id && target.ring_slots >= kMinRingSlots && target.ring_slots <= kMaxRingSlots &&
+          (target.transport_flags & ~kAllowedRingTransportFlags) == 0) {
+        VgdRingHandle *ring = vgd_ring_open(target.session_id, target.ring_slots);
+        if (ring) {
+          VgdRingStatus first {};
+          VgdRingStatus second {};
+          const bool first_ok = vgd_ring_status(ring, &first) == 0;
+          if (first_ok) std::this_thread::sleep_for(std::chrono::milliseconds(20));
+          const bool second_ok = first_ok && vgd_ring_status(ring, &second) == 0;
+          vgd_ring_close(ring);
+          LARGE_INTEGER now_qpc {};
+          QueryPerformanceCounter(&now_qpc);
+          const bool stable = second_ok && first.state == 1 && second.state == 1 &&
+                              first.generation == second.generation && second.generation != 0 &&
+                              first.transport_flags == second.transport_flags &&
+                              second.latest_sequence >= first.latest_sequence && second.latest_sequence != 0 &&
+                              second.heartbeat_qpc != 0 && second.qpc_frequency != 0 &&
+                              (second.transport_flags & ~kAllowedRingTransportFlags) == 0 &&
+                              now_qpc.QuadPart >= 0 && static_cast<uint64_t>(now_qpc.QuadPart) >= second.heartbeat_qpc &&
+                              static_cast<uint64_t>(now_qpc.QuadPart) - second.heartbeat_qpc <= second.qpc_frequency * 2ULL;
+          if (stable) {
+            target.generation = second.generation;
+            target.transport_flags = second.transport_flags;
+            return target;
+          }
+        }
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    } while (std::chrono::steady_clock::now() < deadline);
+    return std::nullopt;
   }
 
   void set_worker_ring_target(std::optional<RingTargetInfo> target, std::string display_name) {
@@ -786,6 +800,16 @@ namespace VDISPLAY::vgd {
   bool has_worker_ring_target() {
     std::lock_guard lk(g_mutex);
     return g_worker_ring_target.has_value();
+  }
+
+  void set_worker_safe_capture(bool enabled) {
+    std::lock_guard lk(g_mutex);
+    g_worker_safe_capture = enabled;
+  }
+
+  bool worker_safe_capture_requested() {
+    std::lock_guard lk(g_mutex);
+    return g_worker_safe_capture;
   }
 
   std::optional<RingTransitionToken> begin_planned_modeset() {

--- a/src/platform/windows/virtual_display_vgd.h
+++ b/src/platform/windows/virtual_display_vgd.h
@@ -80,7 +80,7 @@ namespace VDISPLAY::vgd {
 
   inline constexpr uint32_t kMinRingSlots = 2;
   inline constexpr uint32_t kMaxRingSlots = 8;
-  inline constexpr uint32_t kAllowedRingTransportFlags = 4;  // VGD_CREATE_D3D12_FENCE_TRANSPORT
+  inline constexpr uint32_t kAllowedRingTransportFlags = 12;  // fence transport + fence-required
 
   /// Resolve the tracked session whose monitor backs `display_name`
   /// (e.g. "\\\\.\\DISPLAY274"). With a single tracked session (the
@@ -98,6 +98,13 @@ namespace VDISPLAY::vgd {
   /// monitor map, but the named ring/fence resources are cross-process.
   void set_worker_ring_target(std::optional<RingTargetInfo> target, std::string display_name = {});
   bool has_worker_ring_target();
+
+  /// Process-local policy imported by an isolated worker. It forces the
+  /// worker to capture the VGD desktop through WGC when no immutable direct
+  /// ring generation can be transferred; the parent process never owns the
+  /// replacement GPU pipeline.
+  void set_worker_safe_capture(bool enabled);
+  bool worker_safe_capture_requested();
 
   struct RingTransitionToken {
     uint64_t session_id {0};


### PR DESCRIPTION
## What changed

- advances the embedded LuminalVGD dependency to proto 0.10 / Build 24 source
- requests immutable fence-only transport when the installed driver advertises it
- waits for a stable, active ring snapshot before transferring it to the video worker
- validates that synchronization cannot change inside a transferred generation
- keeps all LuminalVGD capture and encoding in the isolated video worker
- starts isolated WGC/DDA safe capture when a transferable direct ring is unavailable
- preserves native D3D12 NVENC and D3D11 compatibility encoder paths

## Root cause

The old coordination could snapshot a fence-backed ring while the driver subsequently changed that same generation to keyed-mutex transport. It could also bypass the worker and create a replacement GPU pipeline in the parent process when ring admission raced monitor activation. Both paths enlarged the graphics-device lifetime and could leave capture, NVENC, and the driver waiting on incompatible or poisoned resources.

## User impact

Healthy direct sessions retain the low-copy VGD-to-worker-to-encoder path. A failed fence transport now transitions to safe desktop capture inside the disposable worker instead of poisoning the LuminalShine server process. HDR, HEVC 4:4:4, D3D11, and native D3D12 encoding remain available.

## Validation

- UCRT64 build: `ninja -C build sunshine test_sunshine -j 4`
- 47 focused `VgdRingLiveness`, `DisplayHelperSessionDeferral`, and `VirtualDisplayClientLabel` tests
- LuminalVGD dependency workspace tests and release build

Depends on NortheBridge/LuminalVGD#29.
