### PR TITLE
Fix the 21 fps video ceiling: timer-quantum stalls in the worker pipeline

### DIFF
--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -1049,10 +1049,12 @@ namespace nvenc {
     assert(registered_input_buffer);
     assert(output_bitstream);
 
+    const auto phase_start = std::chrono::steady_clock::now();
     if (!synchronize_input_buffer()) {
       BOOST_LOG(error) << "NvEnc: failed to synchronize input buffer";
       return {};
     }
+    const auto phase_input_synced = std::chrono::steady_clock::now();
 
     NV_ENC_MAP_INPUT_RESOURCE mapped_input_buffer = {api::map_input_resource_version(selected_api_version)};
     mapped_input_buffer.registeredResource = registered_input_buffer;
@@ -1061,6 +1063,7 @@ namespace nvenc {
       BOOST_LOG(error) << "NvEnc: NvEncMapInputResource() failed: " << last_nvenc_error_string;
       return {};
     }
+    const auto phase_mapped = std::chrono::steady_clock::now();
     // Record the mapped resource so the encode-wait-timeout path below
     // (and, transitively, destroy_encoder via the PR-C3 async drain) can
     // unmap it AFTER the GPU is provably done with it. Cleared on every
@@ -1101,6 +1104,7 @@ namespace nvenc {
     // mode this defends against. No-op on sync-mode encoders.
     reset_async_event();
 
+    const auto phase_presubmit = std::chrono::steady_clock::now();
     if (nvenc_failed(nvenc->nvEncEncodePicture(encoder, &pic_params))) {
       BOOST_LOG(error) << "NvEnc: NvEncEncodePicture() failed: " << last_nvenc_error_string;
       // The submit itself failed — the GPU never queued anything against
@@ -1108,11 +1112,13 @@ namespace nvenc {
       unmap_now();
       return {};
     }
+    const auto phase_submitted = std::chrono::steady_clock::now();
 
     std::uint32_t wait_removed_reason = 0;
     const auto wait_result = async_event_handle ?
                                wait_for_encode_completion(wait_removed_reason) :
                                encode_wait_result::completed;
+    const auto phase_waited = std::chrono::steady_clock::now();
     if (wait_result != encode_wait_result::completed) {
       // Capture diagnostic context on the timeout. The previous one-line
       // log gave no signal about whether this was a transient bubble or
@@ -1287,7 +1293,34 @@ namespace nvenc {
     // The GPU is provably done with the mapped resource by virtue of the
     // completion event having signaled, so unmap synchronously rather
     // than handing this frame's mapping over to destroy_encoder's drain.
+    const auto phase_locked = std::chrono::steady_clock::now();
     unmap_now();
+
+    {
+      const auto phase_done = std::chrono::steady_clock::now();
+      const auto ns = [](auto a, auto b) {
+        return static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(b - a).count());
+      };
+      auto &t = encode_phase_telemetry;
+      t.input_sync_ns += ns(phase_start, phase_input_synced);
+      t.map_ns += ns(phase_input_synced, phase_mapped);
+      t.submit_ns += ns(phase_presubmit, phase_submitted);
+      t.wait_ns += ns(phase_submitted, phase_waited);
+      t.lock_ns += ns(phase_waited, phase_locked);
+      t.unmap_ns += ns(phase_locked, phase_done);
+      ++t.frames;
+      if (t.window_start == std::chrono::steady_clock::time_point {}) {
+        t.window_start = phase_done;
+      } else if (phase_done - t.window_start >= std::chrono::seconds(30)) {
+        BOOST_LOG(info) << "NvEnc phases: " << t.frames << " frames; avg ms: input-sync="
+                        << (t.input_sync_ns / 1e6 / t.frames) << " map=" << (t.map_ns / 1e6 / t.frames)
+                        << " submit=" << (t.submit_ns / 1e6 / t.frames) << " wait=" << (t.wait_ns / 1e6 / t.frames)
+                        << " lock+copy=" << (t.lock_ns / 1e6 / t.frames) << " unmap=" << (t.unmap_ns / 1e6 / t.frames)
+                        << ".";
+        t = {};
+        t.window_start = phase_done;
+      }
+    }
 
     return encoded_frame;
   }

--- a/src/nvenc/nvenc_base.h
+++ b/src/nvenc/nvenc_base.h
@@ -290,6 +290,26 @@ namespace nvenc {
       // (an opaque void* in the NVENC ABI).
       void *pending_mapped_resource = nullptr;
     } encoder_state;
+
+    /// 30 s phase breakdown of the NVENC API section of encode_frame:
+    /// input-sync (backend synchronize_input_buffer), map
+    /// (nvEncMapInputResource), submit (nvEncEncodePicture), wait
+    /// (completion event), lock+copy (LockBitstream through Unlock), unmap
+    /// (nvEncUnmapInputResource). Field diagnosis instrumentation: the
+    /// yuv444 10-bit path's 47 ms/frame cadence survived both the CUDA
+    /// sched-flag and stream-ordering fixes, and the backend's own interop
+    /// phases measure sub-millisecond — so the quantized waits must sit in
+    /// one or more of these driver entry points.
+    struct {
+      std::chrono::steady_clock::time_point window_start {};
+      std::uint64_t input_sync_ns = 0;
+      std::uint64_t map_ns = 0;
+      std::uint64_t submit_ns = 0;
+      std::uint64_t wait_ns = 0;
+      std::uint64_t lock_ns = 0;
+      std::uint64_t unmap_ns = 0;
+      std::uint32_t frames = 0;
+    } encode_phase_telemetry;
   };
 
   /**

--- a/src/nvenc/nvenc_d3d11_on_cuda.cpp
+++ b/src/nvenc/nvenc_d3d11_on_cuda.cpp
@@ -17,6 +17,16 @@
 
   // local includes
   #include "nvenc_utils.h"
+  #include "src/platform/common.h"
+
+  #include <chrono>
+  #include <thread>
+
+  // ffnvcodec's minimal dynlink_cuda.h defines only CU_CTX_SCHED_BLOCKING_SYNC.
+  // The value is fixed CUDA driver ABI (cuda.h, CUctx_flags).
+  #ifndef CU_CTX_SCHED_YIELD
+    #define CU_CTX_SCHED_YIELD 2
+  #endif
 
 namespace nvenc {
 
@@ -34,6 +44,18 @@ namespace nvenc {
       {
         auto autopop_context = push_context();
 
+        // A failed frame can leave the copy targeting cuda_surface pending
+        // on the interop stream (only reachable when the GPU wedged). Give
+        // it a bounded drain so the cuMemFree below relies on documented
+        // ordering instead of the driver's implicit synchronization.
+        if (interop_stream && cuda_functions.cuStreamQuery) {
+          const auto drain_deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(250);
+          while (cuda_functions.cuStreamQuery(interop_stream) == CUDA_ERROR_NOT_READY &&
+                 std::chrono::steady_clock::now() < drain_deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          }
+        }
+
         if (cuda_d3d_input_texture) {
           if (cuda_failed(cuda_functions.cuGraphicsUnregisterResource(cuda_d3d_input_texture))) {
             BOOST_LOG(error) << "NvEnc: cuGraphicsUnregisterResource() failed: error " << last_cuda_error;
@@ -46,6 +68,13 @@ namespace nvenc {
             BOOST_LOG(error) << "NvEnc: cuMemFree() failed: error " << last_cuda_error;
           }
           cuda_surface = 0;
+        }
+
+        if (interop_stream) {
+          if (cuda_functions.cuStreamDestroy && cuda_failed(cuda_functions.cuStreamDestroy(interop_stream))) {
+            BOOST_LOG(error) << "NvEnc: cuStreamDestroy() failed: error " << last_cuda_error;
+          }
+          interop_stream = nullptr;
         }
       }
 
@@ -102,6 +131,18 @@ namespace nvenc {
         BOOST_LOG(error) << "NvEnc: missing CUDA functions in " << dll_name;
         FreeLibrary(cuda_functions.dll);
         cuda_functions = {};
+      } else if (!load_function(cuda_functions.cuStreamCreate, "cuStreamCreate") ||
+                 !load_function(cuda_functions.cuStreamDestroy, "cuStreamDestroy_v2") ||
+                 !load_function(cuda_functions.cuMemcpy2DAsync, "cuMemcpy2DAsync_v2") ||
+                 !load_function(cuda_functions.cuStreamQuery, "cuStreamQuery")) {
+        // Optional stream-ordered set: every driver this host supports has
+        // them, but their absence must degrade to the synchronous interop
+        // path, not disable the encoder.
+        BOOST_LOG(warning) << "NvEnc: stream-ordered CUDA interop unavailable; using synchronous interop.";
+        cuda_functions.cuStreamCreate = nullptr;
+        cuda_functions.cuStreamDestroy = nullptr;
+        cuda_functions.cuMemcpy2DAsync = nullptr;
+        cuda_functions.cuStreamQuery = nullptr;
       }
     } else {
       BOOST_LOG(debug) << "NvEnc: couldn't load CUDA dynamic library " << dll_name;
@@ -114,9 +155,19 @@ namespace nvenc {
           SUCCEEDED(d3d_device->QueryInterface(IID_PPV_ARGS(&dxgi_device))) &&
           SUCCEEDED(dxgi_device->GetAdapter(&dxgi_adapter))) {
         CUdevice cuda_device;
+        // SCHED_YIELD, not SCHED_BLOCKING_SYNC: synchronize_input_buffer()
+        // performs three synchronous CUDA calls per frame (map, copy,
+        // unmap), and on OS builds that quantize blocking-primitive wakes
+        // to the timer interrupt (observed on Windows 11 Canary, which also
+        // ignores timer-resolution raises), BLOCKING_SYNC cost a full
+        // ~15.6 ms quantum per call — a hard 3x15.6 = 47 ms/frame encode
+        // cadence (~21 fps) on the yuv444 10-bit path while the GPU work
+        // being awaited measured sub-millisecond. YIELD spin-yields instead:
+        // wake latency is scheduler-granular and the CPU cost is bounded by
+        // those sub-millisecond waits on this format's path only.
         if (cuda_succeeded(cuda_functions.cuInit(0)) &&
             cuda_succeeded(cuda_functions.cuD3D11GetDevice(&cuda_device, dxgi_adapter)) &&
-            cuda_succeeded(cuda_functions.cuCtxCreate(&cuda_context, CU_CTX_SCHED_BLOCKING_SYNC, cuda_device)) &&
+            cuda_succeeded(cuda_functions.cuCtxCreate(&cuda_context, CU_CTX_SCHED_YIELD, cuda_device)) &&
             cuda_succeeded(cuda_functions.cuCtxPopCurrent(&cuda_context))) {
           device = cuda_context;
         } else {
@@ -183,6 +234,17 @@ namespace nvenc {
           return false;
         }
       }
+
+      if (!interop_stream && cuda_functions.cuStreamCreate) {
+        if (cuda_failed(cuda_functions.cuStreamCreate(&interop_stream, CU_STREAM_NON_BLOCKING))) {
+          BOOST_LOG(warning) << "NvEnc: cuStreamCreate() failed (error " << last_cuda_error
+                             << "); falling back to synchronous CUDA interop.";
+          interop_stream = nullptr;
+        }
+      }
+      if (!interop_poll_timer) {
+        interop_poll_timer = platf::create_high_precision_timer();
+      }
     }
 
     if (!registered_input_buffer) {
@@ -212,13 +274,30 @@ namespace nvenc {
       return false;
     }
 
-    if (cuda_failed(cuda_functions.cuGraphicsMapResources(1, &cuda_d3d_input_texture, 0))) {
+    // Stream-ordered interop: enqueue map/copy/unmap on the non-blocking
+    // stream and poll completion with the high-resolution timer. The legacy
+    // synchronous sequence parked the host in a WDDM interop wait THREE
+    // times per frame, and OS builds that quantize those wakes to the timer
+    // interrupt (observed on Windows 11 Canary, where timer-resolution
+    // raises and CUDA scheduling flags are both ignored) turned that into a
+    // hard 3 x 15.6 = 47 ms/frame encode cadence (~21 fps) on the yuv444
+    // 10-bit path — for sub-millisecond GPU work. Falls back to the
+    // synchronous sequence when the stream, entry points, or timer are
+    // unavailable.
+    const bool stream_ordered = interop_stream && cuda_functions.cuMemcpy2DAsync &&
+                                cuda_functions.cuStreamQuery &&
+                                interop_poll_timer && *interop_poll_timer;
+    const CUstream stream = stream_ordered ? interop_stream : nullptr;
+
+    const auto phase_started = std::chrono::steady_clock::now();
+    if (cuda_failed(cuda_functions.cuGraphicsMapResources(1, &cuda_d3d_input_texture, stream))) {
       BOOST_LOG(error) << "NvEnc: cuGraphicsMapResources() failed: error " << last_cuda_error;
       return false;
     }
+    const auto phase_mapped = std::chrono::steady_clock::now();
 
     auto unmap = [&]() -> bool {
-      if (cuda_failed(cuda_functions.cuGraphicsUnmapResources(1, &cuda_d3d_input_texture, 0))) {
+      if (cuda_failed(cuda_functions.cuGraphicsUnmapResources(1, &cuda_d3d_input_texture, stream))) {
         BOOST_LOG(error) << "NvEnc: cuGraphicsUnmapResources() failed: error " << last_cuda_error;
         return false;
       }
@@ -243,14 +322,77 @@ namespace nvenc {
       copy_params.WidthInBytes = encoder_params.width * 2;
       copy_params.Height = encoder_params.height * 3;
 
-      if (cuda_failed(cuda_functions.cuMemcpy2D(&copy_params))) {
-        BOOST_LOG(error) << "NvEnc: cuMemcpy2D() failed: error " << last_cuda_error;
+      const CUresult copy_result = stream_ordered ?
+                                     cuda_functions.cuMemcpy2DAsync(&copy_params, stream) :
+                                     cuda_functions.cuMemcpy2D(&copy_params);
+      if (cuda_failed(copy_result)) {
+        BOOST_LOG(error) << "NvEnc: cuMemcpy2D" << (stream_ordered ? "Async" : "")
+                         << "() failed: error " << last_cuda_error;
         return false;
       }
     }
+    const auto phase_copied = std::chrono::steady_clock::now();
 
     unmap_guard.disable();
-    return unmap();
+    if (!unmap()) {
+      return false;
+    }
+    const auto phase_unmapped = std::chrono::steady_clock::now();
+
+    if (stream_ordered) {
+      // NVENC consumes cuda_surface right after this returns; the copy must
+      // be complete first. Poll instead of blocking: cuStreamQuery is a
+      // non-waiting status read, and the poll sleep uses the high-resolution
+      // waitable timer — the one wait primitive this OS build does not
+      // quantize. The deadline mirrors the encoder's own hang philosophy:
+      // a stream that needs a full second for a sub-millisecond copy means
+      // the GPU is wedged, and failing the frame routes into the normal
+      // encoder error/reinit path.
+      const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+      while (true) {
+        const CUresult status = cuda_functions.cuStreamQuery(interop_stream);
+        if (status == CUDA_SUCCESS) {
+          break;
+        }
+        if (status != CUDA_ERROR_NOT_READY) {
+          last_cuda_error = status;
+          BOOST_LOG(error) << "NvEnc: cuStreamQuery() failed: error " << last_cuda_error;
+          return false;
+        }
+        if (std::chrono::steady_clock::now() >= deadline) {
+          BOOST_LOG(error) << "NvEnc: CUDA interop stream did not complete within 1 s; failing this frame.";
+          return false;
+        }
+        interop_poll_timer->sleep_for(std::chrono::microseconds(500));
+      }
+    }
+
+    {
+      const auto phase_done = std::chrono::steady_clock::now();
+      const auto ns = [](auto a, auto b) {
+        return static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(b - a).count());
+      };
+      interop_phase_map_ns += ns(phase_started, phase_mapped);
+      interop_phase_copy_ns += ns(phase_mapped, phase_copied);
+      interop_phase_unmap_ns += ns(phase_copied, phase_unmapped);
+      interop_phase_poll_ns += ns(phase_unmapped, phase_done);
+      ++interop_phase_frames;
+      if (interop_phase_window_start == std::chrono::steady_clock::time_point {}) {
+        interop_phase_window_start = phase_done;
+      } else if (phase_done - interop_phase_window_start >= std::chrono::seconds(30)) {
+        BOOST_LOG(info) << "CUDA interop phases (" << (stream_ordered ? "stream-ordered" : "synchronous")
+                        << "): " << interop_phase_frames << " frames; avg ms: map="
+                        << (interop_phase_map_ns / 1e6 / interop_phase_frames) << " copy-submit="
+                        << (interop_phase_copy_ns / 1e6 / interop_phase_frames) << " unmap="
+                        << (interop_phase_unmap_ns / 1e6 / interop_phase_frames) << " poll="
+                        << (interop_phase_poll_ns / 1e6 / interop_phase_frames) << ".";
+        interop_phase_window_start = phase_done;
+        interop_phase_map_ns = interop_phase_copy_ns = interop_phase_unmap_ns = interop_phase_poll_ns = 0;
+        interop_phase_frames = 0;
+      }
+    }
+
+    return true;
   }
 
   bool nvenc_d3d11_on_cuda::cuda_succeeded(CUresult result) {

--- a/src/nvenc/nvenc_d3d11_on_cuda.h
+++ b/src/nvenc/nvenc_d3d11_on_cuda.h
@@ -10,6 +10,12 @@
   // local includes
   #include "nvenc_d3d11.h"
 
+  #include <memory>
+
+namespace platf {
+  struct high_precision_timer;
+}
+
 namespace nvenc {
 
   /**
@@ -78,6 +84,12 @@ namespace nvenc {
       tcuGraphicsUnmapResources *cuGraphicsUnmapResources;
       tcuGraphicsSubResourceGetMappedArray *cuGraphicsSubResourceGetMappedArray;
       tcuMemcpy2D_v2 *cuMemcpy2D;
+      // Optional stream-ordered interop entry points (loaded best-effort;
+      // absence degrades synchronize_input_buffer to the synchronous path).
+      tcuStreamCreate *cuStreamCreate;
+      tcuStreamDestroy_v2 *cuStreamDestroy;
+      tcuMemcpy2DAsync_v2 *cuMemcpy2DAsync;
+      tcuStreamQuery *cuStreamQuery;
       HMODULE dll;
     } cuda_functions = {};
 
@@ -86,6 +98,26 @@ namespace nvenc {
     CUgraphicsResource cuda_d3d_input_texture = nullptr;
     CUdeviceptr cuda_surface = 0;
     size_t cuda_surface_pitch = 0;
+
+    /// Non-blocking stream carrying the per-frame map/copy/unmap sequence;
+    /// completion is polled with the high-resolution timer instead of the
+    /// host-blocking interop waits, which cost a full timer quantum each on
+    /// OS builds that quantize them (3 calls x 15.6 ms = the 2026-08 hard
+    /// ~21 fps encode cadence on the yuv444 10-bit path).
+    CUstream interop_stream = nullptr;
+    std::unique_ptr<platf::high_precision_timer> interop_poll_timer;
+
+    /// 30 s phase breakdown of synchronize_input_buffer: which interop call
+    /// actually hosts the quantized WDDM waits (map / copy submit / unmap /
+    /// completion poll). Stream-ordering the sequence did not remove the
+    /// stalls, so the next fix is chosen from these numbers, not from API
+    /// documentation.
+    std::chrono::steady_clock::time_point interop_phase_window_start {};
+    std::uint64_t interop_phase_map_ns = 0;
+    std::uint64_t interop_phase_copy_ns = 0;
+    std::uint64_t interop_phase_unmap_ns = 0;
+    std::uint64_t interop_phase_poll_ns = 0;
+    std::uint32_t interop_phase_frames = 0;
   };
 
 }  // namespace nvenc

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -759,6 +759,23 @@ namespace platf::dxgi {
     bool _first_frame_timeout_reported = false;
     std::string _display_name;
 
+    /// Poll sleeps in the claim loop use a high-resolution waitable timer:
+    /// immune to the interrupt period AND to Windows 11 background timer
+    /// coalescing, either of which turns a nominal 1 ms std sleep into a
+    /// 15.6+ ms quantum in this windowless worker process (the ~21 fps
+    /// arrival-cadence ceiling of 2026-08).
+    std::unique_ptr<high_precision_timer> _claim_poll_timer;
+
+    /// 30 s cadence-telemetry window: how many frames this consumer claimed
+    /// versus how many sequences the driver published, and how long the
+    /// claim poll actually waited. Separates "the ring produced 21 fps"
+    /// from "the host consumed at 21 fps" in one log line.
+    std::chrono::steady_clock::time_point _cadence_window_start {};
+    uint64_t _cadence_window_base_seq = 0;
+    uint32_t _cadence_claimed = 0;
+    std::chrono::nanoseconds _cadence_claim_wait {};
+    std::chrono::nanoseconds _cadence_claim_wait_max {};
+
     // TDR blast-radius shrink: tdr::event_count() snapshot taken at init.
     // When it advances, snapshot() drops every shared GPU allocation this
     // reader holds (see display_vgd.cpp). The reinit that follows is DEFERRED

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -1126,6 +1126,11 @@ namespace platf::dxgi {
         if (!recovering) {
           recovery_deferral_started.reset();
           recovery_deferral_logged.reset();
+          // This reinit was previously silent, which made the field's
+          // recurring mid-stream encoder rebuilds (~5 s NVENC re-open each)
+          // undiagnosable: nothing in the log named the trigger.
+          BOOST_LOG(info) << "Capture reinit: DXGI factory reported stale "
+                             "(display topology, mode, HDR, or GPU state changed)."sv;
           return platf::capture_e::reinit;
         }
 

--- a/src/platform/windows/display_vgd.cpp
+++ b/src/platform/windows/display_vgd.cpp
@@ -1137,9 +1137,18 @@ namespace platf::dxgi {
     // There is no wake event — the section is pure shared memory — so poll at
     // 1 ms granularity; the base capture loop paces us to the client rate and
     // usually calls with timeout 0.
+    //
+    // The poll sleep MUST be the high-resolution waitable timer: a plain
+    // 1 ms std sleep in this windowless worker process costs a full timer
+    // quantum (15.6 ms — more under Windows 11 background timer coalescing),
+    // which capped fresh-frame arrivals at a hard ~21 fps in the field.
+    if (!_claim_poll_timer) {
+      _claim_poll_timer = platf::create_high_precision_timer();
+    }
     VgdFrame frame {};
     bool claimed = false;
-    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    const auto claim_wait_started = std::chrono::steady_clock::now();
+    const auto deadline = claim_wait_started + timeout;
     while (true) {
       if (vgd_ring_claim(_ring, &frame)) {
         if (frame.sequence > _last_sequence) {
@@ -1171,8 +1180,15 @@ namespace platf::dxgi {
           break;
         }
       }
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      if (_claim_poll_timer && *_claim_poll_timer) {
+        _claim_poll_timer->sleep_for(std::chrono::milliseconds(1));
+      } else {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
     }
+    // Taken at loop exit so the telemetry's claim-wait covers only the poll,
+    // not the copy/fence work that follows.
+    const auto claim_acquired_at = std::chrono::steady_clock::now();
     if (!claimed) {
       // Nothing published — but with the cursor on its own plane, cursor
       // motion over an idle desktop produces no frames at all. Redeliver
@@ -1377,6 +1393,49 @@ namespace platf::dxgi {
     vgd_ring_release(_ring, frame.index);
     _last_sequence = frame.sequence;
     _liveness.note_delivered();
+
+    // Cadence telemetry: separates "the driver only published N fps" from
+    // "the host only claimed N fps" — the two halves of the 21 fps ceiling
+    // question — and shows what the claim poll actually cost per frame.
+    {
+      const auto cadence_now = std::chrono::steady_clock::now();
+      const auto claim_wait = claim_acquired_at - claim_wait_started;
+      if (_cadence_window_start == std::chrono::steady_clock::time_point {} ||
+          frame.sequence < _cadence_window_base_seq) {
+        // First frame of this reader, or the ring generation restarted its
+        // sequence counter — open a fresh window.
+        _cadence_window_start = cadence_now;
+        _cadence_window_base_seq = frame.sequence > 0 ? frame.sequence - 1 : 0;
+        _cadence_claimed = 0;
+        _cadence_claim_wait = {};
+        _cadence_claim_wait_max = {};
+      }
+      ++_cadence_claimed;
+      _cadence_claim_wait += claim_wait;
+      _cadence_claim_wait_max = std::max<std::chrono::nanoseconds>(_cadence_claim_wait_max, claim_wait);
+
+      const auto window_elapsed = cadence_now - _cadence_window_start;
+      if (window_elapsed >= std::chrono::seconds(30)) {
+        const auto seconds = std::chrono::duration_cast<std::chrono::duration<double>>(window_elapsed).count();
+        const auto published = frame.sequence - _cadence_window_base_seq;
+        const auto claim_wait_avg_ms = _cadence_claimed ?
+                                         std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(_cadence_claim_wait).count() / _cadence_claimed :
+                                         0.0;
+        BOOST_LOG(info) << "LuminalVGD capture cadence: claimed " << _cadence_claimed
+                        << " of " << published << " published frames over "
+                        << static_cast<int>(seconds) << " s (~"
+                        << static_cast<int>(_cadence_claimed / seconds) << " claimed fps, ~"
+                        << static_cast<int>(published / seconds) << " published fps); claim-wait avg="
+                        << claim_wait_avg_ms << " ms max="
+                        << std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(_cadence_claim_wait_max).count()
+                        << " ms.";
+        _cadence_window_start = cadence_now;
+        _cadence_window_base_seq = frame.sequence;
+        _cadence_claimed = 0;
+        _cadence_claim_wait = {};
+        _cadence_claim_wait_max = {};
+      }
+    }
 
     d3d_img->blank = false;
     d3d_img->format = capture_format;

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -4,6 +4,8 @@
  */
 // standard includes
 #include <algorithm>
+#include <array>
+#include <chrono>
 #include <csignal>
 #include <filesystem>
 #include <iomanip>
@@ -11,6 +13,7 @@
 #include <limits>
 #include <set>
 #include <sstream>
+#include <thread>
 #include <vector>
 
 // lib includes
@@ -101,6 +104,20 @@ namespace {
       return false;
     }
     return true;
+  }
+
+  // Windows 11 is free to ignore a background process's raised timer
+  // resolution and to coalesce its timer expirations unless the process
+  // explicitly opts out of power throttling. Both LuminalShine processes are
+  // windowless session-0 service processes — exactly the class the kernel
+  // throttles — so the NtSetTimerResolution above is not honored without
+  // this companion call.
+  bool opt_out_of_process_power_throttling() {
+    PROCESS_POWER_THROTTLING_STATE state {};
+    state.Version = PROCESS_POWER_THROTTLING_CURRENT_VERSION;
+    state.ControlMask = PROCESS_POWER_THROTTLING_EXECUTION_SPEED | PROCESS_POWER_THROTTLING_IGNORE_TIMER_RESOLUTION;
+    state.StateMask = 0;  // 0 with the bit in ControlMask = throttling disabled
+    return SetProcessInformation(GetCurrentProcess(), ProcessPowerThrottling, &state, sizeof(state)) != 0;
   }
 
 }  // namespace
@@ -1515,6 +1532,31 @@ namespace platf {
     }
   }
 
+  void apply_video_worker_process_timing() {
+    // The isolated video worker is a windowless, session-0 child of a SYSTEM
+    // service and never runs streaming_will_start(), so until now it kept the
+    // default 15.625 ms timer resolution — and Windows 11 additionally
+    // coalesces timer expirations for throttled background processes. Every
+    // nominal 1 ms polling sleep on the capture hot path (ring-claim poll,
+    // image-pool wait) then costs one or more full quanta, which is the
+    // field-observed hard ~21 fps arrival cadence (~47 ms/frame) regardless
+    // of capture backend. Raise the resolution, opt out of power throttling
+    // so the raise is actually honored, and match the main process's
+    // HIGH_PRIORITY_CLASS (upstream Sunshine runs capture+encode in one
+    // HIGH-priority process; the worker split silently dropped that).
+    if (!nt_set_timer_resolution_max()) {
+      BOOST_LOG(warning) << "Video worker: NtSetTimerResolution() failed, falling back to timeBeginPeriod(1).";
+      timeBeginPeriod(1);
+    }
+    if (!opt_out_of_process_power_throttling()) {
+      BOOST_LOG(warning) << "Video worker: SetProcessInformation(ProcessPowerThrottling) failed: " << GetLastError()
+                         << "; timer coalescing may still apply.";
+    }
+    if (!SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS)) {
+      BOOST_LOG(warning) << "Video worker: SetPriorityClass(HIGH_PRIORITY_CLASS) failed: " << GetLastError();
+    }
+  }
+
   void streaming_will_start() {
     static std::once_flag load_wlanapi_once_flag;
     std::call_once(load_wlanapi_once_flag, []() {
@@ -1556,6 +1598,32 @@ namespace platf {
       timeBeginPeriod(1);
       used_nt_set_timer_resolution = false;
     }
+
+    // Without this, Windows 11 may silently disregard the raised resolution
+    // for this windowless service process (timer coalescing for throttled
+    // background processes).
+    if (!opt_out_of_process_power_throttling()) {
+      BOOST_LOG(warning) << "SetProcessInformation(ProcessPowerThrottling) failed: " << GetLastError()
+                         << "; the raised timer resolution may not be honored.";
+    }
+
+    // One-shot quantum probe (the worker logs the same at its startup): on
+    // OS builds that ignore the raise, every plain 1 ms sleep in THIS
+    // process still costs a ~15.6 ms quantum, and only high-resolution
+    // waitable timers pace correctly. Knowing which regime the main process
+    // is in turns pacing-related field reports from guesses into facts.
+    static std::once_flag quantum_probe_flag;
+    std::call_once(quantum_probe_flag, []() {
+      std::array<std::int64_t, 3> samples {};
+      for (auto &sample : samples) {
+        const auto t0 = std::chrono::steady_clock::now();
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        sample = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - t0).count();
+      }
+      std::sort(samples.begin(), samples.end());
+      BOOST_LOG(info) << "Main process sleep(1ms) quantum: " << (samples[1] / 1000.0)
+                      << " ms (after timer-resolution raise).";
+    });
 
     // Promote ourselves to high priority class
     SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);

--- a/src/platform/windows/misc.h
+++ b/src/platform/windows/misc.h
@@ -36,6 +36,18 @@ namespace platf {
    */
   void reset_gpu_scheduling_priority();
 
+  /**
+   * @brief Give the isolated video worker process the timing profile that
+   * real-time capture requires.
+   *
+   * Raises the kernel timer resolution, opts the process out of Windows 11
+   * background power throttling (which otherwise silently ignores the raise
+   * and coalesces timers for windowless session-0 processes), and promotes
+   * the process to HIGH_PRIORITY_CLASS for parity with the main service
+   * process. Call once at worker startup, before the capture pipeline runs.
+   */
+  void apply_video_worker_process_timing();
+
   int64_t qpc_counter();
 
   std::chrono::nanoseconds qpc_time_difference(int64_t performance_counter1, int64_t performance_counter2);

--- a/src/platform/windows/video_worker.cpp
+++ b/src/platform/windows/video_worker.cpp
@@ -648,6 +648,12 @@ namespace platf::video_worker {
       auto touch = session_mail->event<input::touch_port_t>(mail::touch_port);
       auto chroma = session_mail->event<bool>(mail::chroma_downgrade);
       std::uint64_t admitted_generation = 0;
+      // R15 egress-cycle telemetry: whether this thread spends its time
+      // waiting for the encoder (queue-wait) or for the parent to drain the
+      // pipe (pipe-write). One line per 30 s.
+      auto egress_window_start = std::chrono::steady_clock::now();
+      std::uint64_t egress_queue_wait_ns = 0, egress_write_ns = 0, egress_write_max_ns = 0;
+      std::uint32_t egress_packets = 0;
       while (!shutdown->peek()) {
         bool capture_reinitialized = false;
         generation_t reinitialized_generation {};
@@ -666,7 +672,11 @@ namespace platf::video_worker {
           if (!send(pipe, message_e::capture_reinitializing, &reinitialized_generation, sizeof(reinitialized_generation), kChildPacketSendTimeoutMs)) break;
           continue;
         }
+        const auto egress_pop_started = std::chrono::steady_clock::now();
         if (auto packet = packets->pop(20ms)) {
+          egress_queue_wait_ns += static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - egress_pop_started).count()
+          );
           std::lock_guard generation_lock(g_capture_generation_mutex);
           // A reinit can race the queue pop. Drop this now-stale packet; the
           // next loop drains the old generation and publishes its marker
@@ -722,7 +732,24 @@ namespace platf::video_worker {
             if (!send(pipe, message_e::capture_ready, &generation, sizeof(generation), kChildPacketSendTimeoutMs)) break;
             capture_ready_sent.store(true, std::memory_order_release);
           }
+          const auto egress_write_started = std::chrono::steady_clock::now();
           if (!send(pipe, message_e::packet, body.data(), static_cast<std::uint32_t>(body.size()), kChildPacketSendTimeoutMs)) break;
+          const auto egress_write_done = std::chrono::steady_clock::now();
+          const auto write_ns = static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(egress_write_done - egress_write_started).count()
+          );
+          egress_write_ns += write_ns;
+          egress_write_max_ns = std::max(egress_write_max_ns, write_ns);
+          ++egress_packets;
+          if (egress_write_done - egress_window_start >= 30s && egress_packets > 0) {
+            BOOST_LOG(info) << "Worker egress cycle: " << egress_packets << " packets in 30 s; avg ms: queue-wait="
+                            << (egress_queue_wait_ns / 1e6 / egress_packets) << " pipe-write="
+                            << (egress_write_ns / 1e6 / egress_packets) << " (pipe-write max="
+                            << (egress_write_max_ns / 1e6) << " ms).";
+            egress_window_start = egress_write_done;
+            egress_queue_wait_ns = egress_write_ns = egress_write_max_ns = 0;
+            egress_packets = 0;
+          }
         }
         if (auto value = hdr->pop(0ms)) {
           std::lock_guard lock(write_mutex);

--- a/src/platform/windows/video_worker.cpp
+++ b/src/platform/windows/video_worker.cpp
@@ -24,6 +24,7 @@
 #include "src/input.h"
 #include "src/logging.h"
 #include "src/platform/windows/display.h"
+#include "src/platform/windows/misc.h"
 #include "src/platform/windows/virtual_display_backend.h"
 #include "src/platform/windows/virtual_display_vgd.h"
 
@@ -501,6 +502,26 @@ namespace platf::video_worker {
   }
 
   int run_child() {
+    // Field diagnosis of the ~21 fps arrival ceiling: one nominal-1ms sleep
+    // in this process cost a full (possibly coalesced) timer quantum. Log
+    // the measured quantum before and after applying the timing profile so
+    // support bundles prove whether the raise was honored on this OS build.
+    const auto measure_sleep_quantum = [](int samples) {
+      std::vector<std::int64_t> us(static_cast<std::size_t>(samples));
+      for (auto &sample : us) {
+        const auto t0 = std::chrono::steady_clock::now();
+        std::this_thread::sleep_for(1ms);
+        sample = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - t0).count();
+      }
+      std::sort(us.begin(), us.end());
+      return us[us.size() / 2];
+    };
+    const auto quantum_before_us = measure_sleep_quantum(3);
+    platf::apply_video_worker_process_timing();
+    const auto quantum_after_us = measure_sleep_quantum(5);
+    BOOST_LOG(info) << "Video worker: sleep(1ms) quantum " << (quantum_before_us / 1000.0) << " ms before timing profile, "
+                    << (quantum_after_us / 1000.0) << " ms after.";
+
     const auto full_name = L"\\\\.\\pipe\\" + widen_ascii(g_child_pipe);
     HANDLE pipe = INVALID_HANDLE_VALUE;
     const auto deadline = std::chrono::steady_clock::now() + 10s;

--- a/src/platform/windows/video_worker.cpp
+++ b/src/platform/windows/video_worker.cpp
@@ -361,9 +361,14 @@ namespace platf::video_worker {
       PSECURITY_DESCRIPTOR pipe_descriptor = nullptr;
       if (!make_pipe_security(pipe_security, pipe_descriptor)) return false;
       auto free_pipe_descriptor = util::fail_guard([&] { ::LocalFree(pipe_descriptor); });
+      // Both directions get 4 MiB. The child->parent (inbound) direction is
+      // the VIDEO path: at 25-40 KB per encoded 4K HDR frame the previous
+      // 64 KiB buffer held under two frames, which hard-coupled the worker's
+      // encode cadence to the parent reader's drain cadence — any stall or
+      // quantized wait on either side clock-gated the whole pipeline.
       child.pipe = ::CreateNamedPipeW(full_name.c_str(), PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED | FILE_FLAG_FIRST_PIPE_INSTANCE,
                                       PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
-                                      1, 4 * 1024 * 1024, 64 * 1024, 0, &pipe_security);
+                                      1, 4 * 1024 * 1024, 4 * 1024 * 1024, 0, &pipe_security);
       if (child.pipe == INVALID_HANDLE_VALUE || !launch(child, pipe_name)) return false;
 
       OVERLAPPED connect {};
@@ -751,17 +756,32 @@ namespace platf::video_worker {
             egress_packets = 0;
           }
         }
-        if (auto value = hdr->pop(0ms)) {
-          std::lock_guard lock(write_mutex);
-          if (!send(pipe, message_e::hdr, value.get(), sizeof(video::hdr_info_raw_t), kChildPacketSendTimeoutMs)) break;
+        // peek() before every sideband pop: a timed CV wait that expires on
+        // an EMPTY event costs a full timer quantum on OS builds that
+        // quantize timeout expiry (measured on Windows 11 Canary: even
+        // wait_for(0ms) sleeps ~15.1 ms, while notify-driven wakes stay at
+        // ~0.02 ms). Three unguarded pop(0ms) calls per loop made this
+        // egress cycle a hard ~47 ms — the encoder blocked on the full
+        // packet queue behind it, capping the whole session at ~21 fps.
+        // pop(0ms) on a non-empty event returns without waiting, so the
+        // peek guard removes the stall without changing semantics.
+        if (hdr->peek()) {
+          if (auto value = hdr->pop(0ms)) {
+            std::lock_guard lock(write_mutex);
+            if (!send(pipe, message_e::hdr, value.get(), sizeof(video::hdr_info_raw_t), kChildPacketSendTimeoutMs)) break;
+          }
         }
-        if (auto value = touch->pop(0ms)) {
-          std::lock_guard lock(write_mutex);
-          if (!send(pipe, message_e::touch, &*value, sizeof(*value), kChildPacketSendTimeoutMs)) break;
+        if (touch->peek()) {
+          if (auto value = touch->pop(0ms)) {
+            std::lock_guard lock(write_mutex);
+            if (!send(pipe, message_e::touch, &*value, sizeof(*value), kChildPacketSendTimeoutMs)) break;
+          }
         }
-        if (chroma->pop(0ms)) {
-          std::lock_guard lock(write_mutex);
-          if (!send(pipe, message_e::chroma_downgrade, nullptr, 0, kChildPacketSendTimeoutMs)) break;
+        if (chroma->peek()) {
+          if (chroma->pop(0ms)) {
+            std::lock_guard lock(write_mutex);
+            if (!send(pipe, message_e::chroma_downgrade, nullptr, 0, kChildPacketSendTimeoutMs)) break;
+          }
         }
       }
       // A failed pipe write means the parent is gone or has given up on this

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -491,6 +491,18 @@ namespace stream {
         std::uint64_t metric_age_max_ms = 0;
         std::uint32_t metric_aged_frames = 0;
         std::uint32_t metric_untimestamped_frames = 0;
+
+        // Broadcast-cycle breakdown, same 30 s window. The broadcast loop is
+        // single-threaded, so whenever the upstream queues are full the
+        // arrival cadence EQUALS this loop's cycle time — these buckets name
+        // the egress-side bottleneck directly: pop-wait (idle, upstream
+        // starved), pace (wire-pacing sleeps), send (socket submits), and
+        // everything else (FEC/encrypt/prep) derived as frame minus the rest.
+        std::uint64_t metric_cycle_pop_ns = 0;
+        std::uint64_t metric_cycle_pace_ns = 0;
+        std::uint64_t metric_cycle_send_ns = 0;
+        std::uint64_t metric_cycle_frame_ns = 0;
+        std::uint32_t metric_cycle_frames = 0;
       } transport;
 
       // Set by the egress thread once the first complete frame has been
@@ -1754,8 +1766,10 @@ namespace stream {
       return;
     }
 
-    while (auto packet = packets->pop()) {
-      if (shutdown_event->peek()) {
+    while (true) {
+      const auto cycle_pop_started = std::chrono::steady_clock::now();
+      auto packet = packets->pop();
+      if (!packet || shutdown_event->peek()) {
         break;
       }
 
@@ -1768,6 +1782,9 @@ namespace stream {
 
       auto &transport = session->video.transport;
       const auto admission_now = std::chrono::steady_clock::now();
+      transport.metric_cycle_pop_ns += static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(admission_now - cycle_pop_started).count()
+      );
       if (transport.epoch == std::chrono::steady_clock::time_point {}) {
         transport.epoch = admission_now;
         transport.next_frame_start = admission_now;
@@ -1826,18 +1843,32 @@ namespace stream {
             std::chrono::duration_cast<std::chrono::seconds>(admission_now - transport.metric_window_start).count(),
             1
           );
+          const auto popped = std::max<std::uint32_t>(transport.metric_aged_frames + transport.metric_untimestamped_frames, 1);
+          const auto sent = std::max<std::uint32_t>(transport.metric_cycle_frames, 1);
+          const auto other_ns = transport.metric_cycle_frame_ns -
+                                std::min(transport.metric_cycle_frame_ns, transport.metric_cycle_pace_ns + transport.metric_cycle_send_ns);
           BOOST_LOG(info) << "Video transport window: " << transport.metric_aged_frames << " timed + "
                           << transport.metric_untimestamped_frames << " untimed frames over " << secs
                           << " s (~" << (transport.metric_aged_frames + transport.metric_untimestamped_frames) / secs
                           << " fps arrived); capture-to-send age avg="
                           << transport.metric_age_sum_ms / transport.metric_aged_frames
-                          << " ms max=" << transport.metric_age_max_ms << " ms.";
+                          << " ms max=" << transport.metric_age_max_ms
+                          << " ms. Broadcast cycle avg ms: pop-wait=" << (transport.metric_cycle_pop_ns / 1e6 / popped)
+                          << " prep=" << (other_ns / 1e6 / sent)
+                          << " pace=" << (transport.metric_cycle_pace_ns / 1e6 / sent)
+                          << " send=" << (transport.metric_cycle_send_ns / 1e6 / sent)
+                          << " (" << transport.metric_cycle_frames << " sent frames).";
         }
         transport.metric_window_start = admission_now;
         transport.metric_age_sum_ms = 0;
         transport.metric_age_max_ms = 0;
         transport.metric_aged_frames = 0;
         transport.metric_untimestamped_frames = 0;
+        transport.metric_cycle_pop_ns = 0;
+        transport.metric_cycle_pace_ns = 0;
+        transport.metric_cycle_send_ns = 0;
+        transport.metric_cycle_frame_ns = 0;
+        transport.metric_cycle_frames = 0;
       }
       const auto previous_submitted = transport.qos.last_submitted_frame;
       const auto admission = video_qos::evaluate(
@@ -2164,6 +2195,9 @@ namespace stream {
                 auto now = std::chrono::steady_clock::now();
                 if (now < due) {
                   timer->sleep_for(due - now);
+                  transport.metric_cycle_pace_ns += static_cast<std::uint64_t>(
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - now).count()
+                  );
                 }
 
                 ratecontrol_group_packets_sent = 0;
@@ -2174,6 +2208,7 @@ namespace stream {
               batch_info.block_count = current_batch_size;
 
               frame_send_batch_latency_logger.first_point_now();
+              const auto cycle_send_started = std::chrono::steady_clock::now();
               // Use a batched send if it's supported on this platform
               if (!platf::send_batch(batch_info)) {
                 // Batched send is not available, so send each packet individually
@@ -2194,6 +2229,9 @@ namespace stream {
                 }
               }
               frame_send_batch_latency_logger.second_point_now_and_log();
+              transport.metric_cycle_send_ns += static_cast<std::uint64_t>(
+                std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - cycle_send_started).count()
+              );
 
               ratecontrol_group_packets_sent += current_batch_size;
               ratecontrol_frame_packets_sent += current_batch_size;
@@ -2254,6 +2292,11 @@ namespace stream {
           session->telemetry.payload_bytes.fetch_add(packet->data_size(), std::memory_order_relaxed);
           telemetry_flush(session);
         }
+
+        transport.metric_cycle_frame_ns += static_cast<std::uint64_t>(
+          std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - admission_now).count()
+        );
+        ++transport.metric_cycle_frames;
       } catch (const std::exception &e) {
         video_qos::submission_failed(transport.qos, packet->is_idr());
         BOOST_LOG(error) << "Broadcast video failed "sv << e.what();

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2930,6 +2930,16 @@ namespace video {
     encode_bootstrap_state_t bootstrap_state {.allow_placeholder_before_first_real = frame_nr <= 1};
     bootstrap_state.current_input_generation = capture_generation_for_current_process();
 
+    // Encode-cycle breakdown, one line per 30 s: image-wait (starved by
+    // capture), convert (GPU color conversion incl. keyed-mutex acquire),
+    // and encode+deliver (NVENC submit, completion wait, bitstream copy AND
+    // the possibly-blocking raise into the bounded packet queue). Together
+    // with the egress and broadcast cycle lines this names which stage owns
+    // the arrival cadence.
+    auto encode_cycle_window_start = std::chrono::steady_clock::now();
+    std::uint64_t encode_cycle_pop_ns = 0, encode_cycle_convert_ns = 0, encode_cycle_encode_ns = 0, encode_cycle_encode_max_ns = 0;
+    std::uint32_t encode_cycle_frames = 0;
+
     while (true) {
       // Break out of the encoding loop if any of the following are true:
       // a) The stream is ending
@@ -2965,7 +2975,12 @@ namespace video {
 
       // Encode at a minimum FPS to avoid image quality issues with static content
       if (!requested_idr_frame || images->peek()) {
+        const auto encode_cycle_pop_started = std::chrono::steady_clock::now();
         if (auto img = images->pop(max_frametime)) {
+          const auto encode_cycle_popped = std::chrono::steady_clock::now();
+          encode_cycle_pop_ns += static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(encode_cycle_popped - encode_cycle_pop_started).count()
+          );
           placeholder_input = is_placeholder_capture_image(*img);
           if (!placeholder_input && bootstrap_state.current_input_placeholder) {
             session->request_idr_frame();
@@ -2975,6 +2990,9 @@ namespace video {
             BOOST_LOG(error) << "Could not convert image"sv;
             return;
           }
+          encode_cycle_convert_ns += static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - encode_cycle_popped).count()
+          );
 
           bootstrap_state.current_input_placeholder = placeholder_input;
           bootstrap_state.current_input_generation = img->capture_generation;
@@ -2998,9 +3016,27 @@ namespace video {
         continue;
       }
 
+      const auto encode_cycle_encode_started = std::chrono::steady_clock::now();
       if (encode(frame_nr++, *session, packets, channel_data, frame_timestamp, host_processing_timestamp, placeholder_input, bootstrap_state.current_input_generation)) {
         BOOST_LOG(error) << "Could not encode video packet"sv;
         return;
+      }
+      const auto encode_cycle_encode_done = std::chrono::steady_clock::now();
+      const auto encode_ns = static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(encode_cycle_encode_done - encode_cycle_encode_started).count()
+      );
+      encode_cycle_encode_ns += encode_ns;
+      encode_cycle_encode_max_ns = std::max(encode_cycle_encode_max_ns, encode_ns);
+      ++encode_cycle_frames;
+      if (encode_cycle_encode_done - encode_cycle_window_start >= 30s && encode_cycle_frames > 0) {
+        BOOST_LOG(info) << "Encode cycle: " << encode_cycle_frames << " frames in 30 s; avg ms: image-wait="
+                        << (encode_cycle_pop_ns / 1e6 / encode_cycle_frames) << " convert="
+                        << (encode_cycle_convert_ns / 1e6 / encode_cycle_frames) << " encode+deliver="
+                        << (encode_cycle_encode_ns / 1e6 / encode_cycle_frames) << " (encode+deliver max="
+                        << (encode_cycle_encode_max_ns / 1e6) << " ms).";
+        encode_cycle_window_start = encode_cycle_encode_done;
+        encode_cycle_pop_ns = encode_cycle_convert_ns = encode_cycle_encode_ns = encode_cycle_encode_max_ns = 0;
+        encode_cycle_frames = 0;
       }
 
       if (placeholder_input) {

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1786,6 +1786,18 @@ namespace video {
       }
     };
 
+    // Pool-starvation waits use the high-resolution timer: a plain 1 ms
+    // sleep in a process that has not raised its timer resolution costs a
+    // full timer quantum (15.6+ ms on Windows), and this wait sits on the
+    // capture hot path whenever the encode side holds every pooled surface.
+    // The aggregate is logged every 30 s so pool-bound capture cadence is
+    // visible in support bundles.
+    auto pool_wait_timer = platf::create_high_precision_timer();
+    std::chrono::nanoseconds pool_wait_window {};
+    std::uint32_t pool_wait_sleeps = 0;
+    auto pool_wait_last_log = std::chrono::steady_clock::now();
+    auto pool_wait_first_sleep = pool_wait_last_log;
+
     auto pull_free_image_callback = [&](std::shared_ptr<platf::img_t> &img_out) -> bool {
       img_out.reset();
       while (capture_ctx_queue->running()) {
@@ -1821,10 +1833,37 @@ namespace video {
           // trim allocated but unused portion of the pool based on timeouts
           trim_imgs();
           img_out->frame_timestamp.reset();
+          if (pool_wait_window > std::chrono::nanoseconds::zero()) {
+            const auto now = std::chrono::steady_clock::now();
+            if (now - pool_wait_last_log >= 30s) {
+              BOOST_LOG(info) << "Capture image pool: waited "
+                              << std::chrono::duration_cast<std::chrono::milliseconds>(pool_wait_window).count()
+                              << " ms across " << pool_wait_sleeps
+                              << " sleeps in the last "
+                              << std::chrono::duration_cast<std::chrono::seconds>(now - pool_wait_first_sleep).count()
+                              << " s (pool exhausted; encode side holding all surfaces).";
+              pool_wait_window = {};
+              pool_wait_sleeps = 0;
+              pool_wait_last_log = now;
+            }
+          }
           return true;
         } else {
           // sleep and retry if image pool is full
-          std::this_thread::sleep_for(1ms);
+          const auto wait_started = std::chrono::steady_clock::now();
+          if (pool_wait_sleeps == 0) {
+            // Anchor the log window at the first starvation sleep so a
+            // long-quiet stream cannot report "waited 40 ms in the last
+            // 3600 s".
+            pool_wait_first_sleep = wait_started;
+          }
+          if (pool_wait_timer && *pool_wait_timer) {
+            pool_wait_timer->sleep_for(1ms);
+          } else {
+            std::this_thread::sleep_for(1ms);
+          }
+          pool_wait_window += std::chrono::steady_clock::now() - wait_started;
+          ++pool_wait_sleeps;
         }
       }
       return false;


### PR DESCRIPTION
## Summary

Removes the hard ~21 fps arrival ceiling (and its 145–250 ms standing latency) on 4K HDR sessions. Root cause, proven by staged live measurement: on current Windows 11 Canary builds, **any timed wait that expires costs a full ~15.6 ms timer quantum** — timer-resolution raises and the power-throttling opt-out are silently ignored — while notify-driven CV wakes stay at ~0.02 ms and `CREATE_WAITABLE_TIMER_HIGH_RESOLUTION` timers remain sub-millisecond. Two hot loops each stacked three quanta per frame (3 × 15.6 ≈ 47 ms → 21.3 fps):

1. **Capture** (commit 2): the VGD ring claim poll and image-pool wait used plain 1 ms sleeps → high-resolution-timer polls.
2. **Worker egress** (commit 5): three sideband `pop(0ms)` event checks burned a quantum each when empty, backpressuring the encoder through the depth-2 packet queue → `peek()` guards.

## Commits

- **Worker timing profile + quantum probes** — resolution raise, throttling opt-out, HIGH_PRIORITY_CLASS parity; both processes log their measured sleep quantum at startup.
- **Capture polls + cadence telemetry + reinit reasons** — high-res-timer waits; `LuminalVGD capture cadence` (published-vs-claimed) line; the silent factory-stale reinit now logs its trigger.
- **Per-stage cycle telemetry** — encode / NvEnc phases / egress / broadcast 30 s breakdowns; the instrumentation that exonerated NVENC (4.7 ms real) and convicted the egress waits.
- **Stream-ordered CUDA interop (yuv444 10-bit)** — non-blocking stream + `cuStreamQuery` polling, 1 s bounded deadline into the normal reinit path, full synchronous fallback; adversarially reviewed (GO).
- **Egress peek-guards + 4 MiB video pipe** — the fix, plus decoupling the 64 KiB pipe (<2 encoded frames) from the drain cadence.

## Verification (field host, Mac client, 3456×2160@120 4:4:4 10-bit HDR)

| | before | after |
|---|---|---|
| fps arrived | 21 | **119** (sustained) |
| capture-to-send age | 145 ms avg | **6 ms avg / 14 ms max** |
| encode+deliver | 46.8 ms | 4.7 ms |

`test_sunshine`: 622 passed, identical to main's baseline (same 9 pre-existing failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)