### PR TITLE
fix(video): skip unsupported NVIDIA AV1 probing

### DIFF
--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -21,6 +21,7 @@ extern "C" {
 #include "misc.h"
 #include "src/config.h"
 #include "src/gpu_recovery_policy.h"
+#include "src/platform/windows/nvidia_codec_support.h"
 #include "src/logging.h"
 #include "src/nvenc/nvenc_config.h"
 #include "src/nvenc/nvenc_d3d11_native.h"
@@ -2044,6 +2045,14 @@ namespace platf::dxgi {
     } else if (adapter_desc.VendorId == 0x10de) {  // Nvidia
       // If it's not an NVENC encoder, it's not compatible with an Nvidia GPU
       if (!boost::algorithm::ends_with(name, "_nvenc")) {
+        return false;
+      }
+      // Ampere (including the RTX 3080 Ti) supports AV1 decoding but not
+      // AV1 encoding. Avoid entering the NVENC AV1 probe at all: the driver
+      // rejects the codec during encoder creation, and that rejection can
+      // escalate through the Windows terminate/SEH crash path.
+      if (config.videoFormat == 2 && !nvidia::supports_av1_encode(adapter_desc.DeviceId)) {
+        BOOST_LOG(info) << "AV1 encoding is not supported by this NVIDIA GPU; skipping " << name;
         return false;
       }
     } else if (adapter_desc.VendorId == 0x4D4F4351 ||  // Qualcomm (QCOM as MOQC reversed)

--- a/src/platform/windows/nvidia_codec_support.h
+++ b/src/platform/windows/nvidia_codec_support.h
@@ -1,0 +1,22 @@
+/**
+ * @file src/platform/windows/nvidia_codec_support.h
+ * @brief Conservative NVIDIA codec-generation capability checks.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace platf::nvidia {
+
+  /**
+   * NVIDIA Ampere (RTX 30 / GA10x) exposes AV1 decode but not AV1 encode.
+   * Ada Lovelace and later generations expose AV1 encode. NVIDIA's PCI
+   * device-ID allocation places Ampere below 0x2680 and Ada at/above 0x2680.
+   * Keep this helper pure so the generation boundary is regression-tested
+   * without requiring a GPU or loading the NVENC DLL.
+   */
+  constexpr bool supports_av1_encode(std::uint32_t device_id) {
+    return device_id >= 0x2680;
+  }
+
+}  // namespace platf::nvidia

--- a/tests/unit/test_nvidia_codec_support.cpp
+++ b/tests/unit/test_nvidia_codec_support.cpp
@@ -1,0 +1,20 @@
+#include "src/platform/windows/nvidia_codec_support.h"
+
+#include <gtest/gtest.h>
+
+TEST(NvidiaCodecSupport, AmpereDoesNotAdvertiseAv1Encode) {
+  EXPECT_FALSE(platf::nvidia::supports_av1_encode(0x2208));  // RTX 3080 Ti
+}
+
+TEST(NvidiaCodecSupport, AdaAdvertisesAv1Encode) {
+  EXPECT_TRUE(platf::nvidia::supports_av1_encode(0x2684));  // RTX 4090
+  EXPECT_TRUE(platf::nvidia::supports_av1_encode(0x2704));  // RTX 4080
+}
+
+TEST(NvidiaCodecSupport, OlderGenerationsDoNotAdvertiseAv1Encode) {
+  EXPECT_FALSE(platf::nvidia::supports_av1_encode(0x1E04));  // RTX 2080 Ti
+}
+
+TEST(NvidiaCodecSupport, FutureDeviceIdsRemainEligible) {
+  EXPECT_TRUE(platf::nvidia::supports_av1_encode(0x2C02));
+}


### PR DESCRIPTION
## Summary

- Fixes the NVIDIA AV1 capability check on Windows.
- Prevents `av1_nvenc` probing on NVIDIA generations without AV1 encode support, including RTX 30/Ampere GPUs such as the RTX 3080 Ti.
- Preserves H.264/HEVC NVENC probing instead of allowing an unsupported AV1 probe to poison the aggregate NVENC result.
- Adds regression tests for Turing, Ampere, Ada, and future NVIDIA device-ID ranges.

Fixes #147

## Root cause

`display_vram_t::is_codec_supported()` previously checked only the NVIDIA vendor ID and the `_nvenc` suffix. It therefore reported `av1_nvenc` as potentially supported on every NVIDIA GPU. On an RTX 3080 Ti, the subsequent NVENC probe rejected AV1 and raised the `std::terminate`/SEH crash path during startup and stream initialization.

## Implementation

A pure, unit-tested NVIDIA generation gate is applied before entering the AV1 NVENC probe:

- Turing/Ampere and older: AV1 encode probing skipped.
- Ada and newer: AV1 probing remains enabled.

## Validation

- [x] Isolated C++ capability-gate smoke test passes.
- [x] Windows CI build passes.
- [x] Recursive submodule initialization passes.
- [x] Packaging passes.
- [x] New `NvidiaCodecSupport` tests pass: 4/4.
- [x] Config consistency gate passes.
- [x] Unsigned portable Windows ZIP produced.
- [x] Runtime validation completed on an RTX 3080 Ti with a real Moonlight client.
- [x] Stream initialization and repeated fallback/re-probe path validated.

The complete unsigned Windows validation run is available here:

https://github.com/magalz/luminalshine/actions/runs/32608687725

The portable artifact was downloaded from that run and tested locally.

## Runtime validation result

The patched build was tested on Windows 11 25H2 with an NVIDIA RTX 3080 Ti and a Moonlight client named `QUARTO` running on a TV.

The patched runtime repeatedly logged:

```text
AV1 encoding is not supported by this NVIDIA GPU; skipping av1_nvenc
Encoder [av1_nvenc] is not supported on this GPU
Found H.264 encoder: h264_nvenc [nvenc]
Found HEVC encoder: hevc_nvenc [nvenc]
```

This occurred during repeated encoder re-probes while the client was connected. No current-run occurrences of the following were observed:

```text
std::terminate
0xe04c5354
Couldn't find any working encoder matching [nvenc]
```

Moonlight connected successfully and streaming worked normally.

## Advisory CI tests

The workflow's full advisory test executable reported 12 environment-sensitive failures involving display/auth/Playnite/locale assumptions. The workflow explicitly uses `continue-on-error` for that suite because those tests are not reliable on a hosted runner. The reliable config-consistency gate passed, and all new capability tests passed.

## Diagnostic archive

The local runtime evidence came from:

```text
luminalshine_logs-20260822-224102.zip
```

The archive contains historical pre-fix logs as well as the patched runtime log. The decisive patched log is:

```text
sunshine-20260822-222712-866.log
```

Relevant patched runtime events occurred at 22:27:17, 22:38:44, and 22:39:54.

The full archive is retained locally by the reporter; the PR includes the relevant excerpts above to avoid publishing unrelated host/client diagnostic data.
