### PR TITLE
Bundle LuminalVGD Build 27 (v0.1.0-alpha.9)

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -341,11 +341,11 @@ jobs:
           # (github.com/NortheBridge/LuminalVGD releases). Bump on driver
           # releases. SudoVDA is gone by decision (2026-07-23) — the MSI's
           # drivers\luminalvgd\install.ps1 also removes it wherever found.
-          LUMINALVGD_VERSION: 'v0.1.0-alpha.8'
+          LUMINALVGD_VERSION: 'v0.1.0-alpha.9'
           # SHA-256 published in the release's SHA256SUMS asset. Keep this
           # pinned with the tag so a replaced or partial download cannot enter
           # the installer supply chain unnoticed.
-          LUMINALVGD_SHA256: '1cbe52890c732e5dfb6d2455d9035eb4c7881ab19dd49d89343b8b1fdbf807c2'
+          LUMINALVGD_SHA256: '582ad01d8a60ac6f1e017e381d1d1ec8ed00478ec62fc46b80317f47f9dedc16'
         run: |
           $ErrorActionPreference = 'Stop'
           $packageDir = Join-Path $PWD 'src_assets/windows/drivers/luminalvgd/driver-package'

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -147,8 +147,8 @@ jobs:
         # sign/install them in the coverage workflow.
         shell: pwsh
         env:
-          LUMINALVGD_VERSION: 'v0.1.0-alpha.8'
-          LUMINALVGD_SHA256: '1cbe52890c732e5dfb6d2455d9035eb4c7881ab19dd49d89343b8b1fdbf807c2'
+          LUMINALVGD_VERSION: 'v0.1.0-alpha.9'
+          LUMINALVGD_SHA256: '582ad01d8a60ac6f1e017e381d1d1ec8ed00478ec62fc46b80317f47f9dedc16'
         run: |
           $ErrorActionPreference = 'Stop'
           $packageDir = Join-Path $PWD 'src_assets/windows/drivers/luminalvgd/driver-package'


### PR DESCRIPTION
## Summary
Bumps the pinned LuminalVGD driver release from v0.1.0-alpha.8 (build 24) to **v0.1.0-alpha.9 (build 27, `DriverVer 08/07/2026, 0.1.0.27`, proto 0.10)** in `ci-windows.yml` and `coverage-windows.yml`, with the SHA-256 from the release's `SHA256SUMS` asset — same two-pin format as #141.

Build 27 highlights (full notes on the [release](https://github.com/NortheBridge/LuminalVGD/releases/tag/v0.1.0-alpha.9)):
- The D3D12 timeline-fence transport engages for the first time (NortheBridge/LuminalVGD#30 — `SHARED|NTHANDLE` ring-texture fix); Direct-to-Encode verified live including 4K HDR Battlefield 6 on native-D3D12 NVENC.
- TerminateIndirectOnStall host-kill windows closed + D3D11 device leak fixed (NortheBridge/LuminalVGD#31).

Fresh installs and the devnode rebind path pick up 0.1.0.27; hosts with a newer installed driver are left in place as usual.

## Test plan
- Pin format identical to #141 (version + SHA-256 supply-chain check already enforced by both workflows).
- Asset name/URL verified against the published release; SHA matches `SHA256SUMS` (`582ad01d…dc16`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)