### PR TITLE
Worker-first streaming stabilization: egress QoS, strict-client startup, VGD self-heal, TLS baseline

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -56,6 +56,27 @@ namespace mail {
   MAIL(gamepad_feedback);
   MAIL(hdr);
   MAIL(chroma_downgrade);
+  // Raised by the RTSP video thread once the client's UDP peer has been
+  // authenticated.  Windows may prewarm capture and encoding before that
+  // point, but encoded packets must not be handed to the broadcaster while
+  // the destination endpoint is still unset.
+  MAIL(video_peer_ready);
+  // Raised once the session's video pipeline can deliver its first packet:
+  // by the isolated worker at FIRST_PACKET, or immediately when a session
+  // commits to the in-process pipeline (which initializes after the peer
+  // attaches and therefore has nothing to wait for). RTSP holds the ANNOUNCE
+  // response on this for strict-first-frame clients (Xbox/webOS ports) whose
+  // older moonlight-common-c enforces a hard 10-second no-video budget.
+  MAIL(video_pipeline_ready);
+  // Raised by the broadcaster when an encoded-frame sequence gap or excessive
+  // packet age makes the current predictive chain unsafe to transmit. The
+  // isolated worker uses this alongside `idr` to bypass only the normal
+  // client-feedback cooldown and produce one immediate recovery IDR.
+  MAIL(video_discontinuity);
+  // Carries the frame index of an IDR after all of its UDP shards have been
+  // submitted. Reading an IDR from worker IPC is not delivery and must not
+  // acknowledge recovery early.
+  MAIL(video_idr_submitted);
 #undef MAIL
 
 }  // namespace mail

--- a/src/httpcommon.cpp
+++ b/src/httpcommon.cpp
@@ -967,9 +967,10 @@ namespace http {
       return false;
     }
 
-    // Perform the download
-    curl_easy_setopt(curl, CURLOPT_SSLVERSION, ssl_version);  // NOSONAR
+    // Perform the download. TLS baseline first, then the caller's explicit
+    // (possibly stricter) version floor so it is never clobbered.
     configure_curl_tls(curl);
+    curl_easy_setopt(curl, CURLOPT_SSLVERSION, ssl_version);  // NOSONAR
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, fwrite);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
@@ -989,6 +990,13 @@ namespace http {
       return false;
     }
     ensure_curl_global_init();
+    // TLS 1.2 minimum for every outbound connection; libcurl still negotiates
+    // TLS 1.3 when the peer supports it. Without this floor libcurl's default
+    // ClientHello offers TLS 1.0+, which current Windows builds flag via the
+    // Program Compatibility Assistant ("insecure TLS versions that are
+    // disabled on Windows"). Callers needing a stricter floor may override
+    // AFTER calling this function.
+    curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);  // NOSONAR
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
     bool applied = apply_default_ca_store(curl);

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -83,6 +83,8 @@ namespace nvhttp {
         ServerBase<SunshineHTTPS>::ServerBase(443),
         context(boost::asio::ssl::context::tls_server) {
       // Disabling TLS 1.0 and 1.1 (see RFC 8996)
+      context.set_options(boost::asio::ssl::context::no_sslv2);
+      context.set_options(boost::asio::ssl::context::no_sslv3);
       context.set_options(boost::asio::ssl::context::no_tlsv1);
       context.set_options(boost::asio::ssl::context::no_tlsv1_1);
       context.use_certificate_chain_file(certification_file);

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -52,6 +52,7 @@
   #include "platform/windows/display.h"
   #include "platform/windows/display_helper_request_helpers.h"
   #include "platform/windows/misc.h"
+  #include "platform/windows/video_worker.h"
   #include "platform/windows/virtual_display.h"
   #include "platform/windows/virtual_display_cleanup.h"
 #endif
@@ -2408,6 +2409,16 @@ namespace nvhttp {
           active_output.empty() ? nullptr : active_output.c_str()
         );
       }
+
+      // Prewarm the isolated video worker in parallel with app launch and the
+      // client's RTSP handshake: process spawn + DLL load + shader compile
+      // (~1.5-2 s) then move off the post-PLAY first-video budget that strict
+      // Xbox/webOS Moonlight ports enforce. Detached: the launch response
+      // must not wait, and a session that starts before the slot fills simply
+      // spawns its own worker as before.
+      std::thread([] {
+        (void) platf::video_worker::prewarm();
+      }).detach();
 #else
       display_helper_integration::DisplayApplyBuilder noop_builder;
       noop_builder.set_session(*launch_session);
@@ -2766,6 +2777,9 @@ namespace nvhttp {
     tree.put("root.<xmlattr>.status_code", 200);
 
     rtsp_stream::terminate_sessions();
+#ifdef _WIN32
+    platf::video_worker::cancel_prewarm();
+#endif
 
     const bool has_running_app = proc::proc.running() > 0;
 #ifdef _WIN32

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -358,6 +358,10 @@ namespace platf {
 
     std::optional<std::chrono::steady_clock::time_point> frame_timestamp;
     std::optional<std::chrono::steady_clock::time_point> host_processing_timestamp;
+    /// Capture-source epoch assigned before this image leaves its capture
+    /// callback.  An isolated encoder uses it to prove that a packet was not
+    /// produced by a display/encoder session retired during reinitialization.
+    std::uint64_t capture_generation = 0;
 
     virtual ~img_t() = default;
   };

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -2064,8 +2064,21 @@ namespace platf {
                              << display_name << "; falling back to WGC/DDA.";
         }
         if (worker_vgd_target) {
-          BOOST_LOG(error) << "Video worker: transferred LuminalVGD ring could not be opened for "
-                           << display_name << "; refusing silent WGC/DDA substitution.";
+          // The parent validated the transport, but a modeset can retire that
+          // generation before the child opens it.  Treat this as an explicit,
+          // observable source handoff instead of repeatedly rebuilding against
+          // the stale generation until the client's first-frame deadline.
+          // The worker remains the isolation boundary and WGC receives the
+          // exact same configured output and encoder contract.
+          BOOST_LOG(warning) << "Video worker: transferred LuminalVGD ring could not be opened for "
+                             << display_name << "; switching this isolated worker to WGC safe-capture.";
+          VDISPLAY::vgd::set_worker_ring_target(std::nullopt, {});
+          VDISPLAY::vgd::set_worker_safe_capture(true);
+          if (auto safe_disp = dxgi::display_wgc_ipc_vram_t::create(config, display_name)) {
+            vgd_transition::note_capture_backend(vgd_transition::kCaptureKindWgc, display_name);
+            return safe_disp;
+          }
+          BOOST_LOG(error) << "Video worker: WGC replacement source also failed for " << display_name << '.';
           return nullptr;
         }
       }

--- a/src/platform/windows/display_helper_integration.cpp
+++ b/src/platform/windows/display_helper_integration.cpp
@@ -1447,8 +1447,7 @@ namespace display_helper_integration {
             BOOST_LOG(info) << "Display helper: requested resolution/refresh already active; skipping redundant mode APPLY.";
           }
 
-          BOOST_LOG(info) << "Display helper: stage 1/3 complete; entering a 2-second quiet settle before making LuminalVGD primary.";
-          std::this_thread::sleep_for(std::chrono::seconds(2));
+          BOOST_LOG(info) << "Display helper: stage 1/3 complete; making LuminalVGD primary after observed activation.";
 
           display_device::SingleDisplayConfiguration primary_config;
           primary_config.m_device_id = verification_configuration->m_device_id;
@@ -1470,26 +1469,36 @@ namespace display_helper_integration {
             g_last_apply_failure.store(ApplyFailure::requested_mode, std::memory_order_release);
             return false;
           }
-          BOOST_LOG(info) << "Display helper: stage 2/3 complete; retaining both displays for a 3-second capture-ready settle.";
-          std::this_thread::sleep_for(std::chrono::seconds(3));
+          if (primary_outcome == platf::display_helper_client::ApplyOutcome::indeterminate) {
+            // Windows already exposes the requested mode, so the operation
+            // succeeded from the stream's perspective. Do NOT hard-restart the
+            // helper here: its SetDisplayConfig may still be settling, and
+            // killing it mid-modeset destabilizes the launch path. Reconnect
+            // the pipe instead so a late acknowledgement cannot be mistaken
+            // for the stage-3 reply.
+            BOOST_LOG(warning) << "Display helper: stage 2/3 mode is active despite an indeterminate helper completion; resetting the IPC connection before the final APPLY.";
+            platf::display_helper_client::reset_connection();
+          }
+          BOOST_LOG(info) << "Display helper: stage 2/3 complete; requested core mode is observable.";
 
           const auto pre_exclusive_ring = VDISPLAY::vgd::begin_planned_modeset();
           (void) apply_best_effort_hdr_now(
             verification_configuration->m_device_id,
             verification_configuration->m_hdr_state
           );
-          if (!pre_exclusive_ring ||
-              !VDISPLAY::vgd::wait_for_planned_modeset(*pre_exclusive_ring, std::chrono::seconds(12))) {
+          if (!pre_exclusive_ring) {
             direct_ring_admitted = false;
-            if (pre_exclusive_ring) {
-              platf::dxgi::mark_vgd_ring_broken(pre_exclusive_ring->session_id);
-            }
-            BOOST_LOG(warning) << "Display helper: LuminalVGD did not publish a pre-exclusive frame; "
-                                  "retaining VGD-primary extended topology and selecting HDR-capable fallback capture.";
+            BOOST_LOG(warning) << "Display helper: LuminalVGD did not expose a ring target; retaining VGD-primary extended topology and selecting HDR-capable fallback capture.";
             final_request.configuration = primary_config;
             final_request.virtual_display_arrangement = VirtualDisplayArrangement::ExtendedPrimary;
           } else {
-            BOOST_LOG(info) << "Display helper: pre-exclusive LuminalVGD frame published after final HDR state; direct capture admitted.";
+            // Preserve the stable session identity across the exclusive APPLY,
+            // but deliberately do not preserve this generation: Windows will
+            // rebuild it as the physical paths are removed. The isolated
+            // worker binds the resulting generation after it opens the same
+            // authenticated session's ring.
+            direct_ring_admitted = true;
+            BOOST_LOG(info) << "Display helper: LuminalVGD session identity admitted; committing requested Exclusive Mode and deferring generation binding to the isolated worker.";
             auto exclusive_config = *verification_configuration;
             exclusive_config.m_resolution.reset();
             exclusive_config.m_refresh_rate.reset();
@@ -1507,8 +1516,11 @@ namespace display_helper_integration {
         BOOST_LOG(info) << (direct_ring_admitted ?
           "Display helper: stage 3/3 committing topology-only exclusive APPLY via helper." :
           "Display helper: stage 3/3 committing safe VGD-primary fallback topology via helper.");
-        const auto ring_before = direct_ring_admitted && request.session && request.session->virtual_display ?
-                                   VDISPLAY::vgd::begin_planned_modeset() : std::nullopt;
+        // Do not wait for a published post-exclusive frame here. On supported
+        // IddCx stacks, opening the consumer is what arms surface publication;
+        // waiting before starting capture is a circular dependency. Requested
+        // mode verification below remains the display-admission gate.
+        const std::optional<VDISPLAY::vgd::RingTransitionToken> ring_before = std::nullopt;
         const auto outcome = platf::display_helper_client::send_apply_json(*payload);
         bool ok = outcome == platf::display_helper_client::ApplyOutcome::applied;
         if (outcome == platf::display_helper_client::ApplyOutcome::indeterminate &&
@@ -1547,6 +1559,11 @@ namespace display_helper_integration {
             BOOST_LOG(info) << "Display helper: LuminalVGD ring is ACTIVE after the planned modeset.";
           }
         }
+        // Do not inspect virtual-desktop coordinates here. The service desktop
+        // is not the interactive capture desktop and previously reported a
+        // false stable rectangle. The isolated worker performs this bounded,
+        // non-fatal observation in the correct user session immediately before
+        // opening WGC.
         BOOST_LOG(info) << "Display helper: APPLY dispatch result=" << (ok ? "true" : "false");
         if (ok && request.session) {
           g_restore_expected.store(false, std::memory_order_relaxed);

--- a/src/platform/windows/display_vgd.cpp
+++ b/src/platform/windows/display_vgd.cpp
@@ -334,8 +334,11 @@ namespace platf::dxgi {
       if (!token || token->session_id != target->session_id ||
           !VDISPLAY::vgd::wait_for_planned_modeset(*token, std::chrono::seconds(3))) {
         BOOST_LOG(warning) << "LuminalVGD capture: session 0x" << std::hex << target->session_id
-                           << std::dec << " did not recover during its final 3-second qualification; using fallback capture.";
+                           << std::dec << " did not publish a stable frame during final qualification; using fallback capture.";
         return -1;
+      } else {
+        BOOST_LOG(info) << "LuminalVGD capture: session 0x" << std::hex << target->session_id
+                        << std::dec << " published a stable frame during final qualification; direct capture restored.";
       }
 
       uint64_t admitted_session = target->session_id;
@@ -345,12 +348,6 @@ namespace platf::dxgi {
         std::memory_order_acq_rel,
         std::memory_order_acquire
       );
-      BOOST_LOG(info) << "LuminalVGD capture: session 0x" << std::hex << target->session_id
-                      << std::dec << " published a stable frame during final qualification; direct capture restored.";
-    }
-
-    if (display_base_t::init(config, display_name, true /* skip_dd_test: ring capture doesn't use Desktop Duplication */)) {
-      return -1;
     }
 
     // The driver creates the ring section at monitor plug; capture starts
@@ -370,12 +367,117 @@ namespace platf::dxgi {
 
     _ring = ring;
     if (VDISPLAY::vgd::has_worker_ring_target()) {
+      // Holding the ring open is what arms surface publication on supported
+      // IddCx stacks, so the first status reads after open routinely show the
+      // provisional REBUILDING/sequence-zero contract (or another transient of
+      // the post-modeset rebuild, e.g. ACTIVE before the first surface). Wait
+      // a bounded interval for the committed ACTIVE contract instead of
+      // abandoning Direct-to-Encode on the first observation; isolated WGC
+      // remains the fallback if the ring never commits.
       VgdRingStatus opened_status {};
-      if (vgd_ring_status(ring, &opened_status) != 0 || opened_status.state != 1 ||
-          opened_status.generation != target->generation ||
-          opened_status.transport_flags != target->transport_flags) {
-        BOOST_LOG(error) << "Video worker: transferred LuminalVGD ring changed before open; "
-                            "rejecting stale generation/transport.";
+      std::int32_t ring_status = -1;
+      auto binding = vgd_worker_ring_binding_e::reject;
+      bool heartbeat_fresh = false;
+      // One second: long enough for a ring that is actively committing its
+      // post-modeset generation, short enough that a producer that has not
+      // started (observed: provisional for 3+ s after the exclusive APPLY)
+      // pivots to WGC before eating the connection budget. A later modeset
+      // re-enters init and can still re-bind Direct-to-Encode.
+      const auto admission_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+      for (;;) {
+        ring_status = vgd_ring_status(ring, &opened_status);
+        if (ring_status != 0 || opened_status.state == vgd_ring_state::dead) {
+          binding = vgd_worker_ring_binding_e::reject;
+          break;  // The ring is gone or dead; waiting cannot revive it.
+        }
+        if (target->generation != 0 && opened_status.generation != 0 &&
+            opened_status.generation != target->generation) {
+          // A Windows modeset retired the previously bound generation while
+          // the authenticated session identity stayed fixed. Re-defer and let
+          // this admission bind the successor generation instead of
+          // permanently degrading the session to WGC.
+          BOOST_LOG(info) << "LuminalVGD capture: session 0x" << std::hex << target->session_id
+                          << std::dec << " generation " << target->generation
+                          << " was retired by a modeset; re-deferring to bind generation "
+                          << opened_status.generation << '.';
+          target->generation = 0;
+        }
+        binding = classify_worker_ring_binding(
+          ring_status,
+          opened_status.state,
+          opened_status.generation,
+          opened_status.latest_sequence,
+          opened_status.transport_flags,
+          target->generation,
+          target->transport_flags
+        );
+        LARGE_INTEGER now_qpc {};
+        const bool qpc_read = QueryPerformanceCounter(&now_qpc) != FALSE;
+        heartbeat_fresh = qpc_read && now_qpc.QuadPart >= 0 &&
+          opened_status.qpc_frequency != 0 && opened_status.heartbeat_qpc != 0 &&
+          static_cast<uint64_t>(now_qpc.QuadPart) >= opened_status.heartbeat_qpc &&
+          static_cast<uint64_t>(now_qpc.QuadPart) - opened_status.heartbeat_qpc <=
+            opened_status.qpc_frequency * 2ULL;
+        if (binding == vgd_worker_ring_binding_e::ready && heartbeat_fresh) break;
+        if (binding == vgd_worker_ring_binding_e::provisional) {
+          // A producer that has never published stays provisional for many
+          // seconds on the current driver; every second spent here charges
+          // the client's first-video budget. Pivot to WGC immediately — the
+          // mid-session re-defer path upgrades to Direct-to-Encode as soon
+          // as the ring commits a generation.
+          break;
+        }
+        if (std::chrono::steady_clock::now() >= admission_deadline) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
+      if (binding != vgd_worker_ring_binding_e::ready || !heartbeat_fresh) {
+        BOOST_LOG(warning) << "Video worker: transferred LuminalVGD ring did not become capture-ready within its bounded admission; switching to isolated WGC"
+                         << " (status=" << ring_status
+                         << ", expected_generation=" << target->generation
+                         << ", observed_generation=" << opened_status.generation
+                         << ", state=" << opened_status.state
+                         << ", sequence=" << opened_status.latest_sequence
+                         << ", expected_transport=0x" << std::hex << target->transport_flags
+                         << ", observed_transport=0x" << opened_status.transport_flags
+                         << std::dec << ", heartbeat_fresh=" << heartbeat_fresh << ").";
+        return -1;
+      }
+      if (target->generation == 0) {
+        target->generation = opened_status.generation;
+        VDISPLAY::vgd::set_worker_ring_target(*target, display_name);
+        BOOST_LOG(info) << "Video worker: bound direct LuminalVGD session 0x" << std::hex
+                        << target->session_id << std::dec << " to post-modeset generation "
+                        << target->generation << " (state=" << opened_status.state << ").";
+      }
+    }
+
+    // Do the comparatively expensive DXGI/display initialization only after
+    // a transferred ring has proven it can deliver. A provisional ring used
+    // to spend roughly two seconds here before selecting WGC, consuming the
+    // Xbox/webOS connection budget for no benefit.
+    if (display_base_t::init(config, display_name, true /* skip_dd_test: ring capture doesn't use Desktop Duplication */)) {
+      return -1;
+    }
+
+    // The display initialization above can overlap a Windows modeset. Recheck
+    // the now-fixed generation before advertising direct capture to NVENC.
+    if (VDISPLAY::vgd::has_worker_ring_target()) {
+      VgdRingStatus confirmed {};
+      const auto status = vgd_ring_status(ring, &confirmed);
+      const auto binding = classify_worker_ring_binding(
+        status,
+        confirmed.state,
+        confirmed.generation,
+        confirmed.latest_sequence,
+        confirmed.transport_flags,
+        target->generation,
+        target->transport_flags
+      );
+      if (binding != vgd_worker_ring_binding_e::ready) {
+        BOOST_LOG(warning) << "Video worker: LuminalVGD ring changed during display initialization; switching to isolated WGC"
+                           << " (status=" << status << ", generation=" << confirmed.generation
+                           << ", state=" << confirmed.state << ", sequence=" << confirmed.latest_sequence
+                           << ", transport=0x" << std::hex << confirmed.transport_flags << std::dec << ").";
         return -1;
       }
     }
@@ -889,6 +991,13 @@ namespace platf::dxgi {
     }
     vgd_ring_sample_t sample {};
     if (!read_ring_sample(sample, false)) {
+      return false;
+    }
+    // Recovery is a transition away from a previously publishing source. A
+    // brand-new REBUILDING ring with no sequence has never supplied a frame;
+    // treating it as a 15-minute GPU outage bypasses startup fallback and
+    // strands every client behind a blank placeholder.
+    if (_last_sequence == 0 && sample.latest_sequence == 0) {
       return false;
     }
     const bool recovering = _liveness.recovering(sample, std::chrono::steady_clock::now());

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -27,6 +27,7 @@ extern "C" {
 #include "src/nvenc/nvenc_d3d12.h"
 #include "src/nvenc/nvenc_d3d11_on_cuda.h"
 #include "src/nvenc/nvenc_utils.h"
+#include "src/platform/windows/virtual_display_vgd.h"
 #include "src/video.h"
 #include "utf_utils.h"
 
@@ -1127,7 +1128,8 @@ namespace platf::dxgi {
       // Prefer the native D3D12 NVENC contract. D3D11On12 lets the proven
       // Sunshine colour-conversion shaders render directly into the D3D12
       // input allocation while NVENC receives explicit fence points.
-      if (pix_fmt != pix_fmt_e::yuv444p16 && !gpu_recovery_policy::force_d3d11()) {
+      const bool safe_capture_d3d11 = VDISPLAY::vgd::worker_safe_capture_requested();
+      if (pix_fmt != pix_fmt_e::yuv444p16 && !gpu_recovery_policy::force_d3d11() && !safe_capture_d3d11) {
         auto native12 = std::make_unique<nvenc::nvenc_d3d12>(adapter_p);
         if (native12->valid() && !base.init(display, adapter_p, pix_fmt,
                                             native12->d3d11_device(), native12->d3d11_context())) {
@@ -1136,9 +1138,10 @@ namespace platf::dxgi {
           BOOST_LOG(info) << "NvEnc: native D3D12 input/output path selected (explicit fences)";
         }
       }
-      if (pix_fmt != pix_fmt_e::yuv444p16 && gpu_recovery_policy::force_d3d11()) {
-        BOOST_LOG(warning) << "NvEnc: native D3D12 path suppressed by the GPU recovery circuit; "
-                              "selecting D3D11 compatibility transport.";
+      if (pix_fmt != pix_fmt_e::yuv444p16 && (gpu_recovery_policy::force_d3d11() || safe_capture_d3d11)) {
+        BOOST_LOG(info) << "NvEnc: native D3D12 path suppressed for "
+                        << (safe_capture_d3d11 ? "isolated WGC safe capture" : "GPU recovery")
+                        << "; selecting D3D11 compatibility transport.";
       }
       if (!nvenc_d3d) {
         if (base.init(display, adapter_p, pix_fmt)) return false;

--- a/src/platform/windows/ipc/display_settings_client.cpp
+++ b/src/platform/windows/ipc/display_settings_client.cpp
@@ -25,7 +25,14 @@ namespace platf::display_helper_client {
     constexpr int kConnectTimeoutMs = 2000;
     constexpr int kSendTimeoutMs = 5000;
     constexpr int kShutdownIpcTimeoutMs = 500;
-    constexpr int kApplyResultTimeoutMs = 30000;
+    // A display-helper completion is advisory: every caller verifies the
+    // requested Windows topology independently.  Blocking the HTTPS launch
+    // response for 30 seconds makes fixed-deadline Moonlight clients abandon
+    // an otherwise healthy host — but real Windows modesets with driver settle
+    // routinely take several seconds, and classifying them as indeterminate
+    // destabilizes the launch path.  10 seconds covers a legitimate modeset
+    // while remaining inside the clients' launch tolerances.
+    constexpr int kApplyResultTimeoutMs = 10000;
     constexpr int kRevertAcceptedTimeoutMs = 2000;
 
     bool shutdown_requested() {

--- a/src/platform/windows/vgd_ring_liveness.h
+++ b/src/platform/windows/vgd_ring_liveness.h
@@ -19,6 +19,41 @@ namespace platf::dxgi {
     inline constexpr uint32_t dead = 3;
   }  // namespace vgd_ring_state
 
+  /// Result of validating the authenticated ring identity imported by an
+  /// isolated video worker. `provisional` is the driver's documented
+  /// pre-first-surface state: generation exists, but its synchronization
+  /// transport has not been published yet.
+  enum class vgd_worker_ring_binding_e {
+    reject,
+    ready,
+    provisional,
+  };
+
+  constexpr vgd_worker_ring_binding_e classify_worker_ring_binding(
+    int32_t status_result,
+    uint32_t state,
+    uint32_t generation,
+    uint64_t latest_sequence,
+    uint32_t transport_flags,
+    uint32_t expected_generation,
+    uint32_t expected_transport_flags
+  ) {
+    if (status_result != 0 ||
+        (state != vgd_ring_state::active && state != vgd_ring_state::rebuilding) ||
+        generation == 0 ||
+        (expected_generation != 0 && generation != expected_generation)) {
+      return vgd_worker_ring_binding_e::reject;
+    }
+    if (state == vgd_ring_state::rebuilding &&
+        latest_sequence == 0 && transport_flags == 0) {
+      return vgd_worker_ring_binding_e::provisional;
+    }
+    return state == vgd_ring_state::active && latest_sequence != 0 &&
+             transport_flags == expected_transport_flags ?
+             vgd_worker_ring_binding_e::ready :
+             vgd_worker_ring_binding_e::reject;
+  }
+
   /// What the ring reader should do with the current observation.
   enum class vgd_ring_verdict_e {
     consume,  ///< Healthy: go claim a frame.

--- a/src/platform/windows/video_worker.cpp
+++ b/src/platform/windows/video_worker.cpp
@@ -6,7 +6,10 @@
 #include <chrono>
 #include <cstring>
 #include <cstdint>
+#include <limits>
 #include <mutex>
+#include <memory>
+#include <optional>
 #include <thread>
 #include <type_traits>
 #include <vector>
@@ -42,6 +45,7 @@ namespace platf::video_worker {
       encoder_ready,
       capture_ready,
       startup_error,
+      capture_reinitializing,
     };
 
 #pragma pack(push, 1)
@@ -51,9 +55,18 @@ namespace platf::video_worker {
     };
     struct packet_header_t {
       std::int64_t frame_index;
+      std::int64_t frame_timestamp_ns;
+      std::int64_t host_processing_timestamp_ns;
       std::uint32_t data_size;
       std::uint8_t idr;
       std::uint8_t after_rfi;
+      std::uint8_t has_frame_timestamp;
+      std::uint8_t has_host_processing_timestamp;
+      std::uint8_t capture_placeholder;
+      std::uint64_t capture_generation;
+    };
+    struct generation_t {
+      std::uint64_t value;
     };
     struct invalidate_t {
       std::int64_t first;
@@ -78,7 +91,10 @@ namespace platf::video_worker {
     std::string g_child_pipe;
     std::uint32_t g_parent_pid {};
     constexpr std::uint32_t kProtocolMagic = 0x4C565750;  // LVWP
-    constexpr std::uint32_t kProtocolVersion = 4;
+    constexpr std::uint32_t kProtocolVersion = 8;
+    std::atomic_bool g_capture_reinitializing {false};
+    std::atomic<std::uint64_t> g_capture_generation {1};
+    std::mutex g_capture_generation_mutex;
     constexpr std::size_t kMaxPacketPayload = 32u * 1024u * 1024u - sizeof(packet_header_t);
 
     static_assert(std::is_trivially_copyable_v<video::config_t>);
@@ -116,6 +132,14 @@ namespace platf::video_worker {
       return bytes;
     }
 
+    std::int64_t serialize_timestamp(const std::chrono::steady_clock::time_point &timestamp) {
+      return std::chrono::duration_cast<std::chrono::nanoseconds>(timestamp.time_since_epoch()).count();
+    }
+
+    std::chrono::steady_clock::time_point deserialize_timestamp(std::int64_t timestamp_ns) {
+      return std::chrono::steady_clock::time_point {std::chrono::nanoseconds {timestamp_ns}};
+    }
+
     bool wait_overlapped(HANDLE pipe, OVERLAPPED &overlapped, DWORD timeout, DWORD &transferred) {
       const DWORD wait = ::WaitForSingleObject(overlapped.hEvent, timeout);
       if (wait != WAIT_OBJECT_0) {
@@ -123,14 +147,21 @@ namespace platf::video_worker {
         // OVERLAPPED and its event are stack-owned. They must remain alive
         // until cancellation is observed as complete.
         (void) ::WaitForSingleObject(overlapped.hEvent, INFINITE);
-        DWORD ignored = 0;
-        (void) ::GetOverlappedResult(pipe, &overlapped, &ignored, FALSE);
+        // The IO can complete in the race window between the wait expiring and
+        // the cancellation taking effect. Those bytes are already consumed from
+        // the byte-mode pipe: discarding them here permanently desynchronizes
+        // message framing, so honor them exactly like an in-time completion.
+        DWORD completed = 0;
+        if (::GetOverlappedResult(pipe, &overlapped, &completed, FALSE) && completed != 0) {
+          transferred = completed;
+          return true;
+        }
         return false;
       }
       return ::GetOverlappedResult(pipe, &overlapped, &transferred, FALSE) != FALSE;
     }
 
-    bool write_exact(HANDLE pipe, const void *data, std::uint32_t size) {
+    bool write_exact(HANDLE pipe, const void *data, std::uint32_t size, DWORD timeout = 500) {
       const auto *cursor = static_cast<const std::uint8_t *>(data);
       while (size) {
         DWORD written = 0;
@@ -139,7 +170,7 @@ namespace platf::video_worker {
         if (!overlapped.hEvent) return false;
         const BOOL started = ::WriteFile(pipe, cursor, size, &written, &overlapped);
         const DWORD error = started ? ERROR_SUCCESS : ::GetLastError();
-        const bool ok = started || (error == ERROR_IO_PENDING && wait_overlapped(pipe, overlapped, 500, written));
+        const bool ok = started || (error == ERROR_IO_PENDING && wait_overlapped(pipe, overlapped, timeout, written));
         ::CloseHandle(overlapped.hEvent);
         if (!ok || written == 0) {
           return false;
@@ -152,14 +183,20 @@ namespace platf::video_worker {
 
     bool read_exact(HANDLE pipe, void *data, std::uint32_t size, DWORD timeout = INFINITE) {
       auto *cursor = static_cast<std::uint8_t *>(data);
+      const std::uint32_t requested = size;
       while (size) {
+        // Once ANY byte of this datum has been consumed from the byte-mode
+        // pipe, abandoning the remainder on a short polling timeout would
+        // permanently desynchronize message framing. Extend the deadline for
+        // the tail exactly like receive() does for payloads.
+        const DWORD effective_timeout = size == requested ? timeout : std::max<DWORD>(timeout, 5000);
         DWORD read = 0;
         OVERLAPPED overlapped {};
         overlapped.hEvent = ::CreateEventW(nullptr, TRUE, FALSE, nullptr);
         if (!overlapped.hEvent) return false;
         const BOOL started = ::ReadFile(pipe, cursor, size, &read, &overlapped);
         const DWORD error = started ? ERROR_SUCCESS : ::GetLastError();
-        const bool ok = started || (error == ERROR_IO_PENDING && wait_overlapped(pipe, overlapped, timeout, read));
+        const bool ok = started || (error == ERROR_IO_PENDING && wait_overlapped(pipe, overlapped, effective_timeout, read));
         ::CloseHandle(overlapped.hEvent);
         if (!ok || read == 0) {
           return false;
@@ -170,10 +207,17 @@ namespace platf::video_worker {
       return true;
     }
 
-    bool send(HANDLE pipe, message_e type, const void *payload = nullptr, std::uint32_t size = 0) {
+    bool send(HANDLE pipe, message_e type, const void *payload = nullptr, std::uint32_t size = 0, DWORD timeout = 500) {
       const header_t header {type, size};
-      return write_exact(pipe, &header, sizeof(header)) && (!size || write_exact(pipe, payload, size));
+      return write_exact(pipe, &header, sizeof(header), timeout) && (!size || write_exact(pipe, payload, size, timeout));
     }
+
+    // The child's packet stream can legitimately stall when the parent reader
+    // is blocked behind the session's bounded egress queue (a slow client).
+    // That is backpressure, not death: give those writes the same tolerance
+    // as the parent's 15-second backpressure verdict. A genuinely gone parent
+    // breaks the pipe, which fails the write immediately regardless.
+    constexpr DWORD kChildPacketSendTimeoutMs = 10000;
 
     bool receive(HANDLE pipe, header_t &header, std::vector<std::uint8_t> &payload, DWORD timeout = INFINITE) {
       if (!read_exact(pipe, &header, sizeof(header), timeout)) {
@@ -188,8 +232,10 @@ namespace platf::video_worker {
           case message_e::finished:
           case message_e::heartbeat:
           case message_e::encoder_ready:
+          case message_e::startup_error:
+            return header.size == 0;
           case message_e::capture_ready:
-          case message_e::startup_error: return header.size == 0;
+          case message_e::capture_reinitializing: return header.size == sizeof(generation_t);
           case message_e::invalidate: return header.size == sizeof(invalidate_t);
           case message_e::hdr: return header.size == sizeof(video::hdr_info_raw_t);
           case message_e::touch: return header.size == sizeof(input::touch_port_t);
@@ -200,7 +246,11 @@ namespace platf::video_worker {
       }();
       if (!valid_size) return false;
       payload.resize(header.size);
-      return !header.size || read_exact(pipe, payload.data(), header.size, timeout);
+      // Once a valid header has arrived, the payload is already being written
+      // by the peer. Short polling timeouts must not abandon a half-read
+      // message: partial progress cannot be rewound on a byte-mode pipe.
+      const DWORD payload_timeout = std::max<DWORD>(timeout, 5000);
+      return !header.size || read_exact(pipe, payload.data(), header.size, payload_timeout);
     }
 
     std::wstring executable_path() {
@@ -301,6 +351,52 @@ namespace platf::video_worker {
       ::CloseHandle(process.hThread);
       return true;
     }
+
+    bool establish_child(child_t &child) {
+      const std::string pipe_name = random_pipe_name();
+      if (pipe_name.empty()) return false;
+      const auto full_name = L"\\\\.\\pipe\\" + widen_ascii(pipe_name);
+      SECURITY_ATTRIBUTES pipe_security {};
+      PSECURITY_DESCRIPTOR pipe_descriptor = nullptr;
+      if (!make_pipe_security(pipe_security, pipe_descriptor)) return false;
+      auto free_pipe_descriptor = util::fail_guard([&] { ::LocalFree(pipe_descriptor); });
+      child.pipe = ::CreateNamedPipeW(full_name.c_str(), PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED | FILE_FLAG_FIRST_PIPE_INSTANCE,
+                                      PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+                                      1, 4 * 1024 * 1024, 64 * 1024, 0, &pipe_security);
+      if (child.pipe == INVALID_HANDLE_VALUE || !launch(child, pipe_name)) return false;
+
+      OVERLAPPED connect {};
+      connect.hEvent = ::CreateEventW(nullptr, TRUE, FALSE, nullptr);
+      if (!connect.hEvent) return false;
+      auto close_event = util::fail_guard([&] { ::CloseHandle(connect.hEvent); });
+      BOOL connected = ::ConnectNamedPipe(child.pipe, &connect);
+      const DWORD connect_error = connected ? ERROR_SUCCESS : ::GetLastError();
+      bool connect_ok = connected || connect_error == ERROR_PIPE_CONNECTED;
+      if (!connect_ok && connect_error == ERROR_IO_PENDING) {
+        HANDLE waits[] {connect.hEvent, child.process};
+        connect_ok = ::WaitForMultipleObjects(2, waits, FALSE, 10000) == WAIT_OBJECT_0;
+        if (connect_ok) {
+          DWORD ignored = 0;
+          connect_ok = ::GetOverlappedResult(child.pipe, &connect, &ignored, FALSE) != FALSE;
+        }
+      }
+      if (!connect_ok) {
+        (void) ::CancelIoEx(child.pipe, &connect);
+        (void) ::WaitForSingleObject(connect.hEvent, INFINITE);
+        DWORD ignored = 0;
+        (void) ::GetOverlappedResult(child.pipe, &connect, &ignored, FALSE);
+        ::TerminateProcess(child.process, 0xE003);
+        (void) ::WaitForSingleObject(child.process, 1000);
+        return false;
+      }
+      ULONG client_pid = 0;
+      if (!::GetNamedPipeClientProcessId(child.pipe, &client_pid) || client_pid != child.pid) {
+        ::TerminateProcess(child.process, 0xE004);
+        return false;
+      }
+      return true;
+    }
+
   }
 
   bool is_child_process() {
@@ -310,6 +406,98 @@ namespace platf::video_worker {
   void set_child_pipe(std::string pipe_name, std::uint32_t parent_pid) {
     g_child_pipe = std::move(pipe_name);
     g_parent_pid = parent_pid;
+  }
+
+  std::uint64_t current_capture_generation() {
+    return g_capture_generation.load(std::memory_order_acquire);
+  }
+
+  bool packet_can_signal_capture_ready(video::packet_raw_t &packet) {
+    return packet.is_idr();
+  }
+
+  bool packet_metadata_can_enter_capture_generation(
+    std::uint64_t packet_generation,
+    bool capture_placeholder,
+    bool is_idr,
+    std::uint64_t active_generation,
+    bool generation_needs_idr,
+    bool first_admission
+  ) {
+    if (packet_generation == 0 || packet_generation < active_generation) {
+      return false;
+    }
+    const bool entering_generation = generation_needs_idr || packet_generation > active_generation;
+    if (!entering_generation) {
+      return true;
+    }
+    if (!is_idr) {
+      return false;
+    }
+    // The synthetic bootstrap IDR may open the very first generation: it is a
+    // decodable frame, and admitting it keeps the client's connection budget
+    // independent of how long the capture source takes to produce real video.
+    // A generation *transition* (capture reinit) still requires a real
+    // captured IDR so a retired encoder can never poison the new chain.
+    return !capture_placeholder || first_admission;
+  }
+
+  namespace {
+    // Single-slot prewarmed worker. Ownership is exclusive at every instant:
+    // the slot owns the child until exactly one of adopt/cancel/supersede
+    // takes the unique_ptr out under the mutex — the unsafe shared-handle
+    // hand-off of the earlier prewarm design cannot recur. The child costs
+    // ~1.5-2 s to spawn (process + DLLs + shaders + pipe handshake); paying
+    // that during the HTTPS launch phase moves it off the client's post-PLAY
+    // first-video budget, which strict Xbox/webOS ports enforce hard.
+    std::mutex g_prewarm_mutex;
+    std::unique_ptr<child_t> g_prewarmed_child;
+    std::chrono::steady_clock::time_point g_prewarm_created {};
+    constexpr auto kPrewarmTtl = std::chrono::seconds(60);
+
+    void discard_prewarmed_locked(const char *reason) {
+      if (!g_prewarmed_child) return;
+      BOOST_LOG(info) << "Video worker: discarding prewarmed process (pid="
+                      << g_prewarmed_child->pid << ", " << reason << ").";
+      ::TerminateProcess(g_prewarmed_child->process, 0xE007);
+      (void) ::WaitForSingleObject(g_prewarmed_child->process, 500);
+      g_prewarmed_child.reset();
+    }
+
+    std::unique_ptr<child_t> take_prewarmed() {
+      std::lock_guard lg(g_prewarm_mutex);
+      if (!g_prewarmed_child) return nullptr;
+      if (std::chrono::steady_clock::now() - g_prewarm_created > kPrewarmTtl) {
+        discard_prewarmed_locked("expired");
+        return nullptr;
+      }
+      if (::WaitForSingleObject(g_prewarmed_child->process, 0) != WAIT_TIMEOUT) {
+        discard_prewarmed_locked("exited");
+        return nullptr;
+      }
+      return std::move(g_prewarmed_child);
+    }
+  }  // namespace
+
+  bool prewarm() {
+    if (is_child_process()) return false;
+    auto owner = std::make_unique<child_t>();
+    if (!establish_child(*owner)) {
+      BOOST_LOG(warning) << "Video worker: prewarm could not establish an isolated process; the session will spawn one on demand.";
+      return false;
+    }
+    std::lock_guard lg(g_prewarm_mutex);
+    discard_prewarmed_locked("superseded by a newer launch");
+    g_prewarmed_child = std::move(owner);
+    g_prewarm_created = std::chrono::steady_clock::now();
+    BOOST_LOG(info) << "Video worker: prewarmed isolated process (pid="
+                    << g_prewarmed_child->pid << ") awaiting session adoption.";
+    return true;
+  }
+
+  void cancel_prewarm() {
+    std::lock_guard lg(g_prewarm_mutex);
+    discard_prewarmed_locked("launch cancelled");
   }
 
   int run_child() {
@@ -356,7 +544,7 @@ namespace platf::video_worker {
           start.vgd_ring_slots < VDISPLAY::vgd::kMinRingSlots ||
           start.vgd_ring_slots > VDISPLAY::vgd::kMaxRingSlots ||
           (start.vgd_transport_flags & ~VDISPLAY::vgd::kAllowedRingTransportFlags) != 0 ||
-          start.vgd_generation == 0 || display_end == std::end(start.vgd_display_name) ||
+          display_end == std::end(start.vgd_display_name) ||
           display_end == std::begin(start.vgd_display_name)) {
         (void) send(pipe, message_e::startup_error);
         return 20;
@@ -367,7 +555,7 @@ namespace platf::video_worker {
       }, display_name);
       BOOST_LOG(info) << "Video worker: imported direct LuminalVGD ring target session 0x"
                       << std::hex << start.vgd_session_id << std::dec
-                      << " generation " << start.vgd_generation
+                      << (start.vgd_generation ? " generation " + std::to_string(start.vgd_generation) : " with deferred generation binding")
                       << " (" << start.vgd_ring_slots << " slots) for " << display_name << '.';
     } else {
       VDISPLAY::vgd::set_worker_ring_target(std::nullopt);
@@ -401,6 +589,7 @@ namespace platf::video_worker {
 
     auto session_mail = std::make_shared<safe::mail_raw_t>();
     auto shutdown = session_mail->event<bool>(mail::shutdown);
+    auto packets = video::packet_queue(session_mail, mail::video_packets);
     std::atomic_bool commands_done {false};
     std::mutex write_mutex;
 
@@ -425,57 +614,120 @@ namespace platf::video_worker {
           break;
         }
       }
+      packets->stop();
       commands_done.store(true, std::memory_order_release);
       shutdown->raise(true);
     });
 
+    g_capture_reinitializing.store(false, std::memory_order_release);
+    g_capture_generation.store(1, std::memory_order_release);
+    std::atomic_bool capture_ready_sent {false};
     std::thread output([&] {
-      auto packets = mail::man->queue<video::packet_t>(mail::video_packets);
       auto hdr = session_mail->event<video::hdr_info_t>(mail::hdr);
       auto touch = session_mail->event<input::touch_port_t>(mail::touch_port);
       auto chroma = session_mail->event<bool>(mail::chroma_downgrade);
-      bool capture_ready_sent = false;
+      std::uint64_t admitted_generation = 0;
       while (!shutdown->peek()) {
+        bool capture_reinitialized = false;
+        generation_t reinitialized_generation {};
+        {
+          std::lock_guard generation_lock(g_capture_generation_mutex);
+          capture_reinitialized = g_capture_reinitializing.exchange(false, std::memory_order_acq_rel);
+          reinitialized_generation.value = g_capture_generation.load(std::memory_order_acquire);
+        }
+        if (capture_reinitialized) {
+          // Retire every encoded packet queued by the old capture device before
+          // announcing the new generation. It is better to wait for one fresh
+          // IDR than to poison the client's new reference tree with an old WGC
+          // desktop or an already-destroyed IddCx swapchain.
+          while (packets->pop(0ms)) {}
+          std::lock_guard lock(write_mutex);
+          if (!send(pipe, message_e::capture_reinitializing, &reinitialized_generation, sizeof(reinitialized_generation), kChildPacketSendTimeoutMs)) break;
+          continue;
+        }
         if (auto packet = packets->pop(20ms)) {
+          std::lock_guard generation_lock(g_capture_generation_mutex);
+          // A reinit can race the queue pop. Drop this now-stale packet; the
+          // next loop drains the old generation and publishes its marker
+          // before any replacement packet is tagged or sent.
+          if (g_capture_reinitializing.load(std::memory_order_acquire)) {
+            continue;
+          }
+          const auto current_generation = g_capture_generation.load(std::memory_order_acquire);
+          const bool generation_needs_idr = admitted_generation != current_generation;
+          if (packet->capture_generation != current_generation ||
+              !packet_metadata_can_enter_capture_generation(
+                packet->capture_generation,
+                packet->capture_placeholder,
+                packet->is_idr(),
+                current_generation,
+                generation_needs_idr,
+                admitted_generation == 0
+              )) {
+            // A late packet from an encoder retired during reinit must not be
+            // relabelled as belonging to the replacement generation. The one
+            // synthetic bootstrap IDR is admissible only before any packet has
+            // entered the pipe: it keeps the client connected while the real
+            // capture source finishes starting.
+            continue;
+          }
+          if (generation_needs_idr) admitted_generation = current_generation;
           auto encoded_bytes = materialize_packet(*packet);
           if (encoded_bytes.empty()) {
             BOOST_LOG(error) << "Video worker: encoded packet exceeded the 32 MiB IPC limit.";
             shutdown->raise(true);
             break;
           }
-          packet_header_t packet_header {
-            packet->frame_index(), static_cast<std::uint32_t>(encoded_bytes.size()),
-            static_cast<std::uint8_t>(packet->is_idr()),
-            static_cast<std::uint8_t>(packet->after_ref_frame_invalidation)
-          };
+          packet_header_t packet_header {};
+          packet_header.frame_index = packet->frame_index();
+          packet_header.frame_timestamp_ns = packet->frame_timestamp ? serialize_timestamp(*packet->frame_timestamp) : 0;
+          packet_header.host_processing_timestamp_ns = packet->host_processing_timestamp ? serialize_timestamp(*packet->host_processing_timestamp) : 0;
+          packet_header.data_size = static_cast<std::uint32_t>(encoded_bytes.size());
+          packet_header.idr = static_cast<std::uint8_t>(packet->is_idr());
+          packet_header.after_rfi = static_cast<std::uint8_t>(packet->after_ref_frame_invalidation);
+          packet_header.has_frame_timestamp = static_cast<std::uint8_t>(packet->frame_timestamp.has_value());
+          packet_header.has_host_processing_timestamp = static_cast<std::uint8_t>(packet->host_processing_timestamp.has_value());
+          packet_header.capture_placeholder = static_cast<std::uint8_t>(packet->capture_placeholder);
+          packet_header.capture_generation = packet->capture_generation;
           std::vector<std::uint8_t> body(sizeof(packet_header) + packet_header.data_size);
           std::memcpy(body.data(), &packet_header, sizeof(packet_header));
           std::memcpy(body.data() + sizeof(packet_header), encoded_bytes.data(), packet_header.data_size);
           std::lock_guard lock(write_mutex);
-          if (!capture_ready_sent) {
-            // This is truthful readiness: display capture, conversion and the
-            // encoder have all succeeded and a valid first packet exists.
-            if (!send(pipe, message_e::capture_ready)) break;
-            capture_ready_sent = true;
+          if (!capture_ready_sent.load(std::memory_order_acquire)) {
+            // Readiness means a decodable IDR exists — possibly the synthetic
+            // bootstrap frame. The client is admitted immediately; real-frame
+            // progress is watched separately by the parent supervisor.
+            const generation_t generation {packet_header.capture_generation};
+            if (!send(pipe, message_e::capture_ready, &generation, sizeof(generation), kChildPacketSendTimeoutMs)) break;
+            capture_ready_sent.store(true, std::memory_order_release);
           }
-          if (!send(pipe, message_e::packet, body.data(), static_cast<std::uint32_t>(body.size()))) break;
+          if (!send(pipe, message_e::packet, body.data(), static_cast<std::uint32_t>(body.size()), kChildPacketSendTimeoutMs)) break;
         }
         if (auto value = hdr->pop(0ms)) {
           std::lock_guard lock(write_mutex);
-          if (!send(pipe, message_e::hdr, value.get(), sizeof(video::hdr_info_raw_t))) break;
+          if (!send(pipe, message_e::hdr, value.get(), sizeof(video::hdr_info_raw_t), kChildPacketSendTimeoutMs)) break;
         }
         if (auto value = touch->pop(0ms)) {
           std::lock_guard lock(write_mutex);
-          if (!send(pipe, message_e::touch, &*value, sizeof(*value))) break;
+          if (!send(pipe, message_e::touch, &*value, sizeof(*value), kChildPacketSendTimeoutMs)) break;
         }
         if (chroma->pop(0ms)) {
           std::lock_guard lock(write_mutex);
-          if (!send(pipe, message_e::chroma_downgrade)) break;
+          if (!send(pipe, message_e::chroma_downgrade, nullptr, 0, kChildPacketSendTimeoutMs)) break;
         }
       }
+      // A failed pipe write means the parent is gone or has given up on this
+      // worker. Continuing to capture/encode into a queue nobody drains only
+      // delays teardown — end the child's capture session promptly.
+      packets->stop();
+      shutdown->raise(true);
     });
 
     video::capture(session_mail, start.config, nullptr);
+    if (!capture_ready_sent.load(std::memory_order_acquire)) {
+      std::lock_guard lock(write_mutex);
+      (void) send(pipe, message_e::startup_error);
+    }
     shutdown->raise(true);
     {
       std::lock_guard lock(write_mutex);
@@ -492,16 +744,34 @@ namespace platf::video_worker {
   bool capture(safe::mail_t mail, video::config_t config, void *channel_data) {
     if (is_child_process()) return false;
 
+    thread_local bool bounded_retry_active = false;
+    auto shutdown = mail->event<bool>(mail::shutdown);
+
     const bool direct_vgd = VDISPLAY::is_luminalvgd_active();
     start_t start {};
     start.magic = kProtocolMagic;
     start.protocol_version = kProtocolVersion;
     start.config = config;
     if (!video::export_encoder_probe_snapshot(start.encoder)) {
+      if (direct_vgd) {
+        // No pipeline of any kind will run for a direct-VGD session. End it
+        // promptly (also releases a strict client's held ANNOUNCE) instead of
+        // leaving it to linger until the ping windows expire.
+        BOOST_LOG(error) << "Video worker: parent has no validated encoder snapshot; ending the direct-VGD session.";
+        shutdown->raise(true);
+        return true;
+      }
       BOOST_LOG(error) << "Video worker: parent has no validated encoder snapshot; using in-process pipeline.";
-      return direct_vgd;
+      return false;
     }
-    if (direct_vgd) {
+    if (direct_vgd && bounded_retry_active) {
+      // The first isolated worker already failed after the parent had admitted
+      // a direct ring. Repeating the identical direct start in a fresh child
+      // loses the child-local failure latch and strands the client twice.
+      // The single bounded retry is therefore the connection-safe backend.
+      start.safe_capture = 1;
+      BOOST_LOG(warning) << "Video worker: bounded retry is forcing isolated WGC safe-capture.";
+    } else if (direct_vgd) {
       const auto display_name = display_device::map_output_name(::config::get_active_output_name());
       const auto target = VDISPLAY::vgd::ring_target_for_worker_display(display_name);
       if (!target) {
@@ -524,57 +794,30 @@ namespace platf::video_worker {
       }
     }
 
-    const std::string pipe_name = random_pipe_name();
-    if (pipe_name.empty()) return direct_vgd;
-    const auto full_name = L"\\\\.\\pipe\\" + widen_ascii(pipe_name);
-    child_t child;
-    SECURITY_ATTRIBUTES pipe_security {};
-    PSECURITY_DESCRIPTOR pipe_descriptor = nullptr;
-    if (!make_pipe_security(pipe_security, pipe_descriptor)) {
-      BOOST_LOG(error) << "Video worker: failed to construct a restricted named-pipe ACL; using in-process pipeline.";
-      return direct_vgd;
-    }
-    auto free_pipe_descriptor = util::fail_guard([&] { ::LocalFree(pipe_descriptor); });
-    child.pipe = ::CreateNamedPipeW(full_name.c_str(), PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED | FILE_FLAG_FIRST_PIPE_INSTANCE,
-                                    PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
-                                    1, 4 * 1024 * 1024, 64 * 1024, 0, &pipe_security);
-    if (child.pipe == INVALID_HANDLE_VALUE || !launch(child, pipe_name)) {
-      BOOST_LOG(error) << "Video worker: failed to establish isolated process; using in-process pipeline.";
-      return direct_vgd;
-    }
-    OVERLAPPED connect {};
-    connect.hEvent = ::CreateEventW(nullptr, TRUE, FALSE, nullptr);
-    BOOL connected = ::ConnectNamedPipe(child.pipe, &connect);
-    const DWORD connect_error = connected ? ERROR_SUCCESS : ::GetLastError();
-    bool connect_ok = connected || connect_error == ERROR_PIPE_CONNECTED;
-    if (!connect_ok && connect_error == ERROR_IO_PENDING) {
-      HANDLE waits[] {connect.hEvent, child.process};
-      connect_ok = ::WaitForMultipleObjects(2, waits, FALSE, 10000) == WAIT_OBJECT_0;
-      if (connect_ok) {
-        DWORD ignored = 0;
-        connect_ok = ::GetOverlappedResult(child.pipe, &connect, &ignored, FALSE) != FALSE;
+    // Adopt the prewarmed worker when one is waiting: ownership transfers
+    // atomically out of the single slot, so this session's video thread holds
+    // every kernel handle exclusively for the full capture lifetime. Fall back
+    // to spawning on demand when no (live) prewarmed process exists.
+    std::unique_ptr<child_t> child_owner = take_prewarmed();
+    if (child_owner) {
+      BOOST_LOG(info) << "Video worker: adopted prewarmed isolated process (pid=" << child_owner->pid << ").";
+    } else {
+      child_owner = std::make_unique<child_t>();
+      if (!establish_child(*child_owner)) {
+        if (direct_vgd) {
+          // Same as the snapshot path: nothing will produce video for this
+          // session — end it promptly rather than burning the strict-client
+          // ANNOUNCE hold and the ping windows on a known-dead session.
+          BOOST_LOG(error) << "Video worker: failed to establish isolated process; ending the direct-VGD session.";
+          shutdown->raise(true);
+          return true;
+        }
+        BOOST_LOG(error) << "Video worker: failed to establish isolated process; using in-process pipeline.";
+        return false;
       }
+      BOOST_LOG(info) << "Video worker: isolated capture/encode process started (pid=" << child_owner->pid << ")";
     }
-    if (!connect_ok) {
-      (void) ::CancelIoEx(child.pipe, &connect);
-      (void) ::WaitForSingleObject(connect.hEvent, INFINITE);
-      DWORD ignored = 0;
-      (void) ::GetOverlappedResult(child.pipe, &connect, &ignored, FALSE);
-      if (connect.hEvent) ::CloseHandle(connect.hEvent);
-      ::TerminateProcess(child.process, 0xE003);
-      (void) ::WaitForSingleObject(child.process, 1000);
-      BOOST_LOG(error) << "Video worker: child did not connect within 10 seconds.";
-      return direct_vgd;
-    }
-    if (connect.hEvent) ::CloseHandle(connect.hEvent);
-    ULONG client_pid = 0;
-    if (!::GetNamedPipeClientProcessId(child.pipe, &client_pid) || client_pid != child.pid) {
-      BOOST_LOG(error) << "Video worker: rejected unexpected pipe client pid=" << client_pid
-                       << " expected=" << child.pid;
-      ::TerminateProcess(child.process, 0xE004);
-      return direct_vgd;
-    }
-    BOOST_LOG(info) << "Video worker: isolated capture/encode process started (pid=" << child.pid << ")";
+    child_t &child = *child_owner;
     if (!send(child.pipe, message_e::start, &start, sizeof(start))) {
       BOOST_LOG(error) << "Video worker: failed to send startup state; using in-process pipeline.";
       ::TerminateProcess(child.process, 0xE005);
@@ -582,51 +825,187 @@ namespace platf::video_worker {
       return false;
     }
 
-    // Do not hand the session to a worker that has not accepted the parent's
-    // validated encoder state and completed its capture-only bootstrap. This
-    // deadline deliberately fits inside the client's initial-frame timeout.
+    // Process launch, DLL loading and startup-state validation have their own
+    // deadline. The first-packet clock starts only after the child explicitly
+    // accepts the startup state; never charge shader/D3D/NVENC initialization
+    // against a misleading 1.5-second catch-all timeout.
     header_t ready_header {};
     std::vector<std::uint8_t> ready_payload;
-    const bool encoder_ready = receive(child.pipe, ready_header, ready_payload, 1500) &&
-                               ready_header.type == message_e::encoder_ready;
-    const bool capture_ready = encoder_ready && receive(child.pipe, ready_header, ready_payload, 7000) &&
-                               ready_header.type == message_e::capture_ready;
+    bool startup_reinitializing = false;
+    const auto publish_sideband = [&](message_e type, const std::vector<std::uint8_t> &body) {
+      if (type == message_e::hdr && body.size() == sizeof(video::hdr_info_raw_t)) {
+        video::hdr_info_raw_t value {false};
+        std::memcpy(&value, body.data(), sizeof(value));
+        mail->event<video::hdr_info_t>(mail::hdr)->raise(std::make_unique<video::hdr_info_raw_t>(value));
+        return true;
+      }
+      if (type == message_e::touch && body.size() == sizeof(input::touch_port_t)) {
+        input::touch_port_t value {};
+        std::memcpy(&value, body.data(), sizeof(value));
+        mail->event<input::touch_port_t>(mail::touch_port)->raise(value);
+        return true;
+      }
+      if (type == message_e::chroma_downgrade && body.empty()) {
+        mail->event<bool>(mail::chroma_downgrade)->raise(true);
+        return true;
+      }
+      if (type == message_e::capture_reinitializing && body.size() == sizeof(generation_t)) {
+        // WGC can observe the final Windows topology normalization at the same
+        // time it produces its bootstrap IDR. Preserve that transition across
+        // FIRST_PACKET; otherwise steady-state starts with the ordinary
+        // three-second watchdog and kills the replacement encoder mid-build.
+        startup_reinitializing = true;
+        return true;
+      }
+      return type == message_e::heartbeat && body.empty();
+    };
+
+    bool startup_message = false;
+    // PROCESS_READY covers child spawn + DLL load + startup validation only
+    // (~2 s observed); FIRST_PACKET additionally covers capture-source
+    // admission and NVENC session creation, which takes ~7 s on some
+    // driver/GPU combinations (observed on RTX 5080). The client-side
+    // no-video budget is protected independently by videoThread's late
+    // keepalive datagram, so these deadlines guard genuine dysfunction, not
+    // the client clock.
+    const auto process_ready_deadline = std::chrono::steady_clock::now() + 5s;
+    while (!shutdown->peek() && std::chrono::steady_clock::now() < process_ready_deadline) {
+      if (receive(child.pipe, ready_header, ready_payload, 100)) {
+        startup_message = true;
+        break;
+      }
+    }
+    const bool encoder_ready = startup_message && ready_header.type == message_e::encoder_ready;
+    if (encoder_ready) {
+      BOOST_LOG(info) << "Video worker: PROCESS_READY and startup state accepted; waiting for first encoded packet.";
+    }
+    bool first_packet_message = false;
+    bool capture_ready = false;
+    std::uint64_t startup_generation = 0;
+    bool startup_failed = false;
+    if (encoder_ready) {
+      // Wide enough for the slowest observed healthy bring-up: 4K HDR NVENC
+      // session creation alone takes ~11 s on this driver, and the 15-second
+      // deadline was killing workers ~2 s before success. Client budgets are
+      // protected separately (ANNOUNCE hold + runt keepalive); this deadline
+      // only guards genuine dysfunction.
+      auto first_packet_deadline = std::chrono::steady_clock::now() + 30s;
+      while (!shutdown->peek() && std::chrono::steady_clock::now() < first_packet_deadline) {
+        if (startup_reinitializing) {
+          // A capture reinit during bootstrap retires the one synthetic
+          // placeholder, so the next packet requires a real captured frame.
+          // Grant the same bounded rebuild window steady state gets instead
+          // of terminating a healthy worker at the short bootstrap deadline.
+          first_packet_deadline = std::max(first_packet_deadline, std::chrono::steady_clock::now() + 12s);
+          startup_reinitializing = false;
+        }
+        if (!receive(child.pipe, ready_header, ready_payload, 100)) continue;
+        first_packet_message = true;
+        if (ready_header.type == message_e::capture_ready) {
+          generation_t generation {};
+          std::memcpy(&generation, ready_payload.data(), sizeof(generation));
+          startup_generation = generation.value;
+          capture_ready = true;
+          break;
+        }
+        if (ready_header.type == message_e::startup_error || ready_header.type == message_e::finished) {
+          startup_failed = true;
+          break;
+        }
+        // Sideband notifications are asynchronous and may legitimately precede
+        // the first encoded packet. Publish them now instead of mistaking them
+        // for a startup failure or losing one-shot HDR/touch state.
+        if (!publish_sideband(ready_header.type, ready_payload)) {
+          startup_failed = true;
+          break;
+        }
+      }
+    }
     if (!capture_ready) {
-      BOOST_LOG(error) << "Video worker: capture bootstrap did not produce a first encoded packet within its deadline.";
+      if (!startup_message) {
+        BOOST_LOG(error) << "Video worker: PROCESS_READY deadline expired or startup pipe closed before acknowledgement.";
+      } else if (!encoder_ready) {
+        BOOST_LOG(error) << "Video worker: rejected startup state (message="
+                         << static_cast<std::uint32_t>(ready_header.type) << ").";
+      } else if (shutdown->peek()) {
+        BOOST_LOG(info) << "Video worker: first-packet wait cancelled because the client session ended.";
+      } else if (!first_packet_message) {
+        BOOST_LOG(error) << "Video worker: FIRST_PACKET deadline expired or worker pipe closed after startup acceptance.";
+      } else if (ready_header.type == message_e::startup_error) {
+        BOOST_LOG(error) << "Video worker: capture or encoder initialization ended before the first encoded packet.";
+      } else if (ready_header.type == message_e::finished) {
+        BOOST_LOG(error) << "Video worker: capture pipeline finished before producing its first encoded packet.";
+      } else if (startup_failed) {
+        BOOST_LOG(error) << "Video worker: expected FIRST_PACKET readiness but received message="
+                         << static_cast<std::uint32_t>(ready_header.type) << '.';
+      }
       (void) ::CancelIoEx(child.pipe, nullptr);
       ::TerminateProcess(child.process, 0xE006);
       const bool worker_reaped = ::WaitForSingleObject(child.process, 3000) == WAIT_OBJECT_0;
       ::DisconnectNamedPipe(child.pipe);
       if (!worker_reaped) {
         BOOST_LOG(error) << "Video worker: process remains stuck after termination; refusing unsafe in-process GPU fallback.";
+        shutdown->raise(true);
         return true;
-      }
-      if (!encoder_ready || ready_header.type == message_e::startup_error) {
-        BOOST_LOG(warning) << "Video worker: failure occurred before GPU capture startup; using in-process pipeline.";
-        return direct_vgd;
       }
       const auto health = platf::dxgi::D3D11ProbeDeviceHealth();
       if (FAILED(health)) {
         BOOST_LOG(error) << "Video worker: display health probe failed after worker termination (hresult=0x"
                          << std::hex << health << std::dec << "); refusing unsafe in-process GPU fallback.";
+        shutdown->raise(true);
         return true;
       }
-      BOOST_LOG(warning) << "Video worker: process exited and display health is good; using in-process pipeline.";
-      return direct_vgd;
+      if (direct_vgd && !shutdown->peek() && !bounded_retry_active) {
+        BOOST_LOG(warning) << "Video worker: display health is good; keeping the client session alive for one bounded isolated-worker retry.";
+        bounded_retry_active = true;
+        const auto reset_retry = util::fail_guard([&] { bounded_retry_active = false; });
+        return platf::video_worker::capture(std::move(mail), config, channel_data);
+      }
+      if (direct_vgd) {
+        BOOST_LOG(error) << "Video worker: bounded isolated retry exhausted; refusing unsafe in-process GPU fallback.";
+        // No pipeline will exist for this session. End it promptly so the
+        // client sees a clean failure instead of a silent zero-video stream.
+        shutdown->raise(true);
+        return true;
+      }
+      BOOST_LOG(warning) << "Video worker: display health is good; using the in-process pipeline for the non-VGD display.";
+      return false;
     }
-    BOOST_LOG(info) << "Video worker: validated encoder snapshot accepted; capture pipeline ready.";
+    BOOST_LOG(info) << "Video worker: FIRST_PACKET received; isolated capture pipeline ready.";
+    // Releases the strict-client ANNOUNCE hold: the first encoded packet
+    // exists, so the client's post-PLAY no-video clock can start safely.
+    mail->event<bool>(mail::video_pipeline_ready)->raise(true);
 
-    auto shutdown = mail->event<bool>(mail::shutdown);
+    const auto now_ms = [] { return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count(); };
     std::atomic_bool reader_done {false};
     std::atomic<std::int64_t> last_frame_ms {0};
+    std::atomic<std::int64_t> reinitializing_until_ms {
+      startup_reinitializing ? now_ms() + 12000 : 0
+    };
+    std::atomic_bool preserve_reinit_across_bootstrap_packet {startup_reinitializing};
     std::atomic_bool first_frame_seen {false};
-    const auto now_ms = [] { return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count(); };
+    std::atomic<std::uint64_t> active_capture_generation {startup_generation};
+    std::atomic_bool generation_needs_idr {true};
+    std::atomic_bool network_attached {mail->event<bool>(mail::video_peer_ready)->peek()};
+    // Recovery requests are deliberately owned by this parent process.  The
+    // client can report every missing reference frame separately, but passing
+    // that burst straight through to NVENC creates an IDR feedback loop: each
+    // oversized invalidation becomes another IDR and induces yet more loss.
+    std::atomic_bool recovery_idr_inflight {false};
+    std::atomic_bool recovery_idr_seen {false};
+    // CAPTURE_READY means the child has already produced a bootstrap IDR even
+    // though the reader has not consumed its packet yet. Seed the timestamp so
+    // the client's mandatory startup request cannot create a duplicate IDR.
+    std::atomic<std::int64_t> last_idr_ms {now_ms()};
+    std::atomic<std::uint64_t> last_idr_frame {0};
     last_frame_ms.store(now_ms(), std::memory_order_release);
 
+    auto packets = video::packet_queue(mail, mail::video_packets);
     std::thread reader([&] {
       header_t header {};
       std::vector<std::uint8_t> body;
-      auto packets = mail::man->queue<video::packet_t>(mail::video_packets);
+      video::packet_t bootstrap_idr;
+      bool any_packet_admitted = false;
       while (receive(child.pipe, header, body)) {
         if (header.type == message_e::finished) break;
         if (header.type == message_e::packet && body.size() >= sizeof(packet_header_t)) {
@@ -634,14 +1013,71 @@ namespace platf::video_worker {
           std::memcpy(&packet_header, body.data(), sizeof(packet_header));
           if (packet_header.data_size <= body.size() - sizeof(packet_header) &&
               body.size() - sizeof(packet_header) == packet_header.data_size) {
+            const auto active_generation = active_capture_generation.load(std::memory_order_acquire);
+            const bool needs_generation_idr = generation_needs_idr.load(std::memory_order_acquire);
+            if (!packet_metadata_can_enter_capture_generation(
+                  packet_header.capture_generation,
+                  packet_header.capture_placeholder != 0,
+                  packet_header.idr != 0,
+                  active_generation,
+                  needs_generation_idr,
+                  !any_packet_admitted
+                )) {
+              continue;
+            }
+            any_packet_admitted = true;
+            if (packet_header.capture_generation > active_generation) {
+              // A packet can win the IPC race against its sideband marker. The
+              // predicate above permits that only at a real captured IDR.
+              active_capture_generation.store(packet_header.capture_generation, std::memory_order_release);
+            }
+            if (packet_header.idr) generation_needs_idr.store(false, std::memory_order_release);
             std::vector<std::uint8_t> bytes(packet_header.data_size);
             std::memcpy(bytes.data(), body.data() + sizeof(packet_header), bytes.size());
             auto packet = std::make_unique<video::packet_raw_generic>(std::move(bytes), packet_header.frame_index, packet_header.idr != 0);
             packet->after_ref_frame_invalidation = packet_header.after_rfi != 0;
+            packet->capture_placeholder = packet_header.capture_placeholder != 0;
+            if (packet_header.has_frame_timestamp) {
+              packet->frame_timestamp = deserialize_timestamp(packet_header.frame_timestamp_ns);
+            }
+            if (packet_header.has_host_processing_timestamp) {
+              packet->host_processing_timestamp = deserialize_timestamp(packet_header.host_processing_timestamp_ns);
+            }
             packet->channel_data = channel_data;
-            packets->raise(std::move(packet));
-            first_frame_seen.store(true, std::memory_order_release);
-            last_frame_ms.store(now_ms(), std::memory_order_release);
+            if (!packet->capture_placeholder) {
+              first_frame_seen.store(true, std::memory_order_release);
+              last_frame_ms.store(now_ms(), std::memory_order_release);
+            }
+            if (packet->is_idr()) {
+              last_idr_ms.store(now_ms(), std::memory_order_release);
+              last_idr_frame.store(packet_header.frame_index, std::memory_order_release);
+            }
+            if (!network_attached.load(std::memory_order_acquire)) {
+              // Retain only a decodable bootstrap point.  Continuing to drain
+              // the child prevents its bounded IPC pipe from back-pressuring
+              // NVENC while RTSP authenticates the UDP destination.
+              if (packet->is_idr()) bootstrap_idr = std::move(packet);
+            } else {
+              if (bootstrap_idr) {
+                // The retained bootstrap IDR was captured while NVENC was
+                // still initializing (5-11 s on this host) — its capture
+                // timestamps are honestly ancient, but it is an intentional
+                // pre-buffered decode point, not pipeline backlog. Strip
+                // the timestamps so the egress age metric skips it (same
+                // treatment as minimum-FPS duplicates) instead of opening
+                // every session with a multi-second "pipeline backlog"
+                // warning.
+                bootstrap_idr->frame_timestamp.reset();
+                bootstrap_idr->host_processing_timestamp.reset();
+                packets->raise(std::move(bootstrap_idr));
+              }
+              packets->raise(std::move(packet));
+            }
+            if (!preserve_reinit_across_bootstrap_packet.exchange(false, std::memory_order_acq_rel)) {
+              reinitializing_until_ms.store(0, std::memory_order_release);
+            } else {
+              BOOST_LOG(info) << "Video worker: bootstrap packet preceded a capture reinitialization; retaining the bounded rebuild window until the replacement packet.";
+            }
           }
         } else if (header.type == message_e::hdr && body.size() == sizeof(video::hdr_info_raw_t)) {
           video::hdr_info_raw_t value {false};
@@ -653,6 +1089,25 @@ namespace platf::video_worker {
           mail->event<input::touch_port_t>(mail::touch_port)->raise(value);
         } else if (header.type == message_e::chroma_downgrade) {
           mail->event<bool>(mail::chroma_downgrade)->raise(true);
+        } else if (header.type == message_e::capture_reinitializing && body.size() == sizeof(generation_t)) {
+          generation_t generation {};
+          std::memcpy(&generation, body.data(), sizeof(generation));
+          const auto previous = active_capture_generation.load(std::memory_order_acquire);
+          if (generation.value > previous) {
+            active_capture_generation.store(generation.value, std::memory_order_release);
+            generation_needs_idr.store(true, std::memory_order_release);
+            recovery_idr_inflight.store(false, std::memory_order_release);
+            recovery_idr_seen.store(false, std::memory_order_release);
+            // A retained bootstrap frame belongs to the retired generation; it
+            // must never become the first frame a late-attaching client sees.
+            bootstrap_idr.reset();
+          }
+          // A topology or desktop switch invalidates WGC and its NVENC device.
+          // Rebuilding a 4K HDR encoder takes 4-6 seconds on the observed host;
+          // advertise a bounded grace period rather than applying the normal
+          // three-second steady-state stall verdict.
+          reinitializing_until_ms.store(now_ms() + 12000, std::memory_order_release);
+          BOOST_LOG(info) << "Video worker: capture pipeline is reinitializing; granting a bounded 12-second frame-progress window.";
         } else if (header.type != message_e::heartbeat) {
           BOOST_LOG(error) << "Video worker: rejected an out-of-state child IPC message.";
           break;
@@ -663,16 +1118,128 @@ namespace platf::video_worker {
 
     auto idr = mail->event<bool>(mail::idr);
     auto invalidate = mail->event<std::pair<std::int64_t, std::int64_t>>(mail::invalidate_ref_frames);
+    auto discontinuity = mail->event<bool>(mail::video_discontinuity);
+    auto submitted_idr = mail->event<std::int64_t>(mail::video_idr_submitted);
+    auto peer_ready = mail->event<bool>(mail::video_peer_ready);
     bool poisoned = false;
+    // Suppress the protocol-mandated startup request: CAPTURE_READY already
+    // guarantees a decodable IDR exists in the pipe.
+    auto suppress_recovery_until = std::chrono::steady_clock::now() + 1000ms;
+    auto recovery_sent_at = std::chrono::steady_clock::time_point {};
+    std::int64_t recovery_after_frame = -1;
+    std::uint64_t coalesced_invalidations = 0;
     while (!shutdown->peek() && !reader_done.load(std::memory_order_acquire)) {
-      if (idr->pop(25ms)) (void) send(child.pipe, message_e::idr);
+      if (!network_attached.load(std::memory_order_acquire) && peer_ready->peek()) {
+        network_attached.store(true, std::memory_order_release);
+        // The reader releases its retained bootstrap IDR before the next live
+        // packet.  Do not manufacture a second startup IDR here.
+        BOOST_LOG(info) << "Video worker: network consumer attached to prewarmed encoder.";
+      }
+
+      const auto recovery_now = std::chrono::steady_clock::now();
+      while (auto frame = submitted_idr->pop(0ms)) {
+        if (recovery_idr_inflight.load(std::memory_order_acquire) &&
+            *frame > recovery_after_frame) {
+          recovery_idr_seen.store(true, std::memory_order_release);
+        }
+      }
+      if (recovery_idr_seen.exchange(false, std::memory_order_acq_rel)) {
+        recovery_idr_inflight.store(false, std::memory_order_release);
+        // Keep discarding reports about frames preceding the recovery point
+        // while that IDR traverses the broadcaster and client decoder.
+        suppress_recovery_until = recovery_now + 1000ms;
+        while (invalidate->pop(0ms)) ++coalesced_invalidations;
+        BOOST_LOG(info) << "Video worker: recovery IDR submitted to UDP; suppressing obsolete reference invalidations for 1 second.";
+      } else if (recovery_idr_inflight.load(std::memory_order_acquire) &&
+                 recovery_now - recovery_sent_at > 1500ms) {
+        // A lost/failed recovery IDR must not suppress recovery forever.
+        recovery_idr_inflight.store(false, std::memory_order_release);
+        suppress_recovery_until = recovery_now + 250ms;
+        BOOST_LOG(warning) << "Video worker: recovery IDR acknowledgement timed out; reopening the bounded recovery gate.";
+      }
+
+      const bool explicit_idr = idr->pop(25ms);
+      const bool host_discontinuity = discontinuity->pop(0ms);
+      bool valid_invalidation = false;
+      std::int64_t merged_first = std::numeric_limits<std::int64_t>::max();
+      std::int64_t merged_last = -1;
       while (auto range = invalidate->pop(0ms)) {
-        const invalidate_t wire {range->first, range->second};
-        (void) send(child.pipe, message_e::invalidate, &wire, sizeof(wire));
+        ++coalesced_invalidations;
+        if (range->first < 0 || range->second < range->first ||
+            recovery_idr_inflight.load(std::memory_order_acquire) ||
+            recovery_now < suppress_recovery_until) {
+          continue;
+        }
+        const auto recovery_frame = last_idr_frame.load(std::memory_order_acquire);
+        if (recovery_frame != 0 &&
+            static_cast<std::uint64_t>(range->second) <= recovery_frame) {
+          // The client report names only frames preceding an IDR that has
+          // already left the encoder. It cannot affect the new reference tree.
+          continue;
+        }
+        valid_invalidation = true;
+        merged_first = std::min(merged_first, range->first);
+        merged_last = std::max(merged_last, range->second);
+      }
+
+      const auto recent_idr_ms = now_ms() - last_idr_ms.load(std::memory_order_acquire);
+      // React to the first missing reference immediately. Waiting for a quiet
+      // interval is incorrect because Moonlight repeats/extends the range once
+      // per damaged frame, so a 100 ms debounce can postpone recovery forever.
+      // Host-detected discontinuities obey the SAME bounded cooldown as client
+      // reports: letting them bypass it turned a single misdetection into a
+      // self-sustaining ~2 Hz IDR storm (every recovery IDR arrived "late",
+      // re-triggering the detector while all deltas were withheld).
+      const bool recovery_requested = host_discontinuity || explicit_idr || valid_invalidation;
+      if (recovery_requested && network_attached.load(std::memory_order_acquire) &&
+          !generation_needs_idr.load(std::memory_order_acquire) &&
+          !recovery_idr_inflight.load(std::memory_order_acquire) &&
+          recovery_now >= suppress_recovery_until && recent_idr_ms >= 1000) {
+        // One IDR is a complete recovery point.  It supersedes the entire
+        // merged invalidation range, so never feed that range to NVENC too.
+        recovery_idr_inflight.store(true, std::memory_order_release);
+        recovery_sent_at = recovery_now;
+        recovery_after_frame = static_cast<std::int64_t>(
+          last_idr_frame.load(std::memory_order_acquire)
+        );
+        if (!send(child.pipe, message_e::idr)) {
+          BOOST_LOG(error) << "Video worker: failed to send the bounded recovery IDR command.";
+          poisoned = true;
+          break;
+        }
+        BOOST_LOG(info) << "Video worker: issued one immediate bounded recovery IDR"
+                        << (host_discontinuity ? " for a host transport discontinuity after frame " + std::to_string(recovery_after_frame) : "")
+                        << " after coalescing "
+                        << coalesced_invalidations << " reference invalidation request(s)"
+                        << (valid_invalidation ? " for frames " + std::to_string(merged_first) + "-" + std::to_string(merged_last) : "")
+                        << '.';
+        coalesced_invalidations = 0;
       }
       const auto silence_ms = now_ms() - last_frame_ms.load(std::memory_order_acquire);
+      const auto reinit_until = reinitializing_until_ms.load(std::memory_order_acquire);
+      if (reinit_until > now_ms()) {
+        continue;
+      }
       const auto deadline_ms = first_frame_seen.load(std::memory_order_acquire) ? 3000 : 7000;
       if (silence_ms > deadline_ms) {
+        // A full — or merely non-empty — egress queue means encoded frames
+        // exist but the client is draining slowly (Wi-Fi congestion, TV
+        // decoder stall). That is not a GPU failure: degrade instead of
+        // disconnecting, and only a very long sustained stall ends the client.
+        // peek() closes the momentary not-full race while the blocked reader
+        // completes its raise.
+        if (packets->at_capacity() || packets->peek()) {
+          if (silence_ms > 15000) {
+            BOOST_LOG(error) << "Video worker: session egress remained backpressured for "
+                             << silence_ms
+                             << " ms; ending this client without classifying the healthy capture worker as a GPU failure.";
+            break;
+          }
+          continue;
+        }
+        if (reinit_until != 0) {
+          BOOST_LOG(error) << "Video worker: bounded capture reinitialization expired without an encoded frame.";
+        }
         BOOST_LOG(error) << "Video worker: encoded-frame progress stalled for " << silence_ms
                          << " ms; terminating poisoned GPU worker without blocking the host.";
         poisoned = true;
@@ -689,10 +1256,22 @@ namespace platf::video_worker {
       ::TerminateProcess(child.process, 0xE001);
       (void) ::WaitForSingleObject(child.process, 500);
     }
+    // The parent reader may be waiting to enqueue into this session's bounded
+    // egress queue. Stop it before joining so transport teardown can never be
+    // mistaken for, or converted into, a stuck GPU worker.
+    packets->stop();
     (void) ::CancelIoEx(child.pipe, nullptr);
     ::DisconnectNamedPipe(child.pipe);
     if (reader.joinable()) reader.join();
     BOOST_LOG(info) << "Video worker: isolated capture/encode process ended.";
     return true;
+  }
+
+  void notify_capture_reinitializing() {
+    if (is_child_process()) {
+      std::lock_guard generation_lock(g_capture_generation_mutex);
+      g_capture_generation.fetch_add(1, std::memory_order_acq_rel);
+      g_capture_reinitializing.store(true, std::memory_order_release);
+    }
   }
 }

--- a/src/platform/windows/video_worker.h
+++ b/src/platform/windows/video_worker.h
@@ -11,6 +11,40 @@ namespace platf::video_worker {
   void set_child_pipe(std::string pipe_name, std::uint32_t parent_pid);
   int run_child();
 
+  /** Notify the isolated-process supervisor that capture is rebuilding. */
+  void notify_capture_reinitializing();
+
+  /** Capture-source epoch currently owned by this worker process. */
+  std::uint64_t current_capture_generation();
+
+  /** True for any decodable IDR, including the synthetic bootstrap frame. */
+  bool packet_can_signal_capture_ready(video::packet_raw_t &packet);
+
+  /**
+   * Validate packet metadata at a capture-generation boundary.
+   *
+   * Packets older than the active generation are stale. A newer generation,
+   * or the first packet still required for the active generation, is admitted
+   * only by an IDR. The synthetic bootstrap IDR may open the very first
+   * generation (`first_admission`) so client admission never waits on a slow
+   * capture source; every later generation transition requires a real
+   * captured IDR.
+   */
+  bool packet_metadata_can_enter_capture_generation(
+    std::uint64_t packet_generation,
+    bool capture_placeholder,
+    bool is_idr,
+    std::uint64_t active_generation,
+    bool generation_needs_idr,
+    bool first_admission
+  );
+
+  /** Launch an authenticated idle worker before RTSP supplies its config. */
+  bool prewarm();
+
+  /** Retire an unused prewarmed worker. */
+  void cancel_prewarm();
+
   /** Run capture+encode in a crash-isolated child process. */
   bool capture(safe::mail_t mail, video::config_t config, void *channel_data);
 }

--- a/src/platform/windows/virtual_display_vgd.cpp
+++ b/src/platform/windows/virtual_display_vgd.cpp
@@ -120,6 +120,25 @@ namespace VDISPLAY::vgd {
       return h ? h : 1;
     }
 
+    DRIVER_STATUS open_locked();
+
+    /// Close and reopen the control device. Caller holds g_mutex.
+    ///
+    /// For when an ioctl fails at the OS level (VGD_ERR_IO): the driver
+    /// host process crashing invalidates every open handle while leaving
+    /// the devnode reopenable once WUDF relaunches it, and a dead handle
+    /// can never heal on its own — every later call through it fails the
+    /// same way. Never touches the ping thread, so it is safe to call
+    /// FROM the ping thread.
+    DRIVER_STATUS reopen_locked() {
+      if (g_device) {
+        vgd_device_close(g_device);
+        g_device = nullptr;
+        g_caps.reset();
+      }
+      return open_locked();
+    }
+
     DRIVER_STATUS open_locked() {
       if (g_device) {
         return DRIVER_STATUS::OK;
@@ -226,37 +245,94 @@ namespace VDISPLAY::vgd {
     g_ping_stop.store(false);
     g_ping_thread = std::thread([] {
       int consecutive_failures = 0;
+      auto last_credit = std::chrono::steady_clock::now();
+      bool starvation_logged = false;
       while (!g_ping_stop.load()) {
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         if (!g_ping_feeding.load()) {
+          // Feeding is off on purpose (cleanup wants the driver watchdog to
+          // collect what remains) — not starvation.
+          last_credit = std::chrono::steady_clock::now();
+          starvation_logged = false;
           continue;
         }
         std::vector<uint64_t> sessions;
         {
           std::lock_guard lk(g_mutex);
           if (!g_device) {
-            break;
+            // Closed or awaiting reopen; keep the thread alive so a later
+            // successful open resumes feeding without a restart.
+            continue;
           }
           for (auto &[k, s] : g_sessions) {
             sessions.push_back(s.session_id);
           }
         }
         bool any_failed = false;
+        bool any_credited = false;
+        if (sessions.empty()) {
+          // Nothing to feed, but the driver must still be reachable. This
+          // is exactly the state a driver-host crash leaves behind (a
+          // failed CREATE erases its tracked session), and without a probe
+          // here the 3-strikes detector below could never fire again.
+          std::lock_guard lk(g_mutex);
+          if (g_device) {
+            VgdCaps caps {};
+            if (vgd_handshake(g_device, &caps) == VGD_ERR_IO) {
+              any_failed = true;
+            } else {
+              any_credited = true;
+            }
+          }
+        }
         for (uint64_t sid : sessions) {
           std::lock_guard lk(g_mutex);
           if (!g_device) {
             break;
           }
-          if (vgd_ping(g_device, sid) == VGD_ERR_IO) {
+          const int rc = vgd_ping(g_device, sid);
+          if (rc == VGD_ERR_IO) {
             any_failed = true;
+          } else if (rc == 0) {
+            any_credited = true;
           }
+        }
+        const auto now = std::chrono::steady_clock::now();
+        if (any_credited) {
+          last_credit = now;
+          starvation_logged = false;
+        } else if (!sessions.empty() && !starvation_logged &&
+                   now - last_credit > std::chrono::seconds(5)) {
+          // Leases are starving without clean I/O failures (driver control
+          // queue stalled, or pings rejected). Say so BEFORE the driver's
+          // lease watchdog starts reaping live monitors.
+          starvation_logged = true;
+          BOOST_LOG(warning) << "LuminalVGD watchdog: no lease ping has been accepted for over 5 s"
+                                " with " << sessions.size() << " tracked session(s); the driver-side"
+                                " lease watchdog may reap live monitors soon.";
         }
         consecutive_failures = any_failed ? consecutive_failures + 1 : 0;
         if (consecutive_failures >= 3) {
-          BOOST_LOG(error) << "LuminalVGD watchdog: ping failed 3x — driver unreachable.";
           consecutive_failures = 0;
+          BOOST_LOG(error) << "LuminalVGD watchdog: ping failed 3x — driver unreachable; "
+                              "recycling the control device handle.";
+          bool reopened = false;
+          {
+            std::lock_guard lk(g_mutex);
+            reopened = reopen_locked() == DRIVER_STATUS::OK;
+          }
+          if (reopened) {
+            BOOST_LOG(info) << "LuminalVGD watchdog: control device reopened; "
+                               "driver connection re-established.";
+            continue;
+          }
+          // The devnode is not answering either (driver mid-restart, or
+          // truly gone). Surface it through the registered callback — on a
+          // DETACHED thread: the callback closes the device, and
+          // close_device() joins this ping thread, which would self-join
+          // if the callback ran inline here.
           if (g_ping_fail_cb) {
-            g_ping_fail_cb();
+            std::thread(g_ping_fail_cb).detach();
           }
         }
       }
@@ -363,7 +439,13 @@ namespace VDISPLAY::vgd {
     req.session_id = fresh_session_id(guid);
     req.display_id = display_id_for_client(s_client_uid);
     req.adapter_luid = 0;        // driver default (largest VRAM)
-    req.lease_timeout_ms = 0;    // driver default; ping thread feeds it
+    // 30 s instead of the driver default (watchdog_secs, 10 s). The ping
+    // thread feeds the lease every second; the margin exists for driver
+    // control-queue stalls, which are otherwise indistinguishable from a
+    // dead host and reaped a LIVE primary monitor after 10 s on
+    // 2026-08-07. Explicit destroy at cleanup still releases sessions
+    // immediately — the lease is only the crash backstop.
+    req.lease_timeout_ms = 30'000;
     // HDR10 when the client asked for it and the driver advertises the cap;
     // otherwise SDR-8. The driver's EDID grows the CTA-861.3 HDR block and
     // Windows offers advanced color on the monitor.
@@ -444,7 +526,21 @@ namespace VDISPLAY::vgd {
     }
 
     VgdCreateReply reply {};
-    const int io = vgd_create_monitor(g_device, &req, &reply);
+    int io = vgd_create_monitor(g_device, &req, &reply);
+    if (io == VGD_ERR_IO) {
+      // OS-level failure: the control handle is dead (driver host process
+      // crash, PnP removal). The handle never heals on its own — without
+      // this recycle every future create fails the same way until a
+      // service restart (2026-08-07 outage: no client could get a virtual
+      // monitor after a driver crash mid-session). Reopen and retry once;
+      // if the devnode is back, the wedge never becomes user-visible.
+      BOOST_LOG(warning) << "LuminalVGD CREATE_MONITOR hit an OS-level I/O failure; "
+                            "recycling the control device handle and retrying once.";
+      if (reopen_locked() == DRIVER_STATUS::OK) {
+        reply = {};
+        io = vgd_create_monitor(g_device, &req, &reply);
+      }
+    }
     if (io != 0 || reply.result != 0) {
       BOOST_LOG(error) << "LuminalVGD CREATE_MONITOR failed: io=" << io
                        << " result=" << reply.result;
@@ -743,22 +839,23 @@ namespace VDISPLAY::vgd {
 
   std::optional<RingTargetInfo> ring_target_for_worker_display(const std::string &display_name) {
     if (display_name.empty()) return std::nullopt;
-    const std::wstring wanted(display_name.begin(), display_name.end());
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(6);
+    // Fast path: transfer a concrete, publishing generation when the ring is
+    // already ACTIVE. When it is not (the common case right after the
+    // exclusive modeset, while IddCx rebuilds the target), fall through below
+    // and export the stable session identity with generation zero: the
+    // isolated child holds the ring open — which is what arms surface
+    // publication — and binds the post-modeset generation itself.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(300);
     do {
-      RingTargetInfo target {};
-      {
-        // Never hold the session-map lock while opening or polling a driver
-        // object. Monitor activation and ring publication advance on other
-        // threads during this bounded admission window.
-        std::lock_guard lk(g_mutex);
-        const auto found = std::find_if(g_sessions.begin(), g_sessions.end(), [&](const auto &entry) {
-          return !entry.second.display_name.empty() && entry.second.display_name == wanted;
-        });
-        if (found != g_sessions.end()) {
-          target = {found->second.session_id, found->second.ring_slots, found->second.transport_flags, 0};
-        }
-      }
+      // Resolve through the normal display lookup before applying the strict
+      // worker-generation checks. In the common one-session case the monitor
+      // can activate after create()'s name poll, leaving the tracked GDI name
+      // empty even though DISPLAY<n> is already usable. The normal resolver
+      // safely adopts that sole active LuminalVGD name (or matches its exact
+      // device id when several sessions exist); bypassing it made every worker
+      // handoff wait six seconds and then fall back despite a live ring.
+      auto resolved = ring_target_for_display(display_name);
+      RingTargetInfo target = resolved.value_or(RingTargetInfo {});
       if (target.session_id && target.ring_slots >= kMinRingSlots && target.ring_slots <= kMaxRingSlots &&
           (target.transport_flags & ~kAllowedRingTransportFlags) == 0) {
         VgdRingHandle *ring = vgd_ring_open(target.session_id, target.ring_slots);
@@ -770,15 +867,17 @@ namespace VDISPLAY::vgd {
           const bool second_ok = first_ok && vgd_ring_status(ring, &second) == 0;
           vgd_ring_close(ring);
           LARGE_INTEGER now_qpc {};
-          QueryPerformanceCounter(&now_qpc);
+          const bool qpc_ok = QueryPerformanceCounter(&now_qpc) != FALSE && now_qpc.QuadPart >= 0;
           const bool stable = second_ok && first.state == 1 && second.state == 1 &&
                               first.generation == second.generation && second.generation != 0 &&
                               first.transport_flags == second.transport_flags &&
-                              second.latest_sequence >= first.latest_sequence && second.latest_sequence != 0 &&
-                              second.heartbeat_qpc != 0 && second.qpc_frequency != 0 &&
+                              second.transport_flags == target.transport_flags &&
                               (second.transport_flags & ~kAllowedRingTransportFlags) == 0 &&
-                              now_qpc.QuadPart >= 0 && static_cast<uint64_t>(now_qpc.QuadPart) >= second.heartbeat_qpc &&
-                              static_cast<uint64_t>(now_qpc.QuadPart) - second.heartbeat_qpc <= second.qpc_frequency * 2ULL;
+                              second.latest_sequence >= first.latest_sequence && second.latest_sequence != 0 &&
+                              second.heartbeat_qpc != 0 && second.qpc_frequency != 0 && qpc_ok &&
+                              static_cast<uint64_t>(now_qpc.QuadPart) >= second.heartbeat_qpc &&
+                              static_cast<uint64_t>(now_qpc.QuadPart) - second.heartbeat_qpc <=
+                                second.qpc_frequency * 2ULL;
           if (stable) {
             target.generation = second.generation;
             target.transport_flags = second.transport_flags;
@@ -788,6 +887,20 @@ namespace VDISPLAY::vgd {
       }
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     } while (std::chrono::steady_clock::now() < deadline);
+
+    // Deferred generation binding: the ring exists but has not published yet.
+    // Export the session identity with generation zero so the child can wait
+    // for (and validate) the post-modeset generation with its own long-lived
+    // ring handle. Returning nullopt here silently abandoned Direct-to-Encode
+    // for the whole session on every cold start.
+    auto resolved = ring_target_for_display(display_name);
+    if (resolved && resolved->session_id &&
+        resolved->ring_slots >= kMinRingSlots && resolved->ring_slots <= kMaxRingSlots &&
+        (resolved->transport_flags & ~kAllowedRingTransportFlags) == 0) {
+      RingTargetInfo target = *resolved;
+      target.generation = 0;
+      return target;
+    }
     return std::nullopt;
   }
 

--- a/src/platform/windows/virtual_display_vgd.h
+++ b/src/platform/windows/virtual_display_vgd.h
@@ -88,9 +88,13 @@ namespace VDISPLAY::vgd {
   /// otherwise the session whose recorded display name matches wins.
   std::optional<RingTargetInfo> ring_target_for_display(const std::string &display_name);
 
-  /// Strict IPC handoff lookup: unlike ring_target_for_display(), this never
-  /// adopts a sole/unnamed session. It requires an exact active GDI display
-  /// match and snapshots the current ACTIVE ring generation.
+  /// IPC handoff lookup. It first resolves/adopts the active GDI display using
+  /// the same identity-safe rules as ring_target_for_display(). If the ring is
+  /// already ACTIVE and publishing (bounded 300 ms probe), the concrete
+  /// generation is exported; otherwise the stable session identity is exported
+  /// with generation zero and the isolated child binds and validates the
+  /// post-modeset generation itself, with a bounded wait on its own long-lived
+  /// ring handle (opening the consumer is what arms surface publication).
   std::optional<RingTargetInfo> ring_target_for_worker_display(const std::string &display_name);
 
   /// Install a process-local ring identity imported by an authenticated

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -795,8 +795,8 @@ namespace proc {
       _virtual_display_active(other._virtual_display_active),
 #endif
       _pipe(std::move(other._pipe)),
-      _app_prep_it(other._app_prep_it),
-      _app_prep_begin(other._app_prep_begin)
+      _completed_prep_cmds(other._completed_prep_cmds),
+      _pending_env(std::move(other._pending_env))
 #ifdef _WIN32
       ,
       _lossless_thread(std::move(other._lossless_thread)),
@@ -810,11 +810,13 @@ namespace proc {
     _lossless_stop_requested.store(other._lossless_stop_requested.load(std::memory_order_acquire), std::memory_order_release);
     other._lossless_profile_applied = false;
 #endif
+    other._completed_prep_cmds = 0;
+    other._app_id = -1;
   }
 
   proc_t &proc_t::operator=(proc_t &&other) noexcept {
     if (this != &other) {
-      std::scoped_lock lk(_apps_mutex, other._apps_mutex);
+      std::scoped_lock lk(_lifecycle_mutex, other._lifecycle_mutex, _apps_mutex, other._apps_mutex);
 #ifdef _WIN32
       stop_lossless_scaling_support();
 #endif
@@ -828,8 +830,8 @@ namespace proc {
       _process = std::move(other._process);
       _process_group = std::move(other._process_group);
       _pipe = std::move(other._pipe);
-      _app_prep_it = other._app_prep_it;
-      _app_prep_begin = other._app_prep_begin;
+      _completed_prep_cmds = other._completed_prep_cmds;
+      _pending_env = std::move(other._pending_env);
 #ifdef _WIN32
       _lossless_thread = std::move(other._lossless_thread);
       _lossless_stop_requested.store(other._lossless_stop_requested.load(std::memory_order_acquire), std::memory_order_release);
@@ -841,6 +843,8 @@ namespace proc {
       _virtual_display_active = other._virtual_display_active;
       other._lossless_profile_applied = false;
 #endif
+      other._completed_prep_cmds = 0;
+      other._app_id = -1;
     }
     return *this;
   }
@@ -1077,9 +1081,14 @@ namespace proc {
   }
 
   int proc_t::execute(int app_id, std::shared_ptr<rtsp_stream::launch_session_t> launch_session) {
+    std::lock_guard lifecycle_lock(_lifecycle_mutex);
     // Ensure starting from a clean slate
     const bool skip_display_revert = launch_session && launch_session->display_config_preapplied;
     terminate(skip_display_revert);
+    if (_pending_env) {
+      _env = std::move(*_pending_env);
+      _pending_env.reset();
+    }
 
 #ifdef _WIN32
     std::optional<std::filesystem::path> resolved_lossless_exe_path;
@@ -1157,8 +1166,7 @@ namespace proc {
         apply_refresh_override(saturating_double(launch_session->fps));
       }
     }
-    _app_prep_begin = std::begin(_app.prep_cmds);
-    _app_prep_it = _app_prep_begin;
+    _completed_prep_cmds = 0;
 
     // Add Stream-specific environment variables
     _env["SUNSHINE_APP_ID"] = std::to_string(_app_id);
@@ -1394,8 +1402,8 @@ namespace proc {
     std::string lossless_install_dir_hint;
 #endif
 
-    for (; _app_prep_it != std::end(_app.prep_cmds); ++_app_prep_it) {
-      auto &cmd = *_app_prep_it;
+    for (; _completed_prep_cmds < _app.prep_cmds.size(); ++_completed_prep_cmds) {
+      const auto &cmd = _app.prep_cmds[_completed_prep_cmds];
 
       // Skip empty commands
       if (cmd.do_cmd.empty()) {
@@ -1699,6 +1707,7 @@ namespace proc {
   }
 
   int proc_t::running() {
+    std::lock_guard lifecycle_lock(_lifecycle_mutex);
 #ifndef _WIN32
     // On POSIX OSes, we must periodically wait for our children to avoid
     // them becoming zombies. This must be synchronized carefully with
@@ -1781,6 +1790,7 @@ namespace proc {
   }
 
   void proc_t::terminate(bool skip_display_revert) {
+    std::lock_guard lifecycle_lock(_lifecycle_mutex);
     std::error_code ec;
     const bool had_active_app = _app_id > 0;
     placebo = false;
@@ -1828,8 +1838,16 @@ namespace proc {
     const bool should_dispatch_revert = has_run && !proc::proc.get_last_run_app_name().empty();
     const auto undo_timeout = std::max(_app.exit_timeout, std::chrono::seconds(15));
 
-    for (; _app_prep_it != _app_prep_begin; --_app_prep_it) {
-      auto &cmd = *(_app_prep_it - 1);
+    if (_completed_prep_cmds > _app.prep_cmds.size()) {
+      BOOST_LOG(error) << "Prep command completion count exceeded the active command snapshot; clamping teardown safely.";
+      _completed_prep_cmds = _app.prep_cmds.size();
+    }
+    while (_completed_prep_cmds > 0) {
+      const auto index = --_completed_prep_cmds;
+      // Own the command for the entire asynchronous launch/wait interval.
+      // Configuration refreshes and proc moves must never invalidate command
+      // text that an elevated teardown path is still using.
+      const cmd_t cmd = _app.prep_cmds[index];
 
       if (cmd.undo_cmd.empty()) {
         continue;
@@ -1942,7 +1960,7 @@ namespace proc {
   }
 
   active_session_guard_t proc_t::active_session_guard() const {
-    std::scoped_lock lk(_apps_mutex);
+    std::scoped_lock lk(_lifecycle_mutex, _apps_mutex);
     active_session_guard_t guard;
     guard.has_active_app = _app_id > 0;
     guard.playnite_id = guard.has_active_app ? _app.playnite_id : std::string();
@@ -1972,6 +1990,7 @@ namespace proc {
   }
 
   std::string proc_t::get_last_run_app_name() {
+    std::lock_guard lifecycle_lock(_lifecycle_mutex);
     return _app.name;
   }
 
@@ -2015,6 +2034,7 @@ namespace proc {
   }
 
   std::string proc_t::get_running_app_exe_name() {
+    std::lock_guard lifecycle_lock(_lifecycle_mutex);
     if (_app_id <= 0) {
       return {};
     }
@@ -2022,12 +2042,13 @@ namespace proc {
   }
 
   bool proc_t::last_run_app_frame_gen_limiter_fix() const {
+    std::lock_guard lifecycle_lock(_lifecycle_mutex);
     return _app.frame_gen_limiter_fix;
   }
 
   bool proc_t::is_launch_deferred() const {
 #ifdef _WIN32
-    std::scoped_lock lk(_apps_mutex);
+    std::lock_guard lifecycle_lock(_lifecycle_mutex);
     return _deferred_launch;
 #else
     return false;
@@ -2828,19 +2849,29 @@ namespace proc {
   }
 
   void proc_t::update_apps(std::vector<ctx_t> &&apps, bp::environment &&env) {
+    std::lock_guard lifecycle_lock(_lifecycle_mutex);
     // Replace app list and environment while keeping current running app intact
     {
       std::scoped_lock lk(_apps_mutex);
       _apps = std::move(apps);
-      _env = std::move(env);
+      if (_app_id > 0) {
+        // The active app's environment is an immutable execution snapshot.
+        // Apply refreshed values to the next launch after teardown completes.
+        _pending_env = std::move(env);
+      } else {
+        _env = std::move(env);
+        _pending_env.reset();
+      }
     }
   }
 
   std::vector<ctx_t> proc_t::release_apps() {
+    std::scoped_lock lk(_lifecycle_mutex, _apps_mutex);
     return std::move(_apps);
   }
 
   bp::environment proc_t::release_env() {
+    std::lock_guard lifecycle_lock(_lifecycle_mutex);
     return std::move(_env);
   }
 }  // namespace proc

--- a/src/process.h
+++ b/src/process.h
@@ -199,6 +199,7 @@ namespace proc {
     std::string _active_client_uuid;
 
     mutable std::mutex _apps_mutex;
+    mutable std::recursive_mutex _lifecycle_mutex;
 
     // If no command associated with _app_id, yet it's still running
     bool placebo {};
@@ -218,8 +219,8 @@ namespace proc {
 #endif
 
     file_t _pipe;
-    std::vector<cmd_t>::const_iterator _app_prep_it;
-    std::vector<cmd_t>::const_iterator _app_prep_begin;
+    std::size_t _completed_prep_cmds {0};
+    std::optional<bp::environment> _pending_env;
 
 #ifdef _WIN32
     void start_lossless_scaling_support(std::unordered_set<DWORD> baseline_pids, const playnite_launcher::lossless::lossless_scaling_app_metadata &metadata, std::string install_dir_hint_utf8, DWORD root_pid);

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -591,15 +591,45 @@ namespace rtsp_stream {
       launch_event.raise(std::move(launch_session));
 
       // Arm the timer to expire this launch session if the client times out
-      raised_timer.expires_after(config::stream.ping_timeout);
-      raised_timer.async_wait([this](const boost::system::error_code &ec) {
-        if (!ec) {
+      arm_launch_timer(config::stream.ping_timeout);
+    }
+
+    /**
+     * @brief Arm (or re-arm) the pending-launch expiry timer.
+     *
+     * The generation counter makes stale handlers inert: a handler whose
+     * deadline elapsed just before a re-arm is queued with a SUCCESS error
+     * code that expires_after cannot revoke — without the generation check it
+     * would pop the launch event despite the extension, rejecting the
+     * client's next RTSP connection with "No pending session". The mutex
+     * serializes the asio timer object across the nvhttp, control and RTSP
+     * threads that all reach it.
+     */
+    void arm_launch_timer(std::chrono::milliseconds timeout) {
+      std::lock_guard lg {_launch_timer_mutex};
+      const auto generation = ++_launch_timer_generation;
+      raised_timer.expires_after(timeout);
+      raised_timer.async_wait([this, generation](const boost::system::error_code &ec) {
+        if (!ec && generation == _launch_timer_generation.load(std::memory_order_acquire)) {
           auto discarded = launch_event.pop(0s);
           if (discarded) {
             BOOST_LOG(debug) << "Event timeout: "sv << discarded->unique_id;
           }
         }
       });
+    }
+
+    /**
+     * @brief Re-arm the pending-launch expiry timer.
+     *
+     * Used when ANNOUNCE has successfully started a session for a
+     * strict-first-frame client and the response is deliberately held while
+     * the video pipeline initializes: the original 10-second timer would pop
+     * the launch event mid-handshake and reject the client's next RTSP
+     * connection with "No pending session".
+     */
+    void extend_launch_timer(std::chrono::milliseconds timeout) {
+      arm_launch_timer(timeout);
     }
 
     /**
@@ -614,7 +644,11 @@ namespace rtsp_stream {
         if (launch_session->id != launch_session_id) {
           BOOST_LOG(error) << "Attempted to clear unexpected session: "sv << launch_session_id << " vs "sv << launch_session->id;
         } else {
-          raised_timer.cancel();
+          {
+            std::lock_guard lg {_launch_timer_mutex};
+            ++_launch_timer_generation;  // invalidate any queued expiry handler
+            raised_timer.cancel();
+          }
           launch_event.pop();
         }
       }
@@ -779,6 +813,8 @@ namespace rtsp_stream {
     boost::asio::io_context io_context;
     tcp::acceptor acceptor {io_context};
     boost::asio::steady_timer raised_timer {io_context};
+    std::mutex _launch_timer_mutex;
+    std::atomic<std::uint64_t> _launch_timer_generation {0};
 
     std::shared_ptr<socket_t> next_socket;
   };
@@ -1361,6 +1397,31 @@ namespace rtsp_stream {
       respond(sock, session, &option, 500, "Internal Server Error", req->sequenceNumber, {});
       return;
     }
+
+#ifdef _WIN32
+    // Strict-first-frame clients (Xbox and webOS Moonlight ports embedding
+    // older moonlight-common-c) enforce a hard ~10-second no-video budget
+    // from stream start and do not credit the runt keepalive. Hold the
+    // ANNOUNCE response for those clients until the video pipeline reports it
+    // can deliver, so their clock starts when video can actually flow. The
+    // 8-second cap stays inside their 10-second per-RTSP-request budget, and
+    // every host-side clock this hold overlaps is explicitly extended:
+    // the pending-launch timer here, and the recv_ping/pingTimeout windows in
+    // session::alloc/start via session_t::strict_client.
+    if (stream::session::strict_first_frame_client(session.client_name)) {
+      server->extend_launch_timer(std::chrono::seconds(30));
+      const auto hold_started = std::chrono::steady_clock::now();
+      if (stream::session::wait_video_pipeline_ready(*stream_session, std::chrono::milliseconds(8000))) {
+        BOOST_LOG(info) << "RTSP admission: strict client '" << session.client_name
+                        << "'; held ANNOUNCE "
+                        << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - hold_started).count()
+                        << " ms until the video pipeline reported ready.";
+      } else {
+        BOOST_LOG(warning) << "RTSP admission: strict client '" << session.client_name
+                           << "'; video pipeline not ready within the 8-second hold; responding anyway.";
+      }
+    }
+#endif
 
     respond(sock, session, &option, 200, "OK", req->sequenceNumber, {});
   }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cctype>
 #include <cmath>
 #include <cstdlib>  // std::_Exit for fast non-WER process termination on hang
 #include <cstring>
@@ -49,6 +50,7 @@ extern "C" {
 #endif
 #include "update.h"
 #include "utility.h"
+#include "video_packet_qos.h"
 #include "webrtc_stream.h"
 #ifdef _WIN32
   #include <excpt.h>  // __try/__except for the videoThread DXGI-cleanup SEH wrapper.
@@ -409,8 +411,13 @@ namespace stream {
   struct broadcast_ctx_t {
     message_queue_queue_t message_queue_queue;
 
+    // Pin the global audio packet queue for the whole broadcast lifetime.
+    // The mailbox map holds only weak_ptrs: without this anchor the queue can
+    // expire between start_broadcast returning and the consumer thread's own
+    // lookup, leaving the id permanently resolving to null.
+    safe::mail_raw_t::queue_t<audio::packet_t> audio_packets;
+
     std::thread recv_thread;
-    std::thread video_thread;
     std::thread audio_thread;
     std::thread control_thread;
 
@@ -434,6 +441,16 @@ namespace stream {
 
     std::chrono::steady_clock::time_point pingTimeout;
 
+    // The client needs the strict-first-frame accommodations (Xbox/webOS
+    // Moonlight ports whose older moonlight-common-c enforces a hard
+    // 10-second no-video budget): ANNOUNCE is held while the video pipeline
+    // initializes, and every host-side establishment window is extended by
+    // the same allowance so the hold cannot trip a cleanup timer.
+    bool strict_client {false};
+
+    // Lifetime anchor for mail::video_pipeline_ready (see session::alloc).
+    safe::mail_raw_t::event_t<bool> video_pipeline_ready_event;
+
     safe::shared_t<broadcast_ctx_t>::ptr_t broadcast_ref;
 
     boost::asio::ip::address localAddress;
@@ -451,6 +468,35 @@ namespace stream {
       safe::mail_raw_t::event_t<std::pair<int64_t, int64_t>> invalidate_ref_frames_events;
 
       std::unique_ptr<platf::deinit_t> qos;
+
+      // Per-client post-encode QoS. Encoded HEVC/H.264/AV1 packets are a
+      // reference chain: after any missing frame, predictive packets must be
+      // withheld until a fresh IDR. Keeping pacing clocks here also prevents a
+      // reconnect or second client from inheriting another session's debt.
+      struct {
+        video_qos::state_t qos;
+
+        std::chrono::steady_clock::time_point epoch {};
+        std::chrono::steady_clock::time_point next_frame_start {};
+        std::chrono::steady_clock::time_point last_latency_log {};
+        std::uint64_t last_rtp_timestamp_ticks = 0;
+        bool pacing_logged = false;
+
+        // 30-second capture-to-send age window (2026-08-07 standing-latency
+        // round). The 250 ms backlog warning is threshold-clipped — it only
+        // ever shows the tail of the distribution — so this window keeps
+        // the true age and the real admitted cadence visible at info level.
+        std::chrono::steady_clock::time_point metric_window_start {};
+        std::uint64_t metric_age_sum_ms = 0;
+        std::uint64_t metric_age_max_ms = 0;
+        std::uint32_t metric_aged_frames = 0;
+        std::uint32_t metric_untimestamped_frames = 0;
+      } transport;
+
+      // Set by the egress thread once the first complete frame has been
+      // transmitted. videoThread watches it to decide whether the client's
+      // no-video-traffic clock needs a keepalive extension.
+      std::atomic_bool frame_transmitted {false};
     } video;
 
     struct {
@@ -1678,10 +1724,17 @@ namespace stream {
     session_mon::sample_now(session_mon::make_id(session->launch_session_id), s);
   }
 
-  void videoBroadcastThread(udp::socket &sock) {
-    auto shutdown_event = mail::man->event<bool>(mail::broadcast_shutdown);
-    auto packets = mail::man->queue<video::packet_t>(mail::video_packets);
-    auto video_epoch = std::chrono::steady_clock::now();
+  void videoBroadcastThread(
+    udp::socket &sock,
+    safe::mail_t packet_mail,
+    std::string_view shutdown_id
+  ) {
+    auto shutdown_event = packet_mail->event<bool>(shutdown_id);
+    auto packets = video::packet_queue(packet_mail, mail::video_packets);
+    const auto notify_shutdown = util::fail_guard([&] {
+      packets->stop();
+      shutdown_event->raise(true);
+    });
 
     // Video traffic is sent on this thread
     platf::set_thread_name("stream::videoBroadcast");
@@ -1701,8 +1754,6 @@ namespace stream {
       return;
     }
 
-    auto ratecontrol_next_frame_start = std::chrono::steady_clock::now();
-
     while (auto packet = packets->pop()) {
       if (shutdown_event->peek()) {
         break;
@@ -1712,6 +1763,116 @@ namespace stream {
 
       auto session = (session_t *) packet->channel_data;
       if (!session) {
+        continue;
+      }
+
+      auto &transport = session->video.transport;
+      const auto admission_now = std::chrono::steady_clock::now();
+      if (transport.epoch == std::chrono::steady_clock::time_point {}) {
+        transport.epoch = admission_now;
+        transport.next_frame_start = admission_now;
+      }
+
+      // Four encoded frames at the requested cadence, with a 250 ms floor,
+      // High capture-to-send latency is an OBSERVATION here, never an
+      // admission verdict. When the encode pipeline runs below the nominal
+      // frame rate (e.g. 4K HDR on the WGC compatibility path), the bounded
+      // queues legitimately hold several hundred milliseconds of frames;
+      // withholding those deltas at the egress cannot drain a backlog that
+      // lives upstream — it only converts a laggy stream into an IDR storm
+      // (observed live: one recovery IDR every ~500 ms with every delta
+      // dropped). Latency is shed upstream instead: capture-image delivery is
+      // latest-frame-wins and the shallow packet queues backpressure the
+      // encoder. Only real sequence gaps gate admission below.
+      const auto frame_period = std::chrono::microseconds {
+        1'000'000 / std::max(session->config.monitor.framerate, 1)
+      };
+      const auto max_frame_age = std::max(
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(250ms),
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(frame_period * 4)
+      );
+      const auto admission_timestamp = packet->host_processing_timestamp ?
+                                         packet->host_processing_timestamp :
+                                         packet->frame_timestamp;
+      if (admission_timestamp && admission_now - *admission_timestamp > max_frame_age &&
+          admission_now - transport.last_latency_log > 5s) {
+        transport.last_latency_log = admission_now;
+        BOOST_LOG(warning) << "Video transport: encoded frames are arriving "
+                           << std::chrono::duration_cast<std::chrono::milliseconds>(admission_now - *admission_timestamp).count()
+                           << " ms after capture (pipeline backlog); streaming continues.";
+      }
+      // 30 s age/cadence window: the warning above only fires past its
+      // 250 ms floor, so on its own it cannot show where the pipeline
+      // actually sits. Untimed frames are minimum-FPS duplicates and the
+      // bootstrap IDR (both intentionally timestamp-free).
+      if (transport.metric_window_start == std::chrono::steady_clock::time_point {}) {
+        transport.metric_window_start = admission_now;
+      }
+      if (admission_timestamp) {
+        const auto age_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                              admission_now - *admission_timestamp
+        )
+                              .count();
+        const auto clamped = static_cast<std::uint64_t>(std::max<long long>(age_ms, 0));
+        transport.metric_age_sum_ms += clamped;
+        transport.metric_age_max_ms = std::max(transport.metric_age_max_ms, clamped);
+        ++transport.metric_aged_frames;
+      } else {
+        ++transport.metric_untimestamped_frames;
+      }
+      if (admission_now - transport.metric_window_start >= 30s) {
+        if (transport.metric_aged_frames > 0) {
+          const auto secs = std::max<long long>(
+            std::chrono::duration_cast<std::chrono::seconds>(admission_now - transport.metric_window_start).count(),
+            1
+          );
+          BOOST_LOG(info) << "Video transport window: " << transport.metric_aged_frames << " timed + "
+                          << transport.metric_untimestamped_frames << " untimed frames over " << secs
+                          << " s (~" << (transport.metric_aged_frames + transport.metric_untimestamped_frames) / secs
+                          << " fps arrived); capture-to-send age avg="
+                          << transport.metric_age_sum_ms / transport.metric_aged_frames
+                          << " ms max=" << transport.metric_age_max_ms << " ms.";
+        }
+        transport.metric_window_start = admission_now;
+        transport.metric_age_sum_ms = 0;
+        transport.metric_age_max_ms = 0;
+        transport.metric_aged_frames = 0;
+        transport.metric_untimestamped_frames = 0;
+      }
+      const auto previous_submitted = transport.qos.last_submitted_frame;
+      const auto admission = video_qos::evaluate(
+        transport.qos,
+        packet->frame_index(),
+        packet->is_idr(),
+        false /* latency is logged above, never dropped at the egress */,
+        admission_now
+      );
+      if (!admission.submit) {
+        if (admission.request_idr) {
+          const char *reason = admission.reason == video_qos::reason_e::frame_discontinuity ?
+                                 "encoded-frame sequence gap" :
+                               admission.reason == video_qos::reason_e::stale_frame ?
+                                 "encoded frame exceeded its latency deadline" :
+                                 "transport has no submitted IDR";
+          BOOST_LOG(warning) << "Video QoS: " << reason
+                             << "; withholding predictive frame " << packet->frame_index()
+                             << (previous_submitted ?
+                                   " after " + std::to_string(*previous_submitted) :
+                                   std::string {})
+                             << " and requesting one fresh IDR.";
+
+          // `idr` reaches both in-process encoders and the isolated-worker
+          // controller; the sideband event marks this as a host-detected
+          // discontinuity. The controller applies the same bounded cooldown to
+          // both host- and client-originated recovery so a misdetection can
+          // never escalate into an IDR storm.
+          session->mail->event<bool>(mail::video_discontinuity)->raise(true);
+          if (session->video.idr_events) {
+            session->video.idr_events->raise(true);
+          } else {
+            session->mail->event<bool>(mail::idr)->raise(true);
+          }
+        }
         continue;
       }
       auto lowseq = session->video.lowseq;
@@ -1823,8 +1984,30 @@ namespace stream {
       }
 
       try {
-        // Use around 80% of 1Gbps          1Gbps            percent    ms     packet      byte
-        size_t ratecontrol_packets_in_1ms = std::giga::num * 80 / 100 / 1000 / blocksize / 8;
+        bool all_shards_submitted = true;
+        // The encoder bitrate describes compressed picture payload, not the
+        // wire stream.  Budget separately for FEC and RTP/video headers;
+        // otherwise integer packets/ms
+        // floors a 65 Mbps stream to about 56 Mbps before FEC and the bounded
+        // broadcast queue repeatedly overflows under motion.
+        const auto pacing_bitrate_kbps = std::max(session->config.monitor.bitrate, 1000);
+        const auto wire_packet_bytes = blocksize +
+          (session->video.cipher ? sizeof(video_packet_enc_prefix_t) : 0);
+        // Shape each client independently just above its FEC/header-aware wire
+        // average. The pre-rework drain was a hardcoded 80% of 1 Gbps — ~100 KiB
+        // microbursts every 1 ms regardless of the negotiated bitrate, which a
+        // 100-Mbps TV/Wi-Fi path drops on the floor ("slow connection" despite
+        // adequate average bitrate). A 1-ms quantum with kWirePacingHeadroom
+        // spreads IDRs without making throughput hostage to timer wake latency.
+        const auto pacing = video_qos::pacing_budget(
+          pacing_bitrate_kbps,
+          fecPercentage,
+          wire_packet_bytes,
+          payload_blocksize
+        );
+        const long double pacing_wire_bitrate_bps = pacing.drain_bitrate_bps;
+        const auto packet_wire_interval = pacing.packet_interval;
+        const size_t ratecontrol_packets_per_quantum = pacing.packets_per_quantum;
 
         // Send less than 64K in a single batch.
         // On Windows, batches above 64K seem to bypass SO_SNDBUF regardless of its size,
@@ -1838,12 +2021,48 @@ namespace stream {
         // unusually small packet size.
         // Generic Segmentation Offload on Linux can't do more than 64.
         send_batch_size = std::min<size_t>(64, send_batch_size);
+        // A batch is submitted atomically by the Windows UDP backend. Limit it
+        // to one pacing quantum of negotiated traffic so pacing actually divides
+        // an IDR instead of sleeping only after the entire burst was sent.
+        send_batch_size = std::min(send_batch_size, ratecontrol_packets_per_quantum);
+        if (!transport.pacing_logged) {
+          transport.pacing_logged = true;
+          BOOST_LOG(info) << "Video packet pacing: negotiated=" << pacing_bitrate_kbps
+                          << " Kbps, wire_drain_cap="
+                          << static_cast<std::uint64_t>(pacing_wire_bitrate_bps / 1000.0L)
+                          << " Kbps, send_batch=" << send_batch_size
+                          << ", pacing_quantum=" << ratecontrol_packets_per_quantum
+                          << " packet(s)/" << video_qos::kWirePacingQuantum.count()
+                          << "us, packet_size=" << wire_packet_bytes << " bytes.";
+        }
 
         // Don't ignore the last ratecontrol group of the previous frame
-        auto ratecontrol_frame_start = std::max(ratecontrol_next_frame_start, std::chrono::steady_clock::now());
+        auto ratecontrol_frame_start = std::max(transport.next_frame_start, std::chrono::steady_clock::now());
 
         size_t ratecontrol_frame_packets_sent = 0;
         size_t ratecontrol_group_packets_sent = 0;
+
+        // All FEC blocks belonging to one encoded frame must carry the same
+        // RTP timestamp.  Advancing this clock inside the FEC-block loop makes
+        // a large 4K/HDR frame look like several different frames to Moonlight,
+        // corrupting its reference tree and provoking a false slow-connection
+        // warning.  Clamp once per encoded frame, then reuse the value below.
+        bool frame_is_dupe = false;
+        if (!packet->frame_timestamp) {
+          packet->frame_timestamp = transport.next_frame_start;
+          frame_is_dupe = true;
+        }
+        using rtp_tick_wide = std::chrono::duration<std::uint64_t, std::ratio<1, 90000>>;
+        auto timestamp_ticks = std::chrono::round<rtp_tick_wide>(
+          std::max(*packet->frame_timestamp, transport.epoch) - transport.epoch
+        ).count();
+        timestamp_ticks = video_qos::next_rtp_timestamp_ticks(
+          timestamp_ticks,
+          transport.last_rtp_timestamp_ticks,
+          session->config.monitor.framerate
+        );
+        transport.last_rtp_timestamp_ticks = timestamp_ticks;
+        const auto timestamp = static_cast<std::uint32_t>(timestamp_ticks);
 
         auto blockIndex = 0;
         std::for_each(fec_blocks_begin, fec_blocks_end, [&](std::string_view &current_payload) {
@@ -1889,16 +2108,6 @@ namespace stream {
 
           size_t next_shard_to_send = 0;
 
-          // RTP video timestamps use a 90 KHz clock and the frame_timestamp from when the frame was captured
-          // When a timestamp isn't available (duplicate frames), the timestamp from rate control is used instead.
-          bool frame_is_dupe = false;
-          if (!packet->frame_timestamp) {
-            packet->frame_timestamp = ratecontrol_next_frame_start;
-            frame_is_dupe = true;
-          }
-          using rtp_tick = std::chrono::duration<uint32_t, std::ratio<1, 90000>>;
-          uint32_t timestamp = std::chrono::round<rtp_tick>(*packet->frame_timestamp - video_epoch).count();
-
           // set FEC info now that we know for sure what our percentage will be for this frame
           for (auto x = 0; x < shards.size(); ++x) {
             auto *inspect = (video_packet_raw_t *) shards.data(x);
@@ -1941,12 +2150,17 @@ namespace stream {
               // Do pacing within the frame.
               // Also trigger pacing before the first send_batch() of the frame
               // to account for the last send_batch() of the previous frame.
-              if (ratecontrol_group_packets_sent >= ratecontrol_packets_in_1ms ||
+              if (ratecontrol_group_packets_sent >= ratecontrol_packets_per_quantum ||
                   ratecontrol_frame_packets_sent == 0) {
-                auto due = ratecontrol_frame_start +
-                           std::chrono::duration_cast<std::chrono::nanoseconds>(1ms) *
-                             ratecontrol_frame_packets_sent / ratecontrol_packets_in_1ms;
-
+                // Absolute per-frame deadlines: after a late timer wake the
+                // sender catches up exactly its elapsed entitlement
+                // (elapsed x drain), which the bitrate-derived drain keeps
+                // inherently burst-bounded. No rebasing — discarding catch-up
+                // credit makes throughput collapse on coarse-resolution timers.
+                const auto due = ratecontrol_frame_start +
+                                 std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                                   packet_wire_interval * ratecontrol_frame_packets_sent
+                                 );
                 auto now = std::chrono::steady_clock::now();
                 if (now < due) {
                   timer->sleep_for(due - now);
@@ -1976,7 +2190,7 @@ namespace stream {
                     session->localAddress,
                   };
 
-                  platf::send(send_info);
+                  all_shards_submitted = platf::send(send_info) && all_shards_submitted;
                 }
               }
               frame_send_batch_latency_logger.second_point_now_and_log();
@@ -1988,9 +2202,10 @@ namespace stream {
           }
 
           // remember this in case the next frame comes immediately
-          ratecontrol_next_frame_start = ratecontrol_frame_start +
-                                         std::chrono::duration_cast<std::chrono::nanoseconds>(1ms) *
-                                           ratecontrol_frame_packets_sent / ratecontrol_packets_in_1ms;
+          transport.next_frame_start = ratecontrol_frame_start +
+                                       std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                                         packet_wire_interval * ratecontrol_frame_packets_sent
+                                       );
 
           frame_network_latency_logger.second_point_now_and_log();
 
@@ -2006,18 +2221,46 @@ namespace stream {
 
         session->video.lowseq = lowseq;
 
+        if (all_shards_submitted) {
+          session->video.frame_transmitted.store(true, std::memory_order_release);
+          const auto recovery = video_qos::submitted(
+            transport.qos,
+            packet->frame_index(),
+            packet->is_idr(),
+            std::chrono::steady_clock::now()
+          );
+          if (packet->is_idr()) {
+            session->mail->event<std::int64_t>(mail::video_idr_submitted)->raise(packet->frame_index());
+          }
+          if (recovery && recovery->withheld_frames != 0) {
+            BOOST_LOG(info) << "Video QoS: fresh IDR " << packet->frame_index()
+                            << " restored the decoder chain after withholding "
+                            << recovery->withheld_frames << " predictive frame(s) for "
+                            << std::chrono::duration_cast<std::chrono::milliseconds>(recovery->duration).count()
+                            << " ms.";
+          }
+        } else {
+          // A rejected shard is packet loss at the host socket. Do not stall
+          // the egress loop over it: record the failure so the QoS gate
+          // withholds the now-undecodable successors and requests exactly one
+          // recovery IDR through the normal discontinuity path.
+          video_qos::submission_failed(transport.qos, packet->is_idr());
+          BOOST_LOG(warning) << "Video broadcast: one or more UDP shards of frame "
+                             << packet->frame_index() << " were rejected by the host socket.";
+        }
+
         if (config::stream.session_monitor) {
           session->telemetry.frames.fetch_add(1, std::memory_order_relaxed);
           session->telemetry.payload_bytes.fetch_add(packet->data_size(), std::memory_order_relaxed);
           telemetry_flush(session);
         }
       } catch (const std::exception &e) {
+        video_qos::submission_failed(transport.qos, packet->is_idr());
         BOOST_LOG(error) << "Broadcast video failed "sv << e.what();
         std::this_thread::sleep_for(100ms);
       }
     }
 
-    shutdown_event->raise(true);
   }
 
   void audioBroadcastThread(udp::socket &sock) {
@@ -2134,12 +2377,12 @@ namespace stream {
     auto broadcast_shutdown_event = mail::man->event<bool>(mail::broadcast_shutdown);
     broadcast_shutdown_event->reset();
 
-    // Reset the packet queues which were stopped in end_broadcast.
-    // If not reset, the broadcast threads will exit immediately when pop() returns null.
-    auto video_packets = mail::man->queue<video::packet_t>(mail::video_packets);
-    auto audio_packets = mail::man->queue<audio::packet_t>(mail::audio_packets);
-    video_packets->reset();
-    audio_packets->reset();
+    // Reset the audio packet queue which was stopped in end_broadcast.
+    // If not reset, the broadcast thread exits immediately when pop() returns
+    // null. Video egress is session-owned (per-session mailbox queues); no
+    // global video packet queue exists any more.
+    ctx.audio_packets = mail::man->queue<audio::packet_t>(mail::audio_packets);
+    ctx.audio_packets->reset();
 
     auto address_family = net::af_from_enum_string(config::sunshine.address_family);
     auto protocol = address_family == net::IPV4 ? udp::v4() : udp::v6();
@@ -2202,7 +2445,6 @@ namespace stream {
     // After calling stop(), restart() must be called before run() will work again.
     ctx.io_context.restart();
 
-    ctx.video_thread = std::thread {videoBroadcastThread, std::ref(ctx.video_sock)};
     ctx.audio_thread = std::thread {audioBroadcastThread, std::ref(ctx.audio_sock)};
     ctx.control_thread = std::thread {controlBroadcastThread, &ctx.control_server};
 
@@ -2216,12 +2458,10 @@ namespace stream {
 
     broadcast_shutdown_event->raise(true);
 
-    auto video_packets = mail::man->queue<video::packet_t>(mail::video_packets);
-    auto audio_packets = mail::man->queue<audio::packet_t>(mail::audio_packets);
-
-    // Minimize delay stopping video/audio threads
-    video_packets->stop();
-    audio_packets->stop();
+    // Minimize delay stopping the audio thread
+    if (ctx.audio_packets) {
+      ctx.audio_packets->stop();
+    }
 
     ctx.message_queue_queue->stop();
     ctx.io_context.stop();
@@ -2229,13 +2469,8 @@ namespace stream {
     ctx.video_sock.close();
     ctx.audio_sock.close();
 
-    video_packets.reset();
-    audio_packets.reset();
-
     BOOST_LOG(debug) << "Waiting for main listening thread to end..."sv;
     ctx.recv_thread.join();
-    BOOST_LOG(debug) << "Waiting for main video thread to end..."sv;
-    ctx.video_thread.join();
     BOOST_LOG(debug) << "Waiting for main audio thread to end..."sv;
     ctx.audio_thread.join();
     BOOST_LOG(debug) << "Waiting for main control thread to end..."sv;
@@ -2268,10 +2503,10 @@ namespace stream {
     auto start_time = std::chrono::steady_clock::now();
     auto current_time = start_time;
 
-    while (current_time - start_time < config::stream.ping_timeout) {
+    while (current_time - start_time < timeout) {
       auto delta_time = current_time - start_time;
 
-      auto msg_opt = messages->pop(config::stream.ping_timeout - delta_time);
+      auto msg_opt = messages->pop(timeout - delta_time);
       if (!msg_opt) {
         break;
       }
@@ -2358,8 +2593,37 @@ namespace stream {
     while_starting_do_nothing(session->state);
 
     auto ref = broadcast.ref();
-    const auto ping_error = recv_ping(session, ref, socket_e::video, session->video.ping_payload, session->video.peer, config::stream.ping_timeout);
+
+#ifdef _WIN32
+    // Start a session-owned isolated capture/encode pipeline while the client
+    // establishes its UDP video peer. Process creation, WGC/ring acquisition,
+    // HDR conversion and NVENC setup therefore remain parallel with recv_ping(),
+    // without transferring worker handles between HTTPS and RTSP lifetimes.
+    auto peer_ready = session->mail->event<bool>(mail::video_peer_ready);
+    peer_ready->reset();
+    seh_video_capture_args_t cap_args {session->mail, session->config.monitor, session};
+    std::atomic<unsigned long> capture_seh {0};
+    std::thread capture_thread([&] {
+      capture_seh.store(seh_invoke_video_capture_(&cap_args), std::memory_order_release);
+    });
+
+    const auto join_capture = util::fail_guard([&] {
+      if (capture_thread.joinable()) capture_thread.join();
+    });
+#endif
+
+    const auto ping_error = recv_ping(
+      session,
+      ref,
+      socket_e::video,
+      session->video.ping_payload,
+      session->video.peer,
+      config::stream.ping_timeout + (session->strict_client ? std::chrono::milliseconds(10000) : std::chrono::milliseconds(0))
+    );
     if (ping_error < 0) {
+#ifdef _WIN32
+      session->shutdown_event->raise(true);
+#endif
       return;
     }
 
@@ -2367,13 +2631,59 @@ namespace stream {
     auto address = session->video.peer.address();
     session->video.qos = platf::enable_socket_qos(ref->video_sock.native_handle(), address, session->video.peer.port(), platf::qos_data_type_e::video, session->config.videoQosType != 0);
 
+    // Encoded egress is session-owned. A slow TV or Wi-Fi client can now apply
+    // backpressure only to its own encoder/latest-frame mailbox rather than a
+    // process-global queue shared by every active client.
+    auto session_packets = video::packet_queue(session->mail, mail::video_packets);
+    std::thread egress_thread {
+      videoBroadcastThread,
+      std::ref(ref->video_sock),
+      session->mail,
+      mail::shutdown
+    };
+    const auto join_egress = util::fail_guard([&] {
+      session_packets->stop();
+      if (egress_thread.joinable()) egress_thread.join();
+    });
+
     BOOST_LOG(debug) << "Start capturing Video"sv;
 #ifdef _WIN32
-    // Build the args struct here (in the videoThread stack frame, before
-    // any __try). Its destructor will run when videoThread returns, well
-    // after the SEH wrapper has unwound.
-    seh_video_capture_args_t cap_args {session->mail, session->config.monitor, session};
-    auto seh = seh_invoke_video_capture_(&cap_args);
+    // Attach the authenticated network consumer to the already-starting (and
+    // commonly already-ready) worker. The worker publishes its retained
+    // bootstrap IDR; requesting another one here created a startup IDR burst.
+    peer_ready->raise(true);
+    BOOST_LOG(info) << "Video worker: authenticated UDP peer attached; releasing buffered IDR.";
+
+    // Moonlight terminates with "no video received" if NO datagram arrives on
+    // the video port within 10 s of PLAY, and separately requires a complete
+    // frame within 10 s of the FIRST datagram (moonlight-common-c
+    // VideoStream.c). NVENC session creation alone can take ~7 s on some
+    // driver/GPU combinations, putting the first real packet past the first
+    // clock. A single runt datagram — below the client's minimum RTP size, so
+    // it is discarded before parsing — permanently disarms the no-traffic
+    // clock. Send it as LATE as possible and only when no real frame has been
+    // transmitted, because it also starts the first-frame clock: sent at
+    // ~8 s, it extends the effective budget for the first frame to ~18 s.
+    {
+      const auto keepalive_deadline = std::chrono::steady_clock::now() + 8s;
+      while (!session->video.frame_transmitted.load(std::memory_order_acquire) &&
+             !session->shutdown_event->peek() &&
+             std::chrono::steady_clock::now() < keepalive_deadline) {
+        std::this_thread::sleep_for(250ms);
+      }
+      if (!session->video.frame_transmitted.load(std::memory_order_acquire) &&
+          !session->shutdown_event->peek()) {
+        const std::array<char, 1> keepalive {0};
+        boost::system::error_code ec;
+        ref->video_sock.send_to(boost::asio::buffer(keepalive), session->video.peer, 0, ec);
+        BOOST_LOG(warning) << "videoThread: no video frame transmitted within 8 s of peer attach; "
+                              "sent a runt keepalive to hold the client's no-video deadline open"
+                           << (ec ? " (send failed: " + ec.message() + ")" : "") << '.';
+      }
+    }
+
+    capture_thread.join();
+    const auto seh = capture_seh.load(std::memory_order_acquire);
     if (seh != 0) {
       BOOST_LOG(warning) << "videoThread: SEH 0x" << std::hex << seh << std::dec
                          << " caught during video::capture (likely dxgi.dll AV during display teardown). "
@@ -2393,7 +2703,14 @@ namespace stream {
     while_starting_do_nothing(session->state);
 
     auto ref = broadcast.ref();
-    auto error = recv_ping(session, ref, socket_e::audio, session->audio.ping_payload, session->audio.peer, config::stream.ping_timeout);
+    auto error = recv_ping(
+      session,
+      ref,
+      socket_e::audio,
+      session->audio.ping_payload,
+      session->audio.peer,
+      config::stream.ping_timeout + (session->strict_client ? std::chrono::milliseconds(10000) : std::chrono::milliseconds(0))
+    );
     if (error < 0) {
       return;
     }
@@ -2412,6 +2729,42 @@ namespace stream {
 
     state_e state(session_t &session) {
       return session.state.load(std::memory_order_relaxed);
+    }
+
+    bool strict_first_frame_client(std::string_view client_name) {
+      // Xbox (moonlight-xbox-dx) and webOS (moonlight-tv / LG) ports embed
+      // older moonlight-common-c with a hard ~10-second no-video budget that
+      // does not credit the runt keepalive. Identified by the paired-client
+      // name resolved from the certificate at launch.
+      std::string lowered {client_name};
+      std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+      });
+      return lowered.find("xbox") != std::string::npos ||
+             lowered.find("webos") != std::string::npos;
+    }
+
+    bool wait_video_pipeline_ready(session_t &session, std::chrono::milliseconds timeout) {
+#ifdef _WIN32
+      auto ready = session.video_pipeline_ready_event ?
+                     session.video_pipeline_ready_event :
+                     session.mail->event<bool>(mail::video_pipeline_ready);
+      const auto deadline = std::chrono::steady_clock::now() + timeout;
+      while (std::chrono::steady_clock::now() < deadline) {
+        if (ready->peek()) {
+          return true;
+        }
+        if (session.shutdown_event->peek()) {
+          return false;  // The session died during the hold; respond and move on.
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
+      return ready->peek();
+#else
+      (void) session;
+      (void) timeout;
+      return true;
+#endif
     }
 
     void stop(session_t &session) {
@@ -2742,7 +3095,11 @@ namespace stream {
       session.audio.peer.address(addr);
       session.audio.peer.port(0);
 
-      session.pingTimeout = std::chrono::steady_clock::now() + config::stream.ping_timeout;
+      // Strict-first-frame clients get every establishment window extended by
+      // the ANNOUNCE-hold allowance (8 s hold + margin) so the deliberate hold
+      // cannot trip the control-thread cleanup timer.
+      session.pingTimeout = std::chrono::steady_clock::now() + config::stream.ping_timeout +
+                            (session.strict_client ? std::chrono::seconds(18) : std::chrono::seconds(0));
 
       session.audioThread = std::thread {audioThread, &session};
       session.videoThread = std::thread {videoThread, &session};
@@ -2846,9 +3203,19 @@ namespace stream {
       auto mail = std::make_shared<safe::mail_raw_t>();
 
       session->shutdown_event = mail->event<bool>(mail::shutdown);
+      // Anchor the readiness event for the session's lifetime: the mailbox
+      // map holds only weak_ptrs, so a raise through a temporary handle
+      // before the ANNOUNCE hold acquires its own would otherwise be lost
+      // with the expiring event object.
+      session->video_pipeline_ready_event = mail->event<bool>(mail::video_pipeline_ready);
       session->launch_session_id = launch_session.id;
 
       session->config = config;
+#ifdef _WIN32
+      // Strict-first-frame accommodations exist only where the ANNOUNCE hold
+      // exists; other platforms keep upstream-identical windows.
+      session->strict_client = strict_first_frame_client(launch_session.client_name);
+#endif
 
 #ifdef _WIN32
       session->virtual_display.active = launch_session.virtual_display;

--- a/src/stream.h
+++ b/src/stream.h
@@ -73,6 +73,19 @@ namespace stream {
 
     std::shared_ptr<session_t> alloc(config_t &config, rtsp_stream::launch_session_t &launch_session);
     int start(session_t &session, const std::string &addr_string);
+
+    /**
+     * @brief True for clients that enforce a hard first-video deadline
+     *        (Xbox / webOS Moonlight ports), identified by paired-client name.
+     */
+    bool strict_first_frame_client(std::string_view client_name);
+
+    /**
+     * @brief Wait (bounded, shutdown-aware) until the session's video
+     *        pipeline reports it can deliver its first packet.
+     */
+    bool wait_video_pipeline_ready(session_t &session, std::chrono::milliseconds timeout);
+
     void stop(session_t &session);
     void join(session_t &session);
     state_e state(session_t &session);

--- a/src/thread_safe.h
+++ b/src/thread_safe.h
@@ -17,6 +17,11 @@
 #include "utility.h"
 
 namespace safe {
+  enum class queue_overflow_e {
+    clear,
+    block,
+  };
+
   template<class T>
   class event_t {
   public:
@@ -117,6 +122,7 @@ namespace safe {
     }
 
     bool peek() {
+      std::lock_guard lg {_lock};
       return _continue && (bool) _status;
     }
 
@@ -137,6 +143,7 @@ namespace safe {
     }
 
     [[nodiscard]] bool running() const {
+      std::lock_guard lg {_lock};
       return _continue;
     }
 
@@ -145,7 +152,7 @@ namespace safe {
     status_t _status {util::false_v<status_t>};
 
     std::condition_variable _cv;
-    std::mutex _lock;
+    mutable std::mutex _lock;
   };
 
   template<class T>
@@ -254,19 +261,34 @@ namespace safe {
   public:
     using status_t = util::optional_t<T>;
 
-    queue_t(std::uint32_t max_elements = 32):
-        _max_elements {max_elements} {
+    queue_t(
+      std::uint32_t max_elements = 32,
+      queue_overflow_e overflow = queue_overflow_e::clear
+    ):
+        _max_elements {max_elements == 0 ? 1u : max_elements},
+        _overflow {overflow} {
     }
 
     template<class... Args>
     void raise(Args &&...args) {
-      std::lock_guard ul {_lock};
+      std::unique_lock ul {_lock};
+      const auto generation = _generation;
 
       if (!_continue) {
         return;
       }
 
-      if (_queue.size() == _max_elements) {
+      if (_overflow == queue_overflow_e::block) {
+        ++_waiting_producers;
+        _cv.wait(ul, [this, generation] {
+          return !_continue || generation != _generation ||
+                 _queue.size() < _max_elements;
+        });
+        --_waiting_producers;
+        if (!_continue || generation != _generation) {
+          return;
+        }
+      } else if (_queue.size() >= _max_elements) {
         _queue.clear();
       }
 
@@ -276,19 +298,32 @@ namespace safe {
     }
 
     bool peek() {
+      std::lock_guard lg {_lock};
       return _continue && !_queue.empty();
+    }
+
+    bool at_capacity() {
+      std::lock_guard lg {_lock};
+      return _continue && _queue.size() >= _max_elements;
+    }
+
+    [[nodiscard]] std::uint32_t waiting_producers() const {
+      std::lock_guard lg {_lock};
+      return _waiting_producers;
     }
 
     template<class Rep, class Period>
     status_t pop(std::chrono::duration<Rep, Period> delay) {
       std::unique_lock ul {_lock};
+      const auto generation = _generation;
 
       if (!_continue) {
         return util::false_v<status_t>;
       }
 
       while (_queue.empty()) {
-        if (!_continue || _cv.wait_for(ul, delay) == std::cv_status::timeout) {
+        if (!_continue || generation != _generation ||
+            _cv.wait_for(ul, delay) == std::cv_status::timeout) {
           return util::false_v<status_t>;
         }
       }
@@ -296,11 +331,14 @@ namespace safe {
       auto val = std::move(_queue.front());
       _queue.erase(std::begin(_queue));
 
+      _cv.notify_all();
+
       return val;
     }
 
     status_t pop() {
       std::unique_lock ul {_lock};
+      const auto generation = _generation;
 
       if (!_continue) {
         return util::false_v<status_t>;
@@ -309,13 +347,15 @@ namespace safe {
       while (_queue.empty()) {
         _cv.wait(ul);
 
-        if (!_continue) {
+        if (!_continue || generation != _generation) {
           return util::false_v<status_t>;
         }
       }
 
       auto val = std::move(_queue.front());
       _queue.erase(std::begin(_queue));
+
+      _cv.notify_all();
 
       return val;
     }
@@ -327,7 +367,10 @@ namespace safe {
     void stop() {
       std::lock_guard lg {_lock};
 
-      _continue = false;
+      if (_continue) {
+        _continue = false;
+        ++_generation;
+      }
 
       _cv.notify_all();
     }
@@ -337,17 +380,23 @@ namespace safe {
 
       _continue = true;
       _queue.clear();
+      ++_generation;
+      _cv.notify_all();
     }
 
     [[nodiscard]] bool running() const {
+      std::lock_guard lg {_lock};
       return _continue;
     }
 
   private:
     bool _continue {true};
     std::uint32_t _max_elements;
+    queue_overflow_e _overflow;
+    std::uint64_t _generation = 0;
+    std::uint32_t _waiting_producers = 0;
 
-    std::mutex _lock;
+    mutable std::mutex _lock;
     std::condition_variable _cv;
 
     std::vector<T> _queue;
@@ -518,7 +567,13 @@ namespace safe {
 
       auto it = id_to_post.find(id);
       if (it != std::end(id_to_post)) {
-        return lock<event_t<T>>(it->second);
+        // The map holds only weak_ptrs. An entry whose object has already
+        // been destroyed must be recreated, not returned as null: callers
+        // dereference the result unconditionally.
+        if (auto existing = lock<event_t<T>>(it->second)) {
+          return existing;
+        }
+        id_to_post.erase(it);
       }
 
       auto post = std::make_shared<typename event_t<T>::element_type>(shared_from_this());
@@ -528,15 +583,23 @@ namespace safe {
     }
 
     template<class T>
-    queue_t<T> queue(const std::string_view &id) {
+    queue_t<T> queue(
+      const std::string_view &id,
+      std::uint32_t max_elements = 32,
+      queue_overflow_e overflow = queue_overflow_e::clear
+    ) {
       std::lock_guard lg {mutex};
 
       auto it = id_to_post.find(id);
       if (it != std::end(id_to_post)) {
-        return lock<queue_t<T>>(it->second);
+        // See event(): expired entries must be recreated, never returned null.
+        if (auto existing = lock<queue_t<T>>(it->second)) {
+          return existing;
+        }
+        id_to_post.erase(it);
       }
 
-      auto post = std::make_shared<typename queue_t<T>::element_type>(shared_from_this(), 32);
+      auto post = std::make_shared<typename queue_t<T>::element_type>(shared_from_this(), max_elements, overflow);
       id_to_post.emplace(std::pair<std::string, std::weak_ptr<void>> {std::string {id}, post});
 
       return post;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -243,11 +243,20 @@ namespace video {
       return false;
     }
 
+    std::uint64_t capture_generation_for_current_process() {
+#ifdef _WIN32
+      return platf::video_worker::current_capture_generation();
+#else
+      return 0;
+#endif
+    }
+
     struct encode_bootstrap_state_t {
       bool allow_placeholder_before_first_real = false;
       bool placeholder_encoded = false;
       bool real_frame_seen = false;
       bool current_input_placeholder = true;
+      std::uint64_t current_input_generation = 0;
 
       bool should_encode_placeholder() const {
         return !real_frame_seen && current_input_placeholder &&
@@ -1837,6 +1846,11 @@ namespace video {
           }
 
           if (frame_captured) {
+            // Stamp the source epoch on the capture thread, before the image is
+            // queued. If this display subsequently reports reinit, a late
+            // encode of this image retains the retired epoch and is discarded
+            // by the isolated-worker generation gate.
+            img->capture_generation = capture_generation_for_current_process();
             capture_ctx->images->raise(img);
           }
 
@@ -1870,6 +1884,9 @@ namespace video {
       switch (status) {
         case platf::capture_e::reinit:
           {
+#ifdef _WIN32
+            platf::video_worker::notify_capture_reinitializing();
+#endif
             reinit_event.raise(true);
 
             // Some classes of images contain references to the display --> display won't delete unless img is deleted
@@ -1972,7 +1989,7 @@ namespace video {
     }
   }
 
-  int encode_avcodec(int64_t frame_nr, avcodec_encode_session_t &session, safe::mail_raw_t::queue_t<packet_t> &packets, void *channel_data, std::optional<std::chrono::steady_clock::time_point> frame_timestamp, std::optional<std::chrono::steady_clock::time_point> host_processing_timestamp) {
+  int encode_avcodec(int64_t frame_nr, avcodec_encode_session_t &session, safe::mail_raw_t::queue_t<packet_t> &packets, void *channel_data, std::optional<std::chrono::steady_clock::time_point> frame_timestamp, std::optional<std::chrono::steady_clock::time_point> host_processing_timestamp, bool capture_placeholder, std::uint64_t capture_generation) {
     auto &frame = session.device->frame;
     frame->pts = frame_nr;
 
@@ -2041,6 +2058,8 @@ namespace video {
 
       packet->replacements = &session.replacements;
       packet->channel_data = channel_data;
+      packet->capture_placeholder = capture_placeholder;
+      packet->capture_generation = capture_generation;
       if (webrtc_stream::has_active_sessions()) {
         webrtc_stream::submit_video_packet(*packet);
       }
@@ -2050,7 +2069,7 @@ namespace video {
     return 0;
   }
 
-  int encode_nvenc(int64_t frame_nr, nvenc_encode_session_t &session, safe::mail_raw_t::queue_t<packet_t> &packets, void *channel_data, std::optional<std::chrono::steady_clock::time_point> frame_timestamp, std::optional<std::chrono::steady_clock::time_point> host_processing_timestamp) {
+  int encode_nvenc(int64_t frame_nr, nvenc_encode_session_t &session, safe::mail_raw_t::queue_t<packet_t> &packets, void *channel_data, std::optional<std::chrono::steady_clock::time_point> frame_timestamp, std::optional<std::chrono::steady_clock::time_point> host_processing_timestamp, bool capture_placeholder, std::uint64_t capture_generation) {
     auto encoded_frame = session.encode_frame(frame_nr);
     if (encoded_frame.data.empty()) {
       BOOST_LOG(error) << "NvENC returned empty packet";
@@ -2064,6 +2083,8 @@ namespace video {
     auto packet = std::make_unique<packet_raw_generic>(std::move(encoded_frame.data), encoded_frame.frame_index, encoded_frame.idr);
     packet->channel_data = channel_data;
     packet->after_ref_frame_invalidation = encoded_frame.after_ref_frame_invalidation;
+    packet->capture_placeholder = capture_placeholder;
+    packet->capture_generation = capture_generation;
     packet->frame_timestamp = frame_timestamp;
     packet->host_processing_timestamp = host_processing_timestamp;
     if (webrtc_stream::has_active_sessions()) {
@@ -2074,11 +2095,11 @@ namespace video {
     return 0;
   }
 
-  int encode(int64_t frame_nr, encode_session_t &session, safe::mail_raw_t::queue_t<packet_t> &packets, void *channel_data, std::optional<std::chrono::steady_clock::time_point> frame_timestamp, std::optional<std::chrono::steady_clock::time_point> host_processing_timestamp) {
+  int encode(int64_t frame_nr, encode_session_t &session, safe::mail_raw_t::queue_t<packet_t> &packets, void *channel_data, std::optional<std::chrono::steady_clock::time_point> frame_timestamp, std::optional<std::chrono::steady_clock::time_point> host_processing_timestamp, bool capture_placeholder = false, std::uint64_t capture_generation = 0) {
     if (auto avcodec_session = dynamic_cast<avcodec_encode_session_t *>(&session)) {
-      return encode_avcodec(frame_nr, *avcodec_session, packets, channel_data, frame_timestamp, host_processing_timestamp);
+      return encode_avcodec(frame_nr, *avcodec_session, packets, channel_data, frame_timestamp, host_processing_timestamp, capture_placeholder, capture_generation);
     } else if (auto nvenc_session = dynamic_cast<nvenc_encode_session_t *>(&session)) {
-      return encode_nvenc(frame_nr, *nvenc_session, packets, channel_data, frame_timestamp, host_processing_timestamp);
+      return encode_nvenc(frame_nr, *nvenc_session, packets, channel_data, frame_timestamp, host_processing_timestamp, capture_placeholder, capture_generation);
     }
 
     return -1;
@@ -2825,7 +2846,7 @@ namespace video {
     BOOST_LOG(info) << "Minimum FPS target set to ~"sv << (minimum_fps_target / 2) << "fps ("sv << max_frametime.count() * 2 << "ms)"sv;
 
     auto shutdown_event = mail->event<bool>(mail::shutdown);
-    auto packets = mail::man->queue<packet_t>(mail::video_packets);
+    auto packets = packet_queue(mail, mail::video_packets);
     auto idr_events = mail->event<bool>(mail::idr);
     auto invalidate_ref_frames_events = mail->event<std::pair<int64_t, int64_t>>(mail::invalidate_ref_frames);
 
@@ -2868,6 +2889,7 @@ namespace video {
     }
 
     encode_bootstrap_state_t bootstrap_state {.allow_placeholder_before_first_real = frame_nr <= 1};
+    bootstrap_state.current_input_generation = capture_generation_for_current_process();
 
     while (true) {
       // Break out of the encoding loop if any of the following are true:
@@ -2916,6 +2938,7 @@ namespace video {
           }
 
           bootstrap_state.current_input_placeholder = placeholder_input;
+          bootstrap_state.current_input_generation = img->capture_generation;
 
           if (!placeholder_input) {
             bootstrap_state.real_frame_seen = true;
@@ -2936,7 +2959,7 @@ namespace video {
         continue;
       }
 
-      if (encode(frame_nr++, *session, packets, channel_data, frame_timestamp, host_processing_timestamp)) {
+      if (encode(frame_nr++, *session, packets, channel_data, frame_timestamp, host_processing_timestamp, placeholder_input, bootstrap_state.current_input_generation)) {
         BOOST_LOG(error) << "Could not encode video packet"sv;
         return;
       }
@@ -3114,8 +3137,22 @@ namespace video {
   std::optional<sync_session_t> make_synced_session(platf::display_t *disp, const encoder_t &encoder, platf::img_t &img, sync_session_ctx_t &ctx) {
     sync_session_t encode_session;
 
+#ifdef _WIN32
+    // Encoder-session creation takes several seconds on some driver/GPU
+    // combinations (7-11 s observed on RTX 5080 at 4K HDR). A REBUILD happens
+    // mid-stream, where the isolated worker's parent applies a 3-second
+    // frame-progress verdict: without a reinit grace it terminates a healthy
+    // worker in the middle of the rebuild (observed live). The FIRST build is
+    // covered by the FIRST_PACKET deadline instead and must not bump the
+    // capture generation before the bootstrap packet is admitted.
+    if (ctx.frame_nr > 1) {
+      platf::video_worker::notify_capture_reinitializing();
+    }
+#endif
+
     encode_session.ctx = &ctx;
 
+    const auto encode_device_started = std::chrono::steady_clock::now();
     auto encode_device = make_encode_device(*disp, encoder, ctx.config);
     if (!encode_device) {
       downgrade_yuv444_to_420(disp, ctx.config, ctx.chroma_downgrade_events, "encode device creation", [&]() {
@@ -3125,6 +3162,15 @@ namespace video {
     }
     if (!encode_device) {
       return std::nullopt;
+    }
+    const auto encode_device_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - encode_device_started
+    ).count();
+    if (encode_device_ms > 1000) {
+      // 7-11 s observed on RTX 5080 (driver-side session-open cost). Logged so
+      // future driver/OS changes to this dominant startup term are visible.
+      BOOST_LOG(warning) << "Encoder device creation took " << encode_device_ms
+                         << " ms; this dominates session time-to-first-frame.";
     }
 
     // absolute mouse coordinates require that the dimensions of the screen are known
@@ -3161,6 +3207,7 @@ namespace video {
     }
 
     encode_session.bootstrap.allow_placeholder_before_first_real = ctx.frame_nr <= 1;
+    encode_session.bootstrap.current_input_generation = capture_generation_for_current_process();
     encode_session.session = std::move(session);
 
     return encode_session;
@@ -3334,6 +3381,7 @@ namespace video {
           bool placeholder_input = pos->bootstrap.current_input_placeholder;
 
           if (frame_captured) {
+            img->capture_generation = capture_generation_for_current_process();
             placeholder_input = is_placeholder_capture_image(*img);
             if (!placeholder_input && pos->bootstrap.current_input_placeholder) {
               pos->session->request_idr_frame();
@@ -3347,6 +3395,7 @@ namespace video {
             }
 
             pos->bootstrap.current_input_placeholder = placeholder_input;
+            pos->bootstrap.current_input_generation = img->capture_generation;
 
             if (!placeholder_input) {
               pos->bootstrap.real_frame_seen = true;
@@ -3362,7 +3411,7 @@ namespace video {
             continue;
           }
 
-          if (encode(ctx->frame_nr++, *pos->session, ctx->packets, ctx->channel_data, frame_timestamp, host_processing_timestamp)) {
+          if (encode(ctx->frame_nr++, *pos->session, ctx->packets, ctx->channel_data, frame_timestamp, host_processing_timestamp, placeholder_input, pos->bootstrap.current_input_generation)) {
             BOOST_LOG(error) << "Could not encode video packet"sv;
             ctx->shutdown_event->raise(true);
 
@@ -3398,6 +3447,10 @@ namespace video {
       auto status = disp->capture(push_captured_image_callback, pull_free_image_callback, &display_cursor);
       switch (status) {
         case platf::capture_e::reinit:
+#ifdef _WIN32
+          platf::video_worker::notify_capture_reinitializing();
+#endif
+          [[fallthrough]];
         case platf::capture_e::error:
         case platf::capture_e::ok:
         case platf::capture_e::timeout:
@@ -3602,8 +3655,30 @@ namespace video {
     void *channel_data
   ) {
 #ifdef _WIN32
+    const bool isolated_worker_child = platf::video_worker::is_child_process();
     if (platf::video_worker::capture(mail, config, channel_data)) {
       return;
+    }
+    // A rare worker-launch/bootstrap failure may still use the legacy
+    // in-process path for a non-VGD output. Release any strict-client
+    // ANNOUNCE hold immediately: the in-process pipeline initializes only
+    // after the UDP peer attaches (below), so there is no readiness to wait
+    // for and holding would deadlock against the client's PLAY.
+    if (!isolated_worker_child) {
+      mail->event<bool>(mail::video_pipeline_ready)->raise(true);
+    }
+    // Do not let the in-process path publish to an unset UDP endpoint while
+    // the video thread is still authenticating it. Only RTSP sessions carry
+    // channel_data and a UDP peer to wait for; the WebRTC capture thread
+    // passes nullptr and would otherwise spin forever because nothing raises
+    // video_peer_ready on its mailbox.
+    if (!isolated_worker_child && channel_data != nullptr) {
+      auto peer_ready = mail->event<bool>(mail::video_peer_ready);
+      auto shutdown = mail->event<bool>(mail::shutdown);
+      while (!peer_ready->peek() && !shutdown->peek()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      }
+      if (shutdown->peek()) return;
     }
 #endif
     // Snapshot the encoder pointer to avoid races with concurrent probe_encoders() calls
@@ -3624,7 +3699,7 @@ namespace video {
       ref->encode_session_ctx_queue.raise(sync_session_ctx_t {
         &join_event,
         mail->event<bool>(mail::shutdown),
-        mail::man->queue<packet_t>(mail::video_packets),
+        packet_queue(mail, mail::video_packets),
         std::move(idr_events),
         mail->event<hdr_info_t>(mail::hdr),
         mail->event<input::touch_port_t>(mail::touch_port),
@@ -3682,7 +3757,7 @@ namespace video {
 
         // Use a probe-local mail/queue to avoid stale packets from previous encoder sessions.
         auto probe_mail = std::make_shared<safe::mail_raw_t>();
-        auto packets = probe_mail->queue<packet_t>(mail::video_packets);
+        auto packets = packet_queue(probe_mail, mail::video_packets);
 
         while (!packets->peek()) {
           if (encode(1, *session, packets, nullptr, {}, {})) {

--- a/src/video.h
+++ b/src/video.h
@@ -276,6 +276,12 @@ namespace video {
     std::vector<replace_t> *replacements = nullptr;
     void *channel_data = nullptr;
     bool after_ref_frame_invalidation = false;
+    /// True when this packet was encoded from the synthetic bootstrap image
+    /// before the capture backend delivered its first real frame.
+    bool capture_placeholder = false;
+    /// Capture-source epoch inherited from the image/session that produced the
+    /// packet. The isolated worker must never replace this at IPC-send time.
+    std::uint64_t capture_generation = 0;
     std::optional<std::chrono::steady_clock::time_point> frame_timestamp;
     std::optional<std::chrono::steady_clock::time_point> host_processing_timestamp;
   };
@@ -337,6 +343,35 @@ namespace video {
   };
 
   using packet_t = std::unique_ptr<packet_raw_t>;
+
+  // Encoded frames form a reference chain. Clearing a full queue (the generic
+  // mailbox default) silently removes those references and makes every later
+  // predictive frame undecodable until the next IDR. Keep only a few encoded
+  // frames in flight and apply stop-aware backpressure instead. Capture image
+  // delivery is already latest-frame-wins, so pressure is shed before encode
+  // without growing latency or damaging the bitstream. Depth matters doubly
+  // because the worker child and the session each hold one of these queues in
+  // series: every queued frame is standing capture-to-send latency at the
+  // REAL encode cadence (observed ~21 fps on the 4K HDR compatibility path,
+  // i.e. ~47 ms per slot). Deeper queues turned sub-nominal encode rates
+  // into a permanent latency FIFO. Two frames per queue still decouples the
+  // encoder from IPC/egress jitter (one being consumed + one queued behind
+  // it) while capping the pair's standing contribution at 4 slots — in the
+  // 2026-08-07 standing-latency round the 3+3 pair plus the in-flight hops
+  // held ~10 slots of post-encoder inventory and the capture-to-send age
+  // equilibrated right at the 250 ms warning floor.
+  inline constexpr std::uint32_t kPacketQueueDepth = 2;
+
+  inline safe::mail_raw_t::queue_t<packet_t> packet_queue(
+    const safe::mail_t &mailbox,
+    std::string_view id
+  ) {
+    return mailbox->queue<packet_t>(
+      id,
+      kPacketQueueDepth,
+      safe::queue_overflow_e::block
+    );
+  }
 
   struct hdr_info_raw_t {
     explicit hdr_info_raw_t(bool enabled):

--- a/src/video_packet_qos.h
+++ b/src/video_packet_qos.h
@@ -1,0 +1,201 @@
+/**
+ * @file src/video_packet_qos.h
+ * @brief Decoder-safe admission for encoded video packets.
+ */
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+namespace stream::video_qos {
+  // 50% headroom keeps the drain comfortably above the encoder's real output
+  // (IDR bursts included) while still shaping traffic a 100-Mbps client path
+  // can absorb — the per-packet wire interval stays the shape, only its
+  // slope rises. Raised from 1.35 in the 2026-08-07 standing-latency round:
+  // transient backlogs (scene-change IDR bursts) drained at only +35% of
+  // saturated production, stretching every excursion above the 250 ms age
+  // floor; +50% clears the same backlog ~1.4x faster with identical
+  // batching and quantum. A 1-ms quantum tolerates ordinary Windows timer
+  // wake latency; a finer quantum makes sustained throughput hostage to the
+  // waitable-timer resolution (the high-resolution flag is not guaranteed
+  // on all builds).
+  inline constexpr long double kWirePacingHeadroom = 1.50L;
+  inline constexpr long double kMaxWireDrainBitrateBps = 800'000'000.0L;
+  inline constexpr std::chrono::microseconds kWirePacingQuantum {1000};
+  inline constexpr std::chrono::seconds kRecoveryRequestRetry {2};
+
+  struct pacing_budget_t {
+    long double average_wire_bitrate_bps = 0;
+    long double drain_bitrate_bps = 0;
+    std::chrono::duration<long double> packet_interval {};
+    std::size_t packets_per_quantum = 1;
+  };
+
+  inline pacing_budget_t pacing_budget(
+    int payload_bitrate_kbps,
+    int fec_percentage,
+    std::size_t wire_packet_bytes,
+    std::size_t payload_packet_bytes
+  ) {
+    const auto safe_payload_bytes = std::max<std::size_t>(payload_packet_bytes, 1);
+    const auto safe_wire_bytes = std::max<std::size_t>(wire_packet_bytes, 1);
+    const long double average =
+      static_cast<long double>(std::max(payload_bitrate_kbps, 1)) * 1000.0L *
+      (100.0L + static_cast<long double>(std::max(fec_percentage, 0))) / 100.0L *
+      static_cast<long double>(safe_wire_bytes) /
+      static_cast<long double>(safe_payload_bytes);
+    const long double drain = std::min(
+      average * kWirePacingHeadroom,
+      kMaxWireDrainBitrateBps
+    );
+    const long double packet_bits = static_cast<long double>(safe_wire_bytes) * 8.0L;
+    const auto interval = std::chrono::duration<long double> {packet_bits / drain};
+    const auto quantum_seconds = std::chrono::duration<long double> {kWirePacingQuantum}.count();
+    const auto packets_per_quantum = std::max<std::size_t>(
+      1,
+      static_cast<std::size_t>(std::ceil(drain * quantum_seconds / packet_bits))
+    );
+    return {
+      .average_wire_bitrate_bps = average,
+      .drain_bitrate_bps = drain,
+      .packet_interval = interval,
+      .packets_per_quantum = packets_per_quantum,
+    };
+  }
+
+  inline std::uint64_t next_rtp_timestamp_ticks(
+    std::uint64_t candidate,
+    std::uint64_t last,
+    int framerate
+  ) {
+    if (candidate > last) {
+      return candidate;
+    }
+
+    const auto nominal_step = std::max<std::uint64_t>(
+      1,
+      90'000u / static_cast<std::uint64_t>(std::max(framerate, 1))
+    );
+    return last + nominal_step;
+  }
+
+  enum class reason_e {
+    none,
+    waiting_for_idr,
+    frame_discontinuity,
+    stale_frame,
+  };
+
+  struct decision_t {
+    bool submit = false;
+    bool request_idr = false;
+    reason_e reason = reason_e::none;
+  };
+
+  struct recovery_t {
+    std::uint64_t withheld_frames = 0;
+    std::chrono::steady_clock::duration duration {};
+  };
+
+  struct state_t {
+    bool awaiting_idr = true;
+    bool recovery_requested = false;
+    std::optional<std::int64_t> last_submitted_frame;
+    std::chrono::steady_clock::time_point recovery_started {};
+    std::chrono::steady_clock::time_point last_recovery_request {};
+    std::uint64_t withheld_frames = 0;
+  };
+
+  /**
+   * Decide whether an encoded packet may enter the transport.
+   *
+   * A predictive frame is useful only when every preceding encoded reference
+   * was submitted. If a mailbox, worker pipe, or deadline loses one packet,
+   * withholding the rest of that GOP is the only decoder-safe response.
+   */
+  inline decision_t evaluate(
+    state_t &state,
+    std::int64_t frame_index,
+    bool is_idr,
+    bool stale,
+    std::chrono::steady_clock::time_point now
+  ) {
+    if (is_idr) {
+      return {.submit = true};
+    }
+
+    reason_e reason = reason_e::none;
+    if (state.awaiting_idr || !state.last_submitted_frame) {
+      reason = reason_e::waiting_for_idr;
+    } else if (frame_index != *state.last_submitted_frame + 1) {
+      reason = reason_e::frame_discontinuity;
+    } else if (stale) {
+      reason = reason_e::stale_frame;
+    }
+
+    if (reason == reason_e::none) {
+      return {.submit = true};
+    }
+
+    if (!state.awaiting_idr || state.recovery_started == std::chrono::steady_clock::time_point {}) {
+      state.recovery_started = now;
+    }
+    state.awaiting_idr = true;
+    ++state.withheld_frames;
+
+    const bool request_idr = !state.recovery_requested ||
+      state.last_recovery_request == std::chrono::steady_clock::time_point {} ||
+      now - state.last_recovery_request >= kRecoveryRequestRetry;
+    state.recovery_requested = true;
+    if (request_idr) {
+      state.last_recovery_request = now;
+    }
+    return {
+      .submit = false,
+      .request_idr = request_idr,
+      .reason = reason,
+    };
+  }
+
+  /** Record a packet only after all of its UDP shards have been submitted. */
+  inline std::optional<recovery_t> submitted(
+    state_t &state,
+    std::int64_t frame_index,
+    bool is_idr,
+    std::chrono::steady_clock::time_point now
+  ) {
+    state.last_submitted_frame = frame_index;
+    if (!is_idr) {
+      return std::nullopt;
+    }
+
+    std::optional<recovery_t> recovery;
+    if (state.awaiting_idr) {
+      recovery = recovery_t {
+        .withheld_frames = state.withheld_frames,
+        .duration = state.recovery_started == std::chrono::steady_clock::time_point {} ?
+                      std::chrono::steady_clock::duration {} :
+                      now - state.recovery_started,
+      };
+    }
+    state.awaiting_idr = false;
+    state.recovery_requested = false;
+    state.recovery_started = {};
+    state.last_recovery_request = {};
+    state.withheld_frames = 0;
+    return recovery;
+  }
+
+  /** Re-arm recovery when an admitted IDR fails before transport submission. */
+  inline void submission_failed(state_t &state, bool is_idr) {
+    if (is_idr) {
+      state.awaiting_idr = true;
+      state.recovery_requested = false;
+      state.last_recovery_request = {};
+    }
+  }
+}  // namespace stream::video_qos

--- a/tests/unit/test_process.cpp
+++ b/tests/unit/test_process.cpp
@@ -327,3 +327,21 @@ TEST(ExtractCommandExeName, TooShortToken) {
 TEST(ExtractCommandExeName, ExeSubstringButNotSuffix) {
   EXPECT_EQ(proc::extract_command_exe_name(R"(C:\Games\game.exe.config)"), "");
 }
+
+TEST(ProcessLifecycle, EmptyAndMovedInstancesTerminateIdempotently) {
+  bp::environment env;
+  proc::proc_t original(std::move(env), {});
+
+  // Regression for prep-command teardown state: a default/empty command
+  // snapshot must never compare or dereference singular vector iterators.
+  original.terminate();
+  original.terminate();
+
+  proc::proc_t moved(std::move(original));
+  moved.terminate();
+
+  proc::proc_t assigned;
+  assigned = std::move(moved);
+  assigned.terminate();
+  assigned.terminate();
+}

--- a/tests/unit/test_vgd_ring_liveness.cpp
+++ b/tests/unit/test_vgd_ring_liveness.cpp
@@ -31,6 +31,7 @@ using platf::dxgi::vgd_ring_liveness_t;
 using platf::dxgi::vgd_ring_reason_e;
 using platf::dxgi::vgd_ring_sample_t;
 using platf::dxgi::vgd_ring_verdict_e;
+using platf::dxgi::vgd_worker_ring_binding_e;
 namespace vgd_ring_state = platf::dxgi::vgd_ring_state;
 using namespace std::chrono_literals;
 
@@ -61,6 +62,78 @@ namespace {
     return s;
   }
 }  // namespace
+
+TEST(VgdWorkerRingBinding, AcceptsOnlyThePreFirstSurfaceProvisionalContract) {
+  using platf::dxgi::classify_worker_ring_binding;
+  EXPECT_EQ(
+    classify_worker_ring_binding(
+      0, vgd_ring_state::rebuilding, 3, 0, 0, 0, 0x0c
+    ),
+    vgd_worker_ring_binding_e::provisional
+  );
+  EXPECT_EQ(
+    classify_worker_ring_binding(
+      0, vgd_ring_state::rebuilding, 3, 1, 0, 0, 0x0c
+    ),
+    vgd_worker_ring_binding_e::reject
+  ) << "zero flags stop being provisional after any frame has been published";
+}
+
+TEST(VgdWorkerRingBinding, AcceptsTheCommittedPostModesetContract) {
+  using platf::dxgi::classify_worker_ring_binding;
+  EXPECT_EQ(
+    classify_worker_ring_binding(
+      0, vgd_ring_state::active, 9, 42, 0x0c, 0, 0x0c
+    ),
+    vgd_worker_ring_binding_e::ready
+  );
+  EXPECT_EQ(
+    classify_worker_ring_binding(
+      0, vgd_ring_state::active, 9, 42, 0x0c, 9, 0x0c
+    ),
+    vgd_worker_ring_binding_e::ready
+  );
+}
+
+TEST(VgdWorkerRingBinding, RejectsDeadStaleAndIncompatibleRings) {
+  using platf::dxgi::classify_worker_ring_binding;
+  EXPECT_EQ(
+    classify_worker_ring_binding(
+      0, vgd_ring_state::dead, 9, 42, 0x0c, 9, 0x0c
+    ),
+    vgd_worker_ring_binding_e::reject
+  );
+  EXPECT_EQ(
+    classify_worker_ring_binding(
+      0, vgd_ring_state::active, 10, 42, 0x0c, 9, 0x0c
+    ),
+    vgd_worker_ring_binding_e::reject
+  );
+  EXPECT_EQ(
+    classify_worker_ring_binding(
+      0, vgd_ring_state::active, 9, 42, 0x04, 9, 0x0c
+    ),
+    vgd_worker_ring_binding_e::reject
+  );
+  EXPECT_EQ(
+    classify_worker_ring_binding(
+      0, vgd_ring_state::active, 9, 0, 0x0c, 9, 0x0c
+    ),
+    vgd_worker_ring_binding_e::reject
+  ) << "ACTIVE without a published frame is not capture-ready";
+  EXPECT_EQ(
+    classify_worker_ring_binding(
+      0, vgd_ring_state::rebuilding, 9, 42, 0x0c, 9, 0x0c
+    ),
+    vgd_worker_ring_binding_e::reject
+  ) << "a rebuilding generation is recovery state, not startup admission";
+  EXPECT_EQ(
+    classify_worker_ring_binding(
+      -1, vgd_ring_state::active, 9, 42, 0x0c, 9, 0x0c
+    ),
+    vgd_worker_ring_binding_e::reject
+  );
+}
 
 TEST(VgdRingLiveness, HealthyRingIsConsumed) {
   vgd_ring_liveness_t live;

--- a/tests/unit/test_vgd_transition.cpp
+++ b/tests/unit/test_vgd_transition.cpp
@@ -21,6 +21,7 @@
   // local includes
   #include "../tests_common.h"
   #include "src/platform/windows/vgd_transition.h"
+  #include "src/platform/windows/video_worker.h"
   #include "src/platform/windows/virtual_display_vgd.h"
 
 namespace {
@@ -38,6 +39,81 @@ namespace {
     EXPECT_FALSE(VDISPLAY::vgd::ring_target_for_display("\\\\.\\DISPLAY78").has_value());
     VDISPLAY::vgd::set_worker_ring_target(std::nullopt);
     EXPECT_FALSE(VDISPLAY::vgd::has_worker_ring_target());
+  }
+
+  TEST(VgdWorkerRingTarget, DeferredGenerationIdentitySurvivesExclusiveHandoff) {
+    const VDISPLAY::vgd::RingTargetInfo imported {0xfedcba9876543210ULL, 4, 0x4, 0};
+    VDISPLAY::vgd::set_worker_ring_target(imported, "\\\\.\\DISPLAY91");
+
+    const auto resolved = VDISPLAY::vgd::ring_target_for_display("\\\\.\\DISPLAY91");
+    ASSERT_TRUE(resolved.has_value());
+    EXPECT_EQ(resolved->session_id, imported.session_id);
+    EXPECT_EQ(resolved->ring_slots, imported.ring_slots);
+    EXPECT_EQ(resolved->transport_flags, imported.transport_flags);
+    EXPECT_EQ(resolved->generation, 0u);
+    EXPECT_FALSE(VDISPLAY::vgd::ring_target_for_display("\\\\.\\DISPLAY92").has_value());
+
+    VDISPLAY::vgd::set_worker_ring_target(std::nullopt);
+  }
+
+  TEST(VideoWorkerReadiness, AnyDecodableIdrCanAdmitAClient) {
+    // The synthetic bootstrap IDR is a decodable frame: admitting it keeps the
+    // client's connection budget independent of a slow capture source, exactly
+    // like the pre-worker pipeline's blank "alive" frame.
+    video::packet_raw_generic placeholder {{0x01}, 1, true};
+    placeholder.capture_placeholder = true;
+    EXPECT_TRUE(platf::video_worker::packet_can_signal_capture_ready(placeholder));
+
+    video::packet_raw_generic idr {{0x01, 0x02}, 3, true};
+    idr.capture_placeholder = false;
+    EXPECT_TRUE(platf::video_worker::packet_can_signal_capture_ready(idr));
+  }
+
+  TEST(VideoWorkerReadiness, DeltaFramesCannotAdmitAClient) {
+    video::packet_raw_generic delta {{0x02}, 2, false};
+    EXPECT_FALSE(platf::video_worker::packet_can_signal_capture_ready(delta));
+  }
+
+  TEST(VideoWorkerGeneration, RetiredEncoderPacketCannotEnterReplacementGeneration) {
+    EXPECT_FALSE(platf::video_worker::packet_metadata_can_enter_capture_generation(
+      4, false, true, 5, true, false
+    ));
+    EXPECT_FALSE(platf::video_worker::packet_metadata_can_enter_capture_generation(
+      4, false, true, 5, true, true
+    ));
+  }
+
+  TEST(VideoWorkerGeneration, PlaceholderIdrBootstrapsOnlyTheFirstAdmission) {
+    // First admission ever: the synthetic bootstrap IDR may open the pipe.
+    EXPECT_TRUE(platf::video_worker::packet_metadata_can_enter_capture_generation(
+      1, true, true, 1, true, true
+    ));
+    // A generation transition (capture reinit) still requires a real IDR.
+    EXPECT_FALSE(platf::video_worker::packet_metadata_can_enter_capture_generation(
+      5, true, true, 5, true, false
+    ));
+    // A zero generation is never admissible, bootstrap or not.
+    EXPECT_FALSE(platf::video_worker::packet_metadata_can_enter_capture_generation(
+      0, true, true, 1, true, true
+    ));
+  }
+
+  TEST(VideoWorkerGeneration, DeltaCannotAdmitGeneration) {
+    EXPECT_FALSE(platf::video_worker::packet_metadata_can_enter_capture_generation(
+      5, false, false, 5, true, false
+    ));
+    EXPECT_FALSE(platf::video_worker::packet_metadata_can_enter_capture_generation(
+      5, false, false, 5, true, true
+    ));
+  }
+
+  TEST(VideoWorkerGeneration, RealIdrAdmitsGenerationAndThenDeltasContinue) {
+    EXPECT_TRUE(platf::video_worker::packet_metadata_can_enter_capture_generation(
+      6, false, true, 5, true, false
+    ));
+    EXPECT_TRUE(platf::video_worker::packet_metadata_can_enter_capture_generation(
+      6, false, false, 6, false, false
+    ));
   }
 
   TEST(VgdTransitionCaptureNote, RecordsKindDisplayAndBumpsSequence) {

--- a/tests/unit/test_video_packet_qos.cpp
+++ b/tests/unit/test_video_packet_qos.cpp
@@ -1,0 +1,286 @@
+#include <chrono>
+#include <future>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "src/globals.h"
+#include "src/thread_safe.h"
+#include "src/video.h"
+#include "src/video_packet_qos.h"
+
+using namespace std::chrono_literals;
+
+namespace {
+  template<class Queue>
+  bool wait_for_blocked_producer(Queue &queue, std::chrono::milliseconds timeout = 1s) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (queue.waiting_producers() != 0) return true;
+      std::this_thread::sleep_for(1ms);
+    }
+    return queue.waiting_producers() != 0;
+  }
+}
+
+TEST(VideoPacketQueue, ReferencePreservingPolicyBlocksInsteadOfClearing) {
+  safe::queue_t<int> queue {2, safe::queue_overflow_e::block};
+  queue.raise(1);
+  queue.raise(2);
+
+  std::future<void> third;
+  auto stop_queue = util::fail_guard([&] {
+    queue.stop();
+  });
+  third = std::async(std::launch::async, [&] {
+    queue.raise(3);
+  });
+  ASSERT_TRUE(wait_for_blocked_producer(queue));
+
+  ASSERT_EQ(queue.pop(0ms), 1);
+  ASSERT_EQ(third.wait_for(1s), std::future_status::ready);
+  third.get();
+  ASSERT_EQ(queue.pop(0ms), 2);
+  ASSERT_EQ(queue.pop(0ms), 3);
+}
+
+TEST(VideoPacketQueue, StopUnblocksAProducerWaitingForSpace) {
+  safe::queue_t<int> queue {1, safe::queue_overflow_e::block};
+  queue.raise(1);
+
+  std::future<void> blocked;
+  auto stop_queue = util::fail_guard([&] {
+    queue.stop();
+  });
+  blocked = std::async(std::launch::async, [&] {
+    queue.raise(2);
+  });
+  ASSERT_TRUE(wait_for_blocked_producer(queue));
+
+  queue.stop();
+  ASSERT_EQ(blocked.wait_for(1s), std::future_status::ready);
+  blocked.get();
+  EXPECT_FALSE(queue.pop(0ms).has_value());
+
+  // Broadcast lifecycle reuses the same mailbox object on the next session.
+  queue.stop();
+  queue.reset();
+  queue.raise(3);
+  const auto reused = queue.pop(0ms);
+  ASSERT_TRUE(reused.has_value());
+  EXPECT_EQ(*reused, 3);
+}
+
+TEST(VideoPacketQueue, UnrelatedQueuesKeepLegacyClearOnOverflowBehavior) {
+  safe::queue_t<int> queue {2};
+  queue.raise(1);
+  queue.raise(2);
+  queue.raise(3);
+
+  ASSERT_EQ(queue.pop(0ms), 3);
+  EXPECT_FALSE(queue.pop(0ms).has_value());
+}
+
+TEST(VideoPacketQueue, StopResetCannotAdmitAProducerFromThePriorEpoch) {
+  safe::queue_t<int> queue {1, safe::queue_overflow_e::block};
+  queue.raise(1);
+  std::future<void> stale_producer;
+  auto stop_queue = util::fail_guard([&] {
+    queue.stop();
+  });
+
+  stale_producer = std::async(std::launch::async, [&] {
+    queue.raise(2);
+  });
+  ASSERT_TRUE(wait_for_blocked_producer(queue));
+
+  queue.stop();
+  queue.reset();
+  ASSERT_EQ(stale_producer.wait_for(1s), std::future_status::ready);
+  stale_producer.get();
+  EXPECT_FALSE(queue.pop(0ms).has_value());
+
+  queue.raise(3);
+  const auto current = queue.pop(0ms);
+  ASSERT_TRUE(current.has_value());
+  EXPECT_EQ(*current, 3);
+}
+
+TEST(VideoPacketQueue, HistoricalThirtySecondToThirtyThirdFrameNeverClearsReferences) {
+  safe::queue_t<int> queue {32, safe::queue_overflow_e::block};
+  for (int frame = 1; frame <= 32; ++frame) queue.raise(frame);
+
+  std::future<void> thirty_third;
+  auto stop_queue = util::fail_guard([&] {
+    queue.stop();
+  });
+  thirty_third = std::async(std::launch::async, [&] {
+    queue.raise(33);
+  });
+  ASSERT_TRUE(wait_for_blocked_producer(queue));
+
+  ASSERT_EQ(queue.pop(0ms), 1);
+  ASSERT_EQ(thirty_third.wait_for(1s), std::future_status::ready);
+  thirty_third.get();
+  for (int frame = 2; frame <= 33; ++frame) {
+    ASSERT_EQ(queue.pop(0ms), frame);
+  }
+}
+
+TEST(VideoPacketQueue, ProductionFactoryIsBoundedBlockingAndSessionOwned) {
+  const auto packet = [](std::int64_t index) -> video::packet_t {
+    return std::make_unique<video::packet_raw_generic>(
+      std::vector<std::uint8_t> {0}, index, index == 1
+    );
+  };
+  auto slow_mail = std::make_shared<safe::mail_raw_t>();
+  auto fast_mail = std::make_shared<safe::mail_raw_t>();
+  auto slow = video::packet_queue(slow_mail, mail::video_packets);
+  auto fast = video::packet_queue(fast_mail, mail::video_packets);
+  for (std::uint32_t i = 0; i < video::kPacketQueueDepth; ++i) {
+    slow->raise(packet(i + 1));
+  }
+
+  std::future<void> blocked_slow;
+  auto stop_queues = util::fail_guard([&] {
+    slow->stop();
+    fast->stop();
+  });
+  blocked_slow = std::async(std::launch::async, [&] {
+    slow->raise(packet(video::kPacketQueueDepth + 1));
+  });
+  ASSERT_TRUE(wait_for_blocked_producer(*slow));
+
+  fast->raise(packet(1));
+  EXPECT_NE(fast->pop(0ms), nullptr);
+  EXPECT_EQ(blocked_slow.wait_for(20ms), std::future_status::timeout);
+
+  slow->stop();
+  ASSERT_EQ(blocked_slow.wait_for(1s), std::future_status::ready);
+  blocked_slow.get();
+}
+
+TEST(VideoPacketQos, GapWithholdsPredictiveFramesAndRequestsExactlyOneIdr) {
+  stream::video_qos::state_t state;
+  const auto start = std::chrono::steady_clock::now();
+
+  auto idr = stream::video_qos::evaluate(state, 100, true, false, start);
+  ASSERT_TRUE(idr.submit);
+  stream::video_qos::submitted(state, 100, true, start);
+
+  auto contiguous = stream::video_qos::evaluate(state, 101, false, false, start + 1ms);
+  ASSERT_TRUE(contiguous.submit);
+  stream::video_qos::submitted(state, 101, false, start + 1ms);
+
+  const auto gap = stream::video_qos::evaluate(state, 133, false, false, start + 2ms);
+  EXPECT_FALSE(gap.submit);
+  EXPECT_TRUE(gap.request_idr);
+  EXPECT_EQ(gap.reason, stream::video_qos::reason_e::frame_discontinuity);
+
+  const auto held = stream::video_qos::evaluate(state, 134, false, false, start + 3ms);
+  EXPECT_FALSE(held.submit);
+  EXPECT_FALSE(held.request_idr);
+
+  ASSERT_TRUE(stream::video_qos::evaluate(state, 135, true, false, start + 4ms).submit);
+  const auto recovery = stream::video_qos::submitted(state, 135, true, start + 4ms);
+  ASSERT_TRUE(recovery.has_value());
+  EXPECT_EQ(recovery->withheld_frames, 2u);
+
+  EXPECT_TRUE(stream::video_qos::evaluate(state, 136, false, false, start + 5ms).submit);
+}
+
+TEST(VideoPacketQos, DeadlineDropWaitsForIdrBeforeResuming) {
+  stream::video_qos::state_t state;
+  const auto now = std::chrono::steady_clock::now();
+  stream::video_qos::submitted(state, 10, true, now);
+
+  const auto stale = stream::video_qos::evaluate(state, 11, false, true, now + 1ms);
+  EXPECT_FALSE(stale.submit);
+  EXPECT_TRUE(stale.request_idr);
+  EXPECT_EQ(stale.reason, stream::video_qos::reason_e::stale_frame);
+
+  EXPECT_FALSE(stream::video_qos::evaluate(state, 12, false, false, now + 2ms).submit);
+  EXPECT_TRUE(stream::video_qos::evaluate(state, 13, true, false, now + 3ms).submit);
+  stream::video_qos::submitted(state, 13, true, now + 3ms);
+  EXPECT_TRUE(stream::video_qos::evaluate(state, 14, false, false, now + 4ms).submit);
+}
+
+TEST(VideoPacketQos, SessionsRecoverIndependently) {
+  stream::video_qos::state_t a;
+  stream::video_qos::state_t b;
+  const auto now = std::chrono::steady_clock::now();
+  stream::video_qos::submitted(a, 1, true, now);
+  stream::video_qos::submitted(b, 20, true, now);
+
+  EXPECT_FALSE(stream::video_qos::evaluate(a, 3, false, false, now + 1ms).submit);
+  EXPECT_TRUE(stream::video_qos::evaluate(b, 21, false, false, now + 1ms).submit);
+}
+
+TEST(VideoPacketQos, FailedIdrSubmissionRearmsExactlyOneRecoveryRequest) {
+  stream::video_qos::state_t state;
+  const auto now = std::chrono::steady_clock::now();
+  stream::video_qos::submitted(state, 10, true, now);
+
+  ASSERT_TRUE(stream::video_qos::evaluate(state, 12, false, false, now + 1ms).request_idr);
+  ASSERT_TRUE(stream::video_qos::evaluate(state, 13, true, false, now + 2ms).submit);
+  stream::video_qos::submission_failed(state, true);
+
+  const auto retry = stream::video_qos::evaluate(state, 14, false, false, now + 3ms);
+  EXPECT_FALSE(retry.submit);
+  EXPECT_TRUE(retry.request_idr);
+}
+
+TEST(VideoPacketQos, DuplicateAndBackwardFramesAreDiscontinuities) {
+  const auto now = std::chrono::steady_clock::now();
+
+  stream::video_qos::state_t duplicate;
+  stream::video_qos::submitted(duplicate, 20, true, now);
+  const auto duplicate_result = stream::video_qos::evaluate(duplicate, 20, false, false, now + 1ms);
+  EXPECT_FALSE(duplicate_result.submit);
+  EXPECT_EQ(duplicate_result.reason, stream::video_qos::reason_e::frame_discontinuity);
+
+  stream::video_qos::state_t backward;
+  stream::video_qos::submitted(backward, 20, true, now);
+  const auto backward_result = stream::video_qos::evaluate(backward, 19, false, false, now + 1ms);
+  EXPECT_FALSE(backward_result.submit);
+  EXPECT_EQ(backward_result.reason, stream::video_qos::reason_e::frame_discontinuity);
+}
+
+TEST(VideoPacketQos, LostRecoveryRequestIsRetriedAfterBoundedDelay) {
+  stream::video_qos::state_t state;
+  const auto now = std::chrono::steady_clock::now();
+  stream::video_qos::submitted(state, 10, true, now);
+
+  EXPECT_TRUE(stream::video_qos::evaluate(state, 12, false, false, now + 1ms).request_idr);
+  EXPECT_FALSE(stream::video_qos::evaluate(state, 13, false, false, now + 1s).request_idr);
+  EXPECT_TRUE(stream::video_qos::evaluate(state, 14, false, false, now + 2100ms).request_idr);
+  EXPECT_FALSE(stream::video_qos::evaluate(state, 15, false, false, now + 3s).request_idr);
+}
+
+TEST(VideoPacketQos, WirePacingIncludesFecAndAvoidsMillisecondMicrobursts) {
+  const auto budget = stream::video_qos::pacing_budget(65'388, 20, 1'408, 1'376);
+
+  EXPECT_GT(budget.average_wire_bitrate_bps, 80'000'000.0L);
+  EXPECT_LT(budget.average_wire_bitrate_bps, 81'000'000.0L);
+  EXPECT_NEAR(
+    static_cast<double>(budget.drain_bitrate_bps),
+    static_cast<double>(budget.average_wire_bitrate_bps * stream::video_qos::kWirePacingHeadroom),
+    1.0
+  );
+  // One 1-ms quantum carries ~11 wire packets at this bitrate (1.50
+  // headroom): a group small enough to shape 100-Mbps client paths, large
+  // enough that one timer wake per quantum sustains the full drain rate.
+  EXPECT_EQ(budget.packets_per_quantum, 11u);
+  EXPECT_GT(budget.packet_interval, std::chrono::microseconds {85});
+  EXPECT_LT(budget.packet_interval, std::chrono::microseconds {100});
+}
+
+TEST(VideoPacketQos, WirePacingHasAnExplicitSafetyCap) {
+  const auto budget = stream::video_qos::pacing_budget(1'000'000, 50, 1'500, 1'000);
+  EXPECT_EQ(budget.drain_bitrate_bps, stream::video_qos::kMaxWireDrainBitrateBps);
+}
+
+TEST(VideoPacketQos, BackwardRtpClockAdvancesByOneNominalFrame) {
+  EXPECT_EQ(stream::video_qos::next_rtp_timestamp_ticks(80'000, 90'000, 120), 90'750u);
+  EXPECT_EQ(stream::video_qos::next_rtp_timestamp_ticks(91'000, 90'000, 120), 91'000u);
+}

--- a/tools/display_settings_helper.cpp
+++ b/tools/display_settings_helper.cpp
@@ -4342,15 +4342,15 @@ namespace {
           if (cancelled()) {
             return;
           }
-          refresh_shell_after_display_change();
-          if (cancelled()) {
-            return;
-          }
-          schedule_hdr_blank_if_needed(wa_hdr_toggle);
-          if (cancelled()) {
-            return;
-          }
 
+          // Reposition physical monitors BEFORE the shell refresh and HDR
+          // blank passes: repositioning is a desktop-geometry modeset, and
+          // every capture backend (WGC in particular) tears down and
+          // reinitializes when the desktop bounding box changes. Sequenced
+          // after those passes it landed ~9 s into the session — mid
+          // NVENC-build inside the isolated worker — forcing a second
+          // multi-second encoder build and blowing the strict-client
+          // first-video budget (observed live 2026-08-07).
           if (requested_virtual_layout) {
             BOOST_LOG(info) << "Display helper: requested virtual display layout=" << *requested_virtual_layout;
           }
@@ -4426,6 +4426,18 @@ namespace {
             }
             BOOST_LOG(info) << "Display helper: monitor position overrides applied result="
                             << (pending_overrides.empty() ? "true" : "false");
+          }
+
+          if (cancelled()) {
+            return;
+          }
+          refresh_shell_after_display_change();
+          if (cancelled()) {
+            return;
+          }
+          schedule_hdr_blank_if_needed(wa_hdr_toggle);
+          if (cancelled()) {
+            return;
           }
 
           // Restore physical monitor refresh rates from pre-VD-creation snapshot.


### PR DESCRIPTION
## Summary
The complete 2026-08 stabilization effort in nine logical commits: the worker-first capture architecture (isolated GPU worker, initial round by Codex) made production-ready across eleven fix rounds, verified live against macOS, Xbox Series X, and LG webOS Moonlight clients.

**What broke and what fixed it, in commit order:**
1. **Mailbox hardening** — queue generation epochs + expired-slot recreation; reconnects no longer race teardown for mailbox slots.
2. **Per-session video egress** — decoder-safe QoS admission (sequence-gap withholding + single-IDR recovery with cooldown), bitrate-derived wire pacing with absolute deadlines (replaces ~800 Mbps microbursts that 100 Mbps TV/Wi-Fi clients dropped), bounded depth-2 packet queues capping standing latency, 30 s age/cadence telemetry. Verified: capture-to-send age settled at the predicted equilibrium (avg 155 ms at 21 fps cadence, 35 ms idle); backlog warnings fell from one per ~30 s to 6 in 5 h.
3. **Process lifecycle** — index-based prep commands (dangling-iterator fix), lifecycle mutex, deferred env swap.
4. **Isolated video worker** — prewarm slot, bounded failure ladder (PROCESS_READY 5 s / FIRST_PACKET 30 s for 5-11 s NVENC session creation), capture-generation packet admission, IPC cancel-race/timeout hardening.
5. **LuminalVGD host** — deferred ring generation binding with observable WGC pivot, control-device reopen-and-retry self-heal (a crashed driver host no longer wedges virtual displays until service restart), 30 s lease request, empty-table reachability probing.
6. **Display helper** — 10 s apply verification, no mid-apply helper restart, modeset-before-capture ordering.
7. **Strict-client startup** — /launch-time worker prewarm + 8 s-capped ANNOUNCE hold for xbox/webos clients with every clock explicitly extended; macOS path untouched; removes the unconditional gate that broke all clients.
8. **TLS baseline** — outbound curl floors at TLS 1.2 (fixes the Windows PCA insecure-TLS warning); SSLv2/v3 off on both HTTPS contexts.
9. **Submodule bumps** — LuminalVGD → merged main (#30/#31, released v0.1.0-alpha.9, already CI-pinned by #144); Simple-Web-Server → NortheBridge/Simple-Web-Server#2.

## Test plan
- 622 C++ tests pass, 0 failed (updated: VGD transition truth table, ring liveness, packet QoS/pacing, process prep-cmds).
- The committed tree is byte-identical to the binaries deployed and soak-tested on the production host: multi-hour sessions on all three client classes, 2h23m Xbox session, 4K HDR Battlefield 6 on native-D3D12 Direct-to-Encode, clean teardown/tscon cycles, telemetry confirming the latency model.
- Full diagnostic history in eleven rounds of log-zip forensics (ETW, WDF minidumps, WER, moonlight-common-c timing analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)