### PR TITLE
fix(nvenc): make teardown of a never-initialized session safe

### DIFF
--- a/src/crash_handler.cpp
+++ b/src/crash_handler.cpp
@@ -194,7 +194,8 @@ namespace crash_handler {
 
     [[noreturn]] void terminate_handler() {
       // Re-entry (e.g. the logging below itself throwing) falls through to
-      // an immediate abort rather than recursing.
+      // an immediate abort rather than recursing. The flag is cleared once
+      // the risky part is behind us — see the reset before RaiseException.
       if (InterlockedExchange(&g_terminate_in_progress, 1) != 0) {
         std::abort();
       }
@@ -231,6 +232,23 @@ namespace crash_handler {
                        << ". Raising exception 0x" << std::hex << kTerminateExceptionCode << std::dec
                        << " to capture a minidump.";
       logging::log_flush();
+
+      // Every step that could itself throw (std::current_exception, the
+      // stderr writes, BOOST_LOG, log_flush) is now behind us, so the
+      // re-entry guard has done its job and must be released.
+      //
+      // It has to be released *here* rather than on the way out because
+      // RaiseException does not return: a caller that absorbs
+      // kTerminateExceptionCode — video::validate_encoder_safe's __except is
+      // the one that matters -- resumes in its own handler and this function
+      // never unwinds. Leaving the flag latched turned the second terminate
+      // anywhere in the process into a bare std::abort(): no fatal log line,
+      // no minidump, and on a SYSTEM service that reads as a silent
+      // disappearance. That is why issue #147 survived the startup encoder
+      // probe but killed the process outright when the probe re-ran at stream
+      // init — the probe is re-run on every launch and resume, and negative
+      // results are deliberately not cached.
+      InterlockedExchange(&g_terminate_in_progress, 0);
 
       // Route through the SEH filter above so the abort produces the same
       // fatal log line + minidump a hardware fault would.

--- a/src/nvenc/nvenc_base.cpp
+++ b/src/nvenc/nvenc_base.cpp
@@ -198,7 +198,21 @@ namespace nvenc {
     if (encoder) {
       destroy_encoder();
     }
+    encoder_initialized = false;
     auto fail_guard = util::fail_guard([this] {
+      if (encoder && !encoder_initialized) {
+        // The session was opened but nvEncInitializeEncoder() never succeeded,
+        // so nothing was ever registered against it. Running the general
+        // teardown here would call nvEncUnregisterAsyncEvent() on a handle that
+        // has no async event; some NVIDIA driver branches answer that invalid
+        // sequence with a non-C++ exception, and because ~FailGuard is noexcept
+        // it becomes std::terminate and kills the process instead of failing
+        // the probe. That is the crash behind issue #147 (av1_nvenc on Ampere,
+        // where the AV1 codec GUID is correctly absent and create_encoder
+        // returns early).
+        discard_uninitialized_session();
+        return;
+      }
       destroy_encoder();
     });
 
@@ -791,6 +805,11 @@ namespace nvenc {
       }
     }
 
+    // Past this point the driver owns a live, initialized session: the async
+    // event and the input/output resources below are registered against it, so
+    // teardown must go through the full destroy_encoder() sequence.
+    encoder_initialized = true;
+
     if (async_event_handle) {
       NV_ENC_EVENT_PARAMS event_params = {api::event_params_version(selected_api_version)};
       event_params.completionEvent = async_event_handle;
@@ -897,6 +916,21 @@ namespace nvenc {
       nvenc->nvEncDestroyEncoder(encoder);
       encoder = nullptr;
     }
+    encoder_initialized = false;
+  }
+
+  void nvenc_base::discard_uninitialized_session() {
+    if (encoder) {
+      if (nvenc_failed(nvenc->nvEncDestroyEncoder(encoder))) {
+        BOOST_LOG(warning) << "NvEnc: NvEncDestroyEncoder() failed while discarding a session "
+                              "that was never initialized: " << last_nvenc_error_string;
+      }
+      encoder = nullptr;
+    }
+    encoder_initialized = false;
+    encoder_state = {};
+    encoder_params = {};
+    selected_api_version = 0;
   }
 
   void nvenc_base::destroy_output_buffer() {
@@ -1036,6 +1070,7 @@ namespace nvenc {
       encoder = nullptr;
     }
 
+    encoder_initialized = false;
     encoder_state = {};
     encoder_params = {};
     selected_api_version = 0;

--- a/src/nvenc/nvenc_base.h
+++ b/src/nvenc/nvenc_base.h
@@ -105,6 +105,27 @@ namespace nvenc {
     virtual void cleanup_rejected_initialize();
 
     /**
+     * @brief Close a session that was opened but never initialized.
+     *
+     * `nvEncOpenEncodeSessionEx()` succeeded but `nvEncInitializeEncoder()`
+     * was never *reached* — a codec or capability check rejected the request
+     * first — so no async event and no input/output resources were ever
+     * registered against the handle. `destroy_encoder()` would still call
+     * `nvEncUnregisterAsyncEvent()` on it, because `async_event_handle` is
+     * created by the `nvenc_d3d11` constructor that `nvenc_d3d12` also
+     * inherits, and some NVIDIA driver branches answer that invalid cleanup
+     * sequence with a non-C++ exception. Destroying the handle directly is the
+     * documented counterpart to `nvEncOpenEncodeSessionEx()` and is all such a
+     * session needs.
+     *
+     * Distinct from `cleanup_rejected_initialize()`, which handles a session
+     * whose `nvEncInitializeEncoder()` was *called and rejected* — a state the
+     * D3D12 backend must additionally respond to by disabling itself for the
+     * rest of the process. Nothing is rejected here, so that must not happen.
+     */
+    void discard_uninitialized_session();
+
+    /**
      * @brief Optional. Override if you must perform additional operations on the registered input surface in the beginning of `encode_frame()`.
      *        Typically used for interop copy.
      * @return `true` on success, `false` on error
@@ -215,6 +236,17 @@ namespace nvenc {
     const NV_ENC_DEVICE_TYPE device_type;
 
     void *encoder = nullptr;
+
+    /**
+     * @brief Whether `nvEncInitializeEncoder()` has succeeded on `encoder`.
+     *
+     * Separates a fully-live session from one that has only been opened with
+     * `nvEncOpenEncodeSessionEx()`. The two require different teardowns: an
+     * uninitialized session has no async event and no registered input/output
+     * resources, so the general `destroy_encoder()` sequence is invalid for
+     * it. See `discard_uninitialized_session()`.
+     */
+    bool encoder_initialized = false;
 
     struct {
       uint32_t width = 0;

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -21,13 +21,13 @@ extern "C" {
 #include "misc.h"
 #include "src/config.h"
 #include "src/gpu_recovery_policy.h"
-#include "src/platform/windows/nvidia_codec_support.h"
 #include "src/logging.h"
 #include "src/nvenc/nvenc_config.h"
 #include "src/nvenc/nvenc_d3d11_native.h"
 #include "src/nvenc/nvenc_d3d12.h"
 #include "src/nvenc/nvenc_d3d11_on_cuda.h"
 #include "src/nvenc/nvenc_utils.h"
+#include "src/platform/windows/nvidia_codec_support.h"
 #include "src/platform/windows/virtual_display_vgd.h"
 #include "src/video.h"
 #include "utf_utils.h"
@@ -2047,12 +2047,23 @@ namespace platf::dxgi {
       if (!boost::algorithm::ends_with(name, "_nvenc")) {
         return false;
       }
-      // Ampere (including the RTX 3080 Ti) supports AV1 decoding but not
-      // AV1 encoding. Avoid entering the NVENC AV1 probe at all: the driver
-      // rejects the codec during encoder creation, and that rejection can
-      // escalate through the Windows terminate/SEH crash path.
+      // Ampere (including the RTX 3080 Ti) supports AV1 decoding but not AV1
+      // encoding, so skip the AV1 NVENC probe on pre-Ada parts rather than
+      // opening an encode session the driver can only reject.
+      //
+      // This is an optimisation, not the crash guard it was originally
+      // written as. The rejection itself was always correct and graceful
+      // (nvenc_base::create_encoder queries nvEncGetEncodeGUIDs and returns
+      // early); what crashed in issue #147 was the teardown afterwards, which
+      // unregistered resources that had never been registered. That is fixed
+      // at the source in nvenc_base::discard_uninitialized_session(), and it
+      // covers the configurations no device-ID table can enumerate — HEVC on
+      // pre-Kepler parts, 10-bit on Pascal, unsupported resolutions, and the
+      // YUV444 rejection the probe provokes deliberately on every run.
+      //
+      // Logged at debug because the probe re-runs on every launch and resume.
       if (config.videoFormat == 2 && !nvidia::supports_av1_encode(adapter_desc.DeviceId)) {
-        BOOST_LOG(info) << "AV1 encoding is not supported by this NVIDIA GPU; skipping " << name;
+        BOOST_LOG(debug) << "AV1 encoding is not supported by this NVIDIA GPU; skipping " << name;
         return false;
       }
     } else if (adapter_desc.VendorId == 0x4D4F4351 ||  // Qualcomm (QCOM as MOQC reversed)

--- a/src/platform/windows/nvidia_codec_support.h
+++ b/src/platform/windows/nvidia_codec_support.h
@@ -9,14 +9,49 @@
 namespace platf::nvidia {
 
   /**
-   * NVIDIA Ampere (RTX 30 / GA10x) exposes AV1 decode but not AV1 encode.
-   * Ada Lovelace and later generations expose AV1 encode. NVIDIA's PCI
-   * device-ID allocation places Ampere below 0x2680 and Ada at/above 0x2680.
-   * Keep this helper pure so the generation boundary is regression-tested
-   * without requiring a GPU or loading the NVENC DLL.
+   * @brief First NVIDIA PCI device ID belonging to an AV1-encode generation.
+   *
+   * Ampere (RTX 30 / GA10x) exposes AV1 *decode* but not AV1 *encode*; Ada
+   * Lovelace and later expose both. Observed allocation either side of this
+   * boundary, checked against pciutils `pci.ids`:
+   *
+   *   - highest Ampere display part: 0x25FB (RTX A500 Embedded)
+   *   - 0x2600-0x267F: unallocated
+   *   - lowest Ada part:              0x2681 (TITAN Ada)
+   *   - lowest shipping Ada part:     0x2684 (RTX 4090)
+   *
+   * Note the margin below the boundary is a single device ID. That ordering
+   * is an observed NVIDIA convention, not a documented contract, so this is
+   * deliberately a `>=` test rather than an enumerated allowlist: an ID above
+   * the boundary that turns out to lack AV1 encode still degrades gracefully
+   * (the NVENC codec-GUID query rejects it and the probe moves on), whereas an
+   * allowlist that has not been taught about a newly-released GPU would deny
+   * AV1 to hardware that supports it. Prefer the failure that costs nothing.
+   *
+   * Known parts on the wrong side of that trade, all of them unreachable via
+   * DXGI display-adapter enumeration in practice: datacenter Blackwell
+   * (GB100/GB110, 0x2900-0x31FE) and Rubin (0x3000+) carry no NVENC at all,
+   * and Jetson AGX Thor (0x2B00) had its AV1 encoder removed in hardware.
+   */
+  inline constexpr std::uint32_t kFirstAv1EncodeDeviceId = 0x2680;
+
+  /**
+   * @brief Whether an NVIDIA GPU's PCI device ID belongs to a generation with
+   *        hardware AV1 encode.
+   *
+   * This is a fast path, not a safety guard: it keeps a codec the GPU is known
+   * not to have out of the encoder probe, sparing the probe an encode session
+   * that can only be rejected. Correctness does not depend on it — NVENC is
+   * asked directly via `nvEncGetEncodeGUIDs()` before any encoder is created,
+   * and that query is authoritative for driver-level support this table cannot
+   * see (a new GPU on an old driver, for instance).
+   *
+   * Kept pure so the boundary is regression-tested without a GPU or the NVENC
+   * DLL. The caller supplies `DXGI_ADAPTER_DESC::DeviceId` and is responsible
+   * for having already matched NVIDIA's vendor ID (0x10DE).
    */
   constexpr bool supports_av1_encode(std::uint32_t device_id) {
-    return device_id >= 0x2680;
+    return device_id >= kFirstAv1EncodeDeviceId;
   }
 
 }  // namespace platf::nvidia

--- a/tests/unit/test_nvenc_uninitialized_teardown.cpp
+++ b/tests/unit/test_nvenc_uninitialized_teardown.cpp
@@ -1,0 +1,185 @@
+/**
+ * @file tests/unit/test_nvenc_uninitialized_teardown.cpp
+ * @brief Teardown of an NVENC session that was opened but never initialized.
+ *
+ * Regression coverage for issue #147. nvenc_base::create_encoder() opens an
+ * encode session before it knows whether the GPU supports the requested
+ * codec. When a capability check then rejects the request -- AV1 on Ampere,
+ * HEVC on pre-Kepler parts, 10-bit on Pascal, an oversized resolution, or the
+ * YUV444 rejection the encoder probe provokes deliberately on every run —
+ * create_encoder returns early with the session open and *nothing registered
+ * against it*.
+ *
+ * The general destroy_encoder() sequence is invalid for that state: it calls
+ * nvEncUnregisterAsyncEvent() on a handle that never registered an async
+ * event. async_event_handle is created by the nvenc_d3d11 constructor, which
+ * nvenc_d3d12 inherits, so this fired on the native D3D12 path too. Some
+ * NVIDIA driver branches answer that invalid sequence with a non-C++
+ * exception; because ~FailGuard is noexcept it became std::terminate and took
+ * the whole process down instead of just failing the probe.
+ *
+ * These tests pin the distinction between the three teardowns and need no
+ * GPU: the NVENC entry points are stubbed and only record that they ran.
+ */
+
+// standard includes
+#include <cstdint>
+
+// lib includes
+#include <gtest/gtest.h>
+
+// local includes
+#include "../tests_common.h"
+#include "src/nvenc/nvenc_base.h"
+
+namespace {
+
+  /// Recorded NVENC entry-point traffic for one test.
+  struct call_log_t {
+    int destroy_encoder = 0;
+    int unregister_async_event = 0;
+    int unregister_resource = 0;
+  };
+
+  call_log_t g_calls;
+
+  NVENCSTATUS NVENCAPI stub_destroy_encoder(void *) {
+    ++g_calls.destroy_encoder;
+    return NV_ENC_SUCCESS;
+  }
+
+  NVENCSTATUS NVENCAPI stub_unregister_async_event(void *, NV_ENC_EVENT_PARAMS *) {
+    ++g_calls.unregister_async_event;
+    return NV_ENC_SUCCESS;
+  }
+
+  NVENCSTATUS NVENCAPI stub_unregister_resource(void *, NV_ENC_REGISTERED_PTR) {
+    ++g_calls.unregister_resource;
+    return NV_ENC_SUCCESS;
+  }
+
+  /// A minimal concrete nvenc_base that talks to the stubs above.
+  class stub_nvenc: public nvenc::nvenc_base {
+  public:
+    stub_nvenc():
+        nvenc_base(NV_ENC_DEVICE_TYPE_DIRECTX) {
+      auto fns = std::make_shared<NV_ENCODE_API_FUNCTION_LIST>();
+      *fns = {};
+      fns->nvEncDestroyEncoder = stub_destroy_encoder;
+      fns->nvEncUnregisterAsyncEvent = stub_unregister_async_event;
+      fns->nvEncUnregisterResource = stub_unregister_resource;
+      nvenc = std::move(fns);
+    }
+
+    /// Put the object into the state create_encoder() leaves behind when a
+    /// capability check rejects the request before NvEncInitializeEncoder.
+    void simulate_opened_session() {
+      encoder = reinterpret_cast<void *>(0xDEADBEEF);
+      async_event_handle = reinterpret_cast<void *>(0xFEEDFACE);
+      encoder_initialized = false;
+    }
+
+    /// Put the object into the state a live, fully-registered session has.
+    void simulate_live_session() {
+      simulate_opened_session();
+      encoder_initialized = true;
+    }
+
+    bool is_initialized() const {
+      return encoder_initialized;
+    }
+
+    bool has_encoder() const {
+      return encoder != nullptr;
+    }
+
+    using nvenc_base::cleanup_rejected_initialize;
+    using nvenc_base::destroy_encoder;
+    using nvenc_base::discard_uninitialized_session;
+
+  private:
+    bool init_library(uint32_t) override {
+      return true;
+    }
+
+    bool create_and_register_input_buffer() override {
+      return true;
+    }
+  };
+
+  class NvencUninitializedTeardown: public ::testing::Test {
+  protected:
+    void SetUp() override {
+      g_calls = {};
+    }
+  };
+
+  TEST_F(NvencUninitializedTeardown, DiscardSkipsTheUnregisterCallsAndClosesTheHandle) {
+    // The whole point: an opened-but-uninitialized session must be closed
+    // with nvEncDestroyEncoder() alone. Unregistering an async event that was
+    // never registered is what the driver faulted on.
+    stub_nvenc enc;
+    enc.simulate_opened_session();
+
+    enc.discard_uninitialized_session();
+
+    EXPECT_EQ(g_calls.unregister_async_event, 0);
+    EXPECT_EQ(g_calls.unregister_resource, 0);
+    EXPECT_EQ(g_calls.destroy_encoder, 1);
+    EXPECT_FALSE(enc.has_encoder());
+    EXPECT_FALSE(enc.is_initialized());
+  }
+
+  TEST_F(NvencUninitializedTeardown, DiscardIsIdempotent) {
+    // create_encoder's fail_guard can run after a path that already cleaned
+    // up; a second pass must not double-destroy the handle.
+    stub_nvenc enc;
+    enc.simulate_opened_session();
+
+    enc.discard_uninitialized_session();
+    enc.discard_uninitialized_session();
+
+    EXPECT_EQ(g_calls.destroy_encoder, 1);
+  }
+
+  TEST_F(NvencUninitializedTeardown, LiveSessionStillGetsTheFullTeardown) {
+    // The fix must not weaken cleanup for a session that really did register
+    // an async event -- that would leak driver resources.
+    stub_nvenc enc;
+    enc.simulate_live_session();
+
+    enc.destroy_encoder();
+
+    EXPECT_EQ(g_calls.unregister_async_event, 1);
+    EXPECT_EQ(g_calls.destroy_encoder, 1);
+    EXPECT_FALSE(enc.has_encoder());
+    EXPECT_FALSE(enc.is_initialized());
+  }
+
+  TEST_F(NvencUninitializedTeardown, RejectedInitializeRemainsASeparatePath) {
+    // cleanup_rejected_initialize() handles a session whose
+    // NvEncInitializeEncoder was called *and rejected*. The D3D12 backend
+    // overrides it to disable itself for the rest of the process, so the
+    // uninitialized case must never be routed through it — doing so would
+    // drop every host to the D3D11 transport the first time the encoder
+    // probe made its routine YUV444 attempt.
+    stub_nvenc enc;
+    enc.simulate_opened_session();
+
+    enc.cleanup_rejected_initialize();
+
+    EXPECT_EQ(g_calls.unregister_async_event, 0);
+    EXPECT_EQ(g_calls.destroy_encoder, 1);
+    EXPECT_FALSE(enc.has_encoder());
+  }
+
+  TEST_F(NvencUninitializedTeardown, TeardownOfANeverOpenedSessionIsANoOp) {
+    stub_nvenc enc;
+
+    enc.discard_uninitialized_session();
+
+    EXPECT_EQ(g_calls.destroy_encoder, 0);
+    EXPECT_EQ(g_calls.unregister_async_event, 0);
+  }
+
+}  // namespace

--- a/tests/unit/test_nvidia_codec_support.cpp
+++ b/tests/unit/test_nvidia_codec_support.cpp
@@ -1,20 +1,99 @@
-#include "src/platform/windows/nvidia_codec_support.h"
+/**
+ * @file tests/unit/test_nvidia_codec_support.cpp
+ * @brief Test the NVIDIA AV1-encode generation gate.
+ *
+ * The gate keeps a codec the GPU is known not to have out of the encoder
+ * probe. It is a fast path, not a safety guard -- NVENC is still asked
+ * directly via nvEncGetEncodeGUIDs() before any encoder is created -- so
+ * these tests pin the boundary and, just as importantly, pin which way it
+ * fails when it is wrong.
+ */
 
+// standard includes
+#include <cstdint>
+
+// lib includes
 #include <gtest/gtest.h>
 
-TEST(NvidiaCodecSupport, AmpereDoesNotAdvertiseAv1Encode) {
-  EXPECT_FALSE(platf::nvidia::supports_av1_encode(0x2208));  // RTX 3080 Ti
-}
+// local includes
+#include "../tests_common.h"
+#include "src/platform/windows/nvidia_codec_support.h"
 
-TEST(NvidiaCodecSupport, AdaAdvertisesAv1Encode) {
-  EXPECT_TRUE(platf::nvidia::supports_av1_encode(0x2684));  // RTX 4090
-  EXPECT_TRUE(platf::nvidia::supports_av1_encode(0x2704));  // RTX 4080
-}
+namespace {
 
-TEST(NvidiaCodecSupport, OlderGenerationsDoNotAdvertiseAv1Encode) {
-  EXPECT_FALSE(platf::nvidia::supports_av1_encode(0x1E04));  // RTX 2080 Ti
-}
+  using platf::nvidia::kFirstAv1EncodeDeviceId;
+  using platf::nvidia::supports_av1_encode;
 
-TEST(NvidiaCodecSupport, FutureDeviceIdsRemainEligible) {
-  EXPECT_TRUE(platf::nvidia::supports_av1_encode(0x2C02));
-}
+  TEST(NvidiaCodecSupport, AmpereDoesNotAdvertiseAv1Encode) {
+    // Issue #147 was reported on the RTX 3080 Ti. Ampere has AV1 decode only.
+    EXPECT_FALSE(supports_av1_encode(0x2208));  // RTX 3080 Ti (GA102)
+    EXPECT_FALSE(supports_av1_encode(0x2204));  // RTX 3090   (GA102)
+    EXPECT_FALSE(supports_av1_encode(0x2484));  // RTX 3070   (GA104)
+    EXPECT_FALSE(supports_av1_encode(0x2503));  // RTX 3060   (GA106)
+    EXPECT_FALSE(supports_av1_encode(0x25FB));  // RTX A500 Embedded — highest Ampere display part
+  }
+
+  TEST(NvidiaCodecSupport, AdaAdvertisesAv1Encode) {
+    EXPECT_TRUE(supports_av1_encode(0x2684));  // RTX 4090 (AD102)
+    EXPECT_TRUE(supports_av1_encode(0x2704));  // RTX 4080 (AD103)
+    EXPECT_TRUE(supports_av1_encode(0x2782));  // RTX 4070 Ti (AD104)
+  }
+
+  TEST(NvidiaCodecSupport, AdaWorkstationAndDatacenterPartsAdvertiseAv1Encode) {
+    // These sit just above the boundary and are easy to strand by mistake.
+    EXPECT_TRUE(supports_av1_encode(0x26B1));  // RTX 6000 Ada
+    EXPECT_TRUE(supports_av1_encode(0x26B5));  // L40
+    EXPECT_TRUE(supports_av1_encode(0x27B8));  // L4
+    EXPECT_TRUE(supports_av1_encode(0x27B2));  // RTX 4000 Ada
+  }
+
+  TEST(NvidiaCodecSupport, AdaLaptopPartsWithAmpereBrandingAdvertiseAv1Encode) {
+    // "RTX 3050 A Laptop" is 30-series *branding* on Ada AD106/AD107 silicon
+    // and does have AV1 encode. A marketing-name check would get these wrong;
+    // the device ID gets them right.
+    EXPECT_TRUE(supports_av1_encode(0x2822));
+    EXPECT_TRUE(supports_av1_encode(0x28A3));
+  }
+
+  TEST(NvidiaCodecSupport, OlderGenerationsDoNotAdvertiseAv1Encode) {
+    EXPECT_FALSE(supports_av1_encode(0x1E04));  // RTX 2080 Ti (Turing TU102)
+    EXPECT_FALSE(supports_av1_encode(0x2182));  // GTX 1660 Ti (Turing TU116)
+    EXPECT_FALSE(supports_av1_encode(0x1B80));  // GTX 1080    (Pascal GP104)
+    EXPECT_FALSE(supports_av1_encode(0x13C0));  // GTX 980     (Maxwell GM204)
+  }
+
+  TEST(NvidiaCodecSupport, BoundaryIsExactAndTight) {
+    // The gap below the boundary is a single device ID: 0x2600-0x267F is
+    // unallocated, the highest Ampere part is 0x25FB and the lowest Ada part
+    // is 0x2681 (TITAN Ada). If either edge ever moves, this fails first.
+    EXPECT_EQ(kFirstAv1EncodeDeviceId, 0x2680u);
+    EXPECT_FALSE(supports_av1_encode(kFirstAv1EncodeDeviceId - 1));
+    EXPECT_TRUE(supports_av1_encode(kFirstAv1EncodeDeviceId));
+    EXPECT_TRUE(supports_av1_encode(0x2681));  // TITAN Ada — lowest known Ada
+  }
+
+  TEST(NvidiaCodecSupport, UnknownFutureDeviceIdsFailOpen) {
+    // Deliberate: an unrecognised high ID is treated as AV1-capable so a GPU
+    // released after this code was written is not denied a codec it has. If
+    // the guess is wrong the NVENC codec-GUID query rejects it and the probe
+    // moves on, which since the create_encoder teardown fix costs nothing.
+    //
+    // The known cost of failing open, all unreachable through DXGI display
+    // adapter enumeration in practice: datacenter parts carrying no NVENC at
+    // all, and Jetson Thor, whose AV1 encoder was removed in hardware.
+    EXPECT_TRUE(supports_av1_encode(0x2C02));  // RTX 5080 (GB203) — correct
+    EXPECT_TRUE(supports_av1_encode(0x2B85));  // RTX 5090 (GB202) — correct
+    EXPECT_TRUE(supports_av1_encode(0x2901));  // B200-class — no NVENC; accepted
+    EXPECT_TRUE(supports_av1_encode(0x2B00));  // Jetson AGX Thor — accepted
+    EXPECT_TRUE(supports_av1_encode(0xFFFFFFFFu));
+  }
+
+  TEST(NvidiaCodecSupport, IsUsableInConstantExpressions) {
+    // The gate is consulted on every probe pass; keeping it constexpr keeps
+    // it free and keeps it testable without a GPU.
+    static_assert(!supports_av1_encode(0x2208), "Ampere must not claim AV1 encode");
+    static_assert(supports_av1_encode(0x2684), "Ada must claim AV1 encode");
+    SUCCEED();
+  }
+
+}  // namespace


### PR DESCRIPTION
## Summary

Follow-up to #156. That PR stopped the `av1_nvenc` crash on Ampere by keeping AV1 out of the encoder probe, which works and is worth keeping — but it treats one instance of a general defect. This fixes the defect itself, so the remaining reachable variants stop crashing too.

Three changes, in descending order of importance:

1. **The actual crash**: teardown of an NVENC session that was opened but never initialized.
2. **The silent-death amplifier**: the terminate handler's re-entry guard was a one-shot that was never cleared.
3. **Hardening of the #156 gate itself**: named constant, honest documentation, corrected comment, log level.

## 1. Root cause of #147

The AV1 rejection was never the bug. `nvenc_base::create_encoder()` already asks the driver properly:

```cpp
// src/nvenc/nvenc_base.cpp
if (std::find_if(encode_guids.begin(), encode_guids.end(), search_predicate) == encode_guids.end()) {
  BOOST_LOG(error) << "NvEnc: encoding format is not supported by the gpu";
  return false;
}
```

That log line in #147 **is that check working correctly**. The `std::terminate` fires afterwards, on the way out.

`create_encoder` opens an encode session before it knows whether the GPU supports the request. On an early rejection it returns with the session open and *nothing registered against it*, and its `fail_guard` ran the general `destroy_encoder()` sequence — which calls `nvEncUnregisterAsyncEvent()` on a handle that never registered an async event. `async_event_handle` is created by the `nvenc_d3d11` constructor, and `nvenc_d3d12` inherits it, so this fired on the native D3D12 path too. Some NVIDIA driver branches answer that invalid sequence with a non-C++ exception. `~FailGuard` is `noexcept`, so it became `std::terminate` and took the process down instead of failing the probe.

The codebase already documents this exact driver fault, in `nvenc_d3d12::cleanup_rejected_initialize()` — but that helper was wired to only the post-`InitializeEncoder` failure paths. Every earlier return bypassed it.

**Fix**: track whether `nvEncInitializeEncoder` succeeded, and route the uninitialized case through a new `discard_uninitialized_session()` that closes the handle with `nvEncDestroyEncoder()` alone.

### Configurations this also fixes

All were reachable on shipping hardware before this change, and none are covered by a device-ID table:

| Trigger | Where |
|---|---|
| HEVC on a GPU without HEVC encode (Kepler GK104, Maxwell-gen1 GM107) | same codec-GUID check |
| Requested resolution above `NV_ENC_CAPS_WIDTH_MAX/HEIGHT_MAX` | resolution cap check |
| 10-bit/HDR on Pascal and older (`prefer_10bit_sdr` included) | `SUPPORT_10BIT_ENCODE` |
| **YUV444 — the probe provokes this deliberately on every run** | `SUPPORT_YUV444_ENCODE` |
| RFI / weighted-prediction cap query failure | cap checks |
| Preset config rejection | `nvEncGetEncodePresetConfig` |

### What this deliberately does *not* do

It does **not** route the uninitialized case through `cleanup_rejected_initialize()`. That helper handles a session whose `InitializeEncoder` was *called and rejected*, and the D3D12 backend overrides it to set `d3d12_nvenc_rejected` — disabling the native D3D12 path for the rest of the process. Reusing it here would have dropped every host to the D3D11 transport the first time the encoder probe made its routine YUV444 attempt. `NvencUninitializedTeardown.RejectedInitializeRemainsASeparatePath` pins that distinction.

## 2. The terminate handler's one-shot guard

`g_terminate_in_progress` was set on entry and never cleared. First `std::terminate` → fatal log + minidump. Every later one → bare `std::abort()`: no log, no dump, and on a SYSTEM service that reads as the process simply vanishing.

This is why #147 was survivable at startup but killed `sunshine.exe` outright at stream init. The probe re-runs on every launch and resume, and negative results are deliberately not cached.

The guard is now released once the throwing-capable work (`std::current_exception`, the stderr writes, `BOOST_LOG`, `log_flush`) is done — immediately before `RaiseException`, because that call does not return when a caller absorbs the code, which is exactly what `video::validate_encoder_safe`'s `__except` does. The recursion protection the guard was written for is unchanged.

## 3. Hardening the #156 gate

Kept as-is in behaviour, fixed in framing:

- `kFirstAv1EncodeDeviceId = 0x2680` replaces the bare literal, with the evidence recorded: highest Ampere display part `0x25FB`, `0x2600`–`0x267F` unallocated, lowest Ada `0x2681` (TITAN Ada). **The margin is one device ID** — worth stating explicitly.
- The doc comment asserted NVIDIA's ID ordering as fact. It is an observed convention, not a contract; now labelled as such, with the fail-open choice justified. An allowlist was considered and rejected: it would deny AV1 to a GPU released after this code was written, whereas failing open costs nothing now that a wrong guess degrades gracefully.
- The `is_codec_supported` comment credited the gate with fixing the crash. Corrected — it is a fast path, and correctness rests on the NVENC codec-GUID query, which also sees driver-level support no device-ID table can (a new GPU on an old driver).
- Log demoted `info` → `debug`; the probe re-runs on every launch and resume.
- Restored sorted include order in `display_vram.cpp` (`.clang-format` sets `SortIncludes: CaseInsensitive`).

## Testing

13 new tests, all passing:

- `NvencUninitializedTeardown` (5) — stubs the NVENC entry points, so no GPU needed. Pins that the discard path skips both unregister calls and closes the handle, that it is idempotent, that a live session still gets the *full* teardown (no resource leak), and that the rejected-initialize path stays separate.
- `NvidiaCodecSupport` (8, extended from 4) — adds Ada workstation/datacenter parts (`26B1` RTX 6000 Ada, `26B5` L40, `27B8` L4, `27B2` RTX 4000 Ada), the Ada laptop parts sold under 30-series branding (`2822`, `28A3` — a name-based check gets these wrong), an exact boundary test, and an explicit fail-open test documenting the accepted false positives.

Full suite on Windows (MSYS2 ucrt64 g++ 16.2): **653 tests, 632 passed, 9 skipped, 12 failed.**

The 12 failures are the pre-existing environment-sensitive auth/Playnite/locale set — the same ones #156's own CI reported. Confirmed rather than assumed: the suite was built and run at `8d6dbf26` with these changes stashed and produced the identical 12-item list.

## Suggested follow-ups (not in this PR)

- **`validate_encoder_safe` blast radius.** Its `reset_state()` clears h264 + hevc + av1 and the caller erases the encoder from `encoder_list`, so any probe fault costs the whole NVENC encoder and drops the user to `libx264`. AV1 is probed last, so a late fault discards already-passing results. Scoping the shield per-codec is a probe-semantics refactor and deserves its own change and its own testing; this PR removes its main trigger instead.
- **WebRTC signaling pre-validation.** `webrtc_stream.cpp` maps the client's codec string straight to `videoFormat` with no capability check. The isolated video worker still rejects a codec missing from the validated probe snapshot, so this is a negotiation-quality issue rather than a crash — an AV1 request on an Ampere host fails at startup instead of negotiating down.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)
