### PR TITLE
Update MSI compatibility baseline for 26.08.2

### DIFF
--- a/tests/fixtures/msi_golden/msi_baseline.txt
+++ b/tests/fixtures/msi_golden/msi_baseline.txt
@@ -25,8 +25,8 @@ Property=WIXUI_INSTALLDIR|Value=INSTALL_ROOT
 Property=WixUIRMOption|Value=UseRM
 
 ## TABLE: Upgrade
-UpgradeCode={C2C36624-2D9C-4AFD-9C79-6B7861AE4A0D}|VersionMin=26.08.1.0|VersionMax=|Language=|Attributes=2|Remove=|ActionProperty=WIX_DOWNGRADE_DETECTED
-UpgradeCode={C2C36624-2D9C-4AFD-9C79-6B7861AE4A0D}|VersionMin=|VersionMax=26.08.1.0|Language=|Attributes=513|Remove=|ActionProperty=WIX_UPGRADE_DETECTED
+UpgradeCode={C2C36624-2D9C-4AFD-9C79-6B7861AE4A0D}|VersionMin=26.08.2.0|VersionMax=|Language=|Attributes=2|Remove=|ActionProperty=WIX_DOWNGRADE_DETECTED
+UpgradeCode={C2C36624-2D9C-4AFD-9C79-6B7861AE4A0D}|VersionMin=|VersionMax=26.08.2.0|Language=|Attributes=513|Remove=|ActionProperty=WIX_UPGRADE_DETECTED
 
 ## TABLE: Component
 Component=ArpCustomUninstallEntry|ComponentId={7843F978-AC8D-508C-8973-17EA02CAE565}|Directory_=INSTALL_ROOT|Attributes=260|Condition=|KeyPath=regKWKE1syhS2LUr3ZQtpKBQsQSUlQ


### PR DESCRIPTION
## Summary

- advance the MSI compatibility oracle's two version-bearing Upgrade rows from 26.08.1.0 to 26.08.2.0
- retain the existing UpgradeCode, attributes, action properties, and every other upgrade-critical row

## Validation

- python scripts/diff_msi_tables.py --selftest
- python scripts/assert_msi_invariants.py --selftest
- git diff --check

This is the documented moving-baseline update required by the 26.08.2 release build. The failed release run generated a valid candidate and reported only these four reciprocal version-row differences.