### PR TITLE
Ignore local Mermaid diagrams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ docs/_generated/
 docs/html/
 docs/latex/
 
+# Local Mermaid architecture diagrams
+mmd/
+
 # Vitest coverage + JUnit XML output (consumed by Codecov in CI; never
 # committed). Includes coverage/web/lcov.info and coverage/web/junit.xml.
 coverage/


### PR DESCRIPTION
## What changed

- ignores the repository-local `mmd/` directory

## Why

Architecture diagrams rendered for local review can include Mermaid source and generated PNG files. These are working artifacts rather than LuminalShine runtime or release inputs and should not appear as accidental untracked changes.

## Impact

Developers can keep local Mermaid diagrams under `mmd/` without risking their inclusion in source commits or release packaging.

## Validation

- `git check-ignore` confirms both `mmd/newarch.mmd` and `mmd/newarch.png` are ignored
- staged diff passes `git diff --cached --check`
