### PR TITLE
MSI oracle: normalize Upgrade-table version fields

### DIFF
--- a/scripts/diff_msi_tables.py
+++ b/scripts/diff_msi_tables.py
@@ -160,6 +160,27 @@ def normalize_table(name: str, rows: "list[str]") -> "list[str]":
     if name in _WEB_ASSET_TABLES:
         return sorted(_normalize_web_asset_row(row) for row in rows)
 
+    if name == "Upgrade":
+        # The Upgrade table's VersionMin/VersionMax cells carry the
+        # ProductVersion (WiX MajorUpgrade emits VersionMax=<current> for
+        # WIX_UPGRADE_DETECTED and VersionMin=<current> for
+        # WIX_DOWNGRADE_DETECTED), so they legitimately change on every
+        # release — the same volatility class as ProductVersion, which the
+        # oracle already normalizes. Enforcing them byte-identically made
+        # the gate fail on the first version bump after it went hard
+        # (26.08.2 baseline vs 26.08.3 candidate, run 31690595030).
+        # UpgradeCode, Attributes, Language, Remove and ActionProperty stay
+        # enforced here, and the invariants gate independently asserts the
+        # UpgradeCode value itself.
+        normalized = []
+        for row in rows:
+            cells = _row_to_dict(row)
+            for cell in ("VersionMin", "VersionMax"):
+                if cells.get(cell):
+                    cells[cell] = "#PRODUCTVERSION#"
+            normalized.append("|".join(f"{k}={v}" for k, v in cells.items()))
+        return sorted(normalized)
+
     # Default: faithful, order-insensitive comparison.
     return sorted(rows)
 


### PR DESCRIPTION
## Summary

The MSI upgrade-compatibility oracle enforces the `Upgrade` table byte-identically, but that table's `VersionMin`/`VersionMax` cells carry the ProductVersion (WiX MajorUpgrade's upgrade/downgrade detection rows). They change on every version bump — the same volatility class as `ProductVersion`, which the oracle already normalizes per its README. Result: the first release attempt after the gate went hard ([run 31690595030](https://github.com/NortheBridge/luminalshine/actions/runs/31690595030), 26.08.3) failed diffing the 26.08.2 baseline's version digits, and every future release would too. Re-baselining per release would defeat the oracle.

This normalizes only those two cells to `#PRODUCTVERSION#`. UpgradeCode, Attributes, Language, Remove, and ActionProperty stay enforced in the diff, and the downstream MSI invariants gate independently asserts the UpgradeCode value regardless of the snapshot.

## Verification (against the committed baseline)

- Original differ reproduces the release failure on the 26.08.2→26.08.3 bump (4 rows).
- Fixed differ: same bump passes with 0 differences.
- Still caught: mutated UpgradeCode, mutated ActionProperty, mutated Attributes, dropped Upgrade row.

Unblocks the 26.08.3 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)