### PR TITLE
Bundle LuminalVGD Build 24

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -341,11 +341,11 @@ jobs:
           # (github.com/NortheBridge/LuminalVGD releases). Bump on driver
           # releases. SudoVDA is gone by decision (2026-07-23) — the MSI's
           # drivers\luminalvgd\install.ps1 also removes it wherever found.
-          LUMINALVGD_VERSION: 'v0.1.0-alpha.7'
+          LUMINALVGD_VERSION: 'v0.1.0-alpha.8'
           # SHA-256 published in the release's SHA256SUMS asset. Keep this
           # pinned with the tag so a replaced or partial download cannot enter
           # the installer supply chain unnoticed.
-          LUMINALVGD_SHA256: 'afe890d0b0b94232b20eb0b6e3aac738e2f1ea73c66572541b9bb1b2e97d5afe'
+          LUMINALVGD_SHA256: '1cbe52890c732e5dfb6d2455d9035eb4c7881ab19dd49d89343b8b1fdbf807c2'
         run: |
           $ErrorActionPreference = 'Stop'
           $packageDir = Join-Path $PWD 'src_assets/windows/drivers/luminalvgd/driver-package'

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -147,7 +147,8 @@ jobs:
         # sign/install them in the coverage workflow.
         shell: pwsh
         env:
-          LUMINALVGD_VERSION: 'v0.1.0-alpha.5'
+          LUMINALVGD_VERSION: 'v0.1.0-alpha.8'
+          LUMINALVGD_SHA256: '1cbe52890c732e5dfb6d2455d9035eb4c7881ab19dd49d89343b8b1fdbf807c2'
         run: |
           $ErrorActionPreference = 'Stop'
           $packageDir = Join-Path $PWD 'src_assets/windows/drivers/luminalvgd/driver-package'
@@ -156,6 +157,10 @@ jobs:
           $zipUrl = "https://github.com/NortheBridge/LuminalVGD/releases/download/$($env:LUMINALVGD_VERSION)/LuminalVGD-$($env:LUMINALVGD_VERSION)-x64.zip"
           $zipPath = Join-Path $env:RUNNER_TEMP 'luminalvgd.zip'
           Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
+          $actualHash = (Get-FileHash -LiteralPath $zipPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualHash -ne $env:LUMINALVGD_SHA256) {
+            throw "LuminalVGD archive SHA-256 mismatch: expected $($env:LUMINALVGD_SHA256), got $actualHash"
+          }
           $tmp = Join-Path $env:RUNNER_TEMP 'luminalvgd'
           Expand-Archive -Path $zipPath -DestinationPath $tmp -Force
 


### PR DESCRIPTION
## What changed

- updates the Windows release workflow to bundle signed LuminalVGD `v0.1.0-alpha.8` / Build 24 / protocol 0.10
- pins the published archive SHA-256 (`1cbe5289…f807c2`) in the installer supply-chain gate
- updates Windows coverage to exercise the same driver package
- adds checksum enforcement to the coverage download path

## Why

LuminalShine 26.08.2 must ship the immutable fence-only transport driver that matches the host-side direct-capture coordination merged in PR #139. The old workflow remained pinned to Build 23, while coverage was further behind on alpha.5.

## Impact

The release installer packages the signed Build 24 INF, DLL, and catalog only after the archive digest and Authenticode signatures pass. Release and coverage jobs now test the same driver version.

## Validation

- LuminalVGD alpha.8 is published as the current stable release
- GitHub asset digest matches the pinned SHA-256
- archive contains `DriverVer 0.1.0.24`, a signed DLL, and a signed catalog
- workflow diff passes `git diff --check`
