### PR TITLE
ci(coverage): make the Windows coverage gate report real data

### DIFF
--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -214,12 +214,82 @@ jobs:
         # cases reliably fail even when the binaries are healthy. Don't gate the
         # workflow on test failures — coverage upload should still run so PRs
         # see the data either way.
+        #
+        # The suite runs in SHARDS rather than as one process because gcov only
+        # writes its .gcda counters from an atexit handler: a process killed by
+        # a signal contributes NOTHING, no matter how many tests passed first.
+        # That is the bug this step shipped with — one segfault
+        # (SimpleWebLifetime, see below) discarded the entire run, and gcovr
+        # then reconstructed a structurally complete but 0%-covered report from
+        # the .gcno compile-time notes alone. Nothing in that report says the
+        # runtime data is missing, so it uploaded clean and quietly failed
+        # codecov/patch on every C++ PR.
+        #
+        # Sharding bounds the blast radius of a future crash to one shard
+        # instead of the whole report; the "Verify coverage data" step below
+        # turns a total loss into a hard failure rather than a silent 0%.
+        # Shards run sequentially on purpose: libgcov merges each exiting
+        # process's counters into the existing .gcda files, so concurrent
+        # shards would race on the same files.
         continue-on-error: true
         working-directory: build/tests
-        run: ./test_sunshine.exe --gtest_color=yes --gtest_output=xml:test_results.xml
+        env:
+          # SimpleWebLifetime is a Boost.Asio threading stress test with
+          # deliberately aggressive 1s/2s timeouts. It passes in the optimized
+          # ci-windows / nightly builds (~3s) but segfaults within ~25ms under
+          # Debug -O0 + gcov instrumentation, whose overhead invalidates those
+          # timing assumptions. What it exercises is
+          # third-party/Simple-Web-Server, which the report excludes anyway, so
+          # skipping it here costs no reported coverage while leaving it a real
+          # gate in the builds where it is meaningful.
+          COVERAGE_GTEST_FILTER: '-SimpleWebLifetime.*'
+          COVERAGE_SHARDS: '6'
+        run: |
+          set +e
+          mkdir -p test_results
+          crashed=0
+          for i in $(seq 0 $((COVERAGE_SHARDS - 1))); do
+            GTEST_TOTAL_SHARDS="${COVERAGE_SHARDS}" GTEST_SHARD_INDEX="${i}" \
+              ./test_sunshine.exe \
+                --gtest_color=yes \
+                --gtest_filter="${COVERAGE_GTEST_FILTER}" \
+                --gtest_output="xml:test_results/shard_${i}.xml"
+            rc=$?
+            # Exit >=128 is a fatal signal (139 = SIGSEGV) and means this
+            # shard's counters were never flushed. Exit 1 is ordinary test
+            # failures, which still write .gcda normally.
+            if [ "${rc}" -ge 128 ]; then
+              echo "::warning::Coverage shard ${i} of ${COVERAGE_SHARDS} crashed (exit ${rc}); its counters were lost."
+              crashed=$((crashed + 1))
+            fi
+          done
+          if [ "${crashed}" -gt 0 ]; then
+            echo "::warning::${crashed} of ${COVERAGE_SHARDS} coverage shards crashed; reported coverage understates reality."
+          fi
+          exit 0
+
+      - name: Verify coverage data was produced
+        # The guard that keeps this gate honest. gcovr will happily emit a
+        # complete-looking 0% report from .gcno notes alone when no .gcda
+        # runtime data exists, and neither the XML nor the Codecov UI
+        # distinguishes that from "genuinely untested". Fail loudly here
+        # instead: uploading a run with no runtime data is worse than not
+        # uploading at all, because codecov/patch then reports "0.00% of diff
+        # hit" on every C++ PR until reviewers learn to ignore a red check.
+        working-directory: build
+        run: |
+          gcno=$(find . -name '*.gcno' | wc -l)
+          gcda=$(find . -name '*.gcda' | wc -l)
+          echo "Coverage notes (.gcno, compile time): ${gcno}"
+          echo "Coverage data  (.gcda, run time):     ${gcda}"
+          if [ "${gcda}" -eq 0 ]; then
+            echo "::error::No .gcda files were produced — the instrumented test binary never reached a clean exit, so every coverage counter was lost. See the 'Run tests' step for a crash. Refusing to upload a report that would show 0% for the entire tree."
+            exit 1
+          fi
 
       - name: Generate coverage XML
-        if: always() && steps.test.outcome != 'cancelled'
+        # No always() here: if the guard above failed there is no runtime data,
+        # and generating/uploading the report regardless is the original bug.
         working-directory: build
         run: |
           python -m gcovr \
@@ -242,11 +312,12 @@ jobs:
           name: coverage-windows
           path: |
             build/coverage.xml
-            build/tests/test_results.xml
+            build/tests/test_results/
           if-no-files-found: warn
 
       - name: Upload to Codecov
-        if: always() && steps.test.outcome != 'cancelled'
+        # Deliberately not always(): an upload with no runtime data is exactly
+        # the failure mode this workflow is being fixed for.
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -257,8 +328,8 @@ jobs:
           verbose: true
 
       - name: Upload test results to Codecov Test Analytics
-        # `--gtest_output=xml:test_results.xml` above already emits the
-        # JUnit-compatible XML; this step just ships it. Run even when
+        # `--gtest_output=xml:...` above already emits the JUnit-compatible
+        # XML (one file per shard); this step just ships them. Run even when
         # the test step exited non-zero (continue-on-error keeps the
         # workflow alive) so the Test Analytics dashboard records
         # failing / flaky tests — those are the ones worth tracking,
@@ -276,7 +347,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
-          files: build/tests/test_results.xml
+          files: build/tests/test_results/shard_0.xml,build/tests/test_results/shard_1.xml,build/tests/test_results/shard_2.xml,build/tests/test_results/shard_3.xml,build/tests/test_results/shard_4.xml,build/tests/test_results/shard_5.xml
           flags: windows
           name: windows-amd64-results
           # Non-blocking: a test-results upload failure is observability

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Key CMake options (`cmake/prep/options.cmake`):
 
 - `SUNSHINE_ENABLE_WEBRTC=ON` — Windows-only; links against a separately-built libwebrtc wrapper. See `docs/building.md` and `scripts/build_mingw_webrtc.ps1`. The build cache lives at `%LOCALAPPDATA%\LuminalShine\deps\libwebrtc\{src,out}` and is **shared across worktrees** — wiping `build/` does not invalidate it.
 - `BUILD_DOCS=OFF` — required on Windows CI because the `third-party/doxyconfig` submodule pin is dead. Default is ON; flip OFF if doxygen build fails.
-- `BUILD_TESTS_WITH_COVERAGE=ON` — opt-in gcov instrumentation. Off by default because MSYS2's clang lacks the profile runtime, which would break the Windows-clang build if unconditional.
+- `BUILD_TESTS_WITH_COVERAGE=ON` — opt-in gcov instrumentation (`-fprofile-arcs -ftest-coverage`, forced `-O0`). Off by default because the flags need a profile runtime at link time and the base `mingw-w64-<toolchain>-clang` package ships headers only — without `mingw-w64-<toolchain>-compiler-rt` the link fails outright (`cannot find …/libclang_rt.profile.a`), so making it unconditional would break the Windows-clang build. Install `compiler-rt` to use it; `.github/workflows/coverage-windows.yml` does. Note that gcov writes its `.gcda` counters from an `atexit` handler, so a test process that dies on a signal contributes **nothing** — gcovr then silently reconstructs a 0%-covered report from the `.gcno` notes alone. That workflow shards the run and hard-fails on zero `.gcda` for exactly this reason; keep both if you touch it.
 
 Web UI commands run from `src_assets/common/assets/web/` (where its own `package.json` lives — there is no root-level `package.json`):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Key CMake options (`cmake/prep/options.cmake`):
 
 - `SUNSHINE_ENABLE_WEBRTC=ON` — Windows-only; links against a separately-built libwebrtc wrapper. See `docs/building.md` and `scripts/build_mingw_webrtc.ps1`. The build cache lives at `%LOCALAPPDATA%\LuminalShine\deps\libwebrtc\{src,out}` and is **shared across worktrees** — wiping `build/` does not invalidate it.
 - `BUILD_DOCS=OFF` — required on Windows CI because the `third-party/doxyconfig` submodule pin is dead. Default is ON; flip OFF if doxygen build fails.
-- `BUILD_TESTS_WITH_COVERAGE=ON` — opt-in gcov instrumentation. Off by default because MSYS2's clang lacks the profile runtime, which would break the Windows-clang build if unconditional.
+- `BUILD_TESTS_WITH_COVERAGE=ON` — opt-in gcov instrumentation (`-fprofile-arcs -ftest-coverage`, forced `-O0`). Off by default because the flags need a profile runtime at link time and the base `mingw-w64-<toolchain>-clang` package ships headers only — without `mingw-w64-<toolchain>-compiler-rt` the link fails outright (`cannot find …/libclang_rt.profile.a`), so making it unconditional would break the Windows-clang build. Install `compiler-rt` to use it; `.github/workflows/coverage-windows.yml` does. Note that gcov writes its `.gcda` counters from an `atexit` handler, so a test process that dies on a signal contributes **nothing** — gcovr then silently reconstructs a 0%-covered report from the `.gcno` notes alone. That workflow shards the run and hard-fails on zero `.gcda` for exactly this reason; keep both if you touch it.
 
 Web UI commands run from `src_assets/common/assets/web/` (where its own `package.json` lives — there is no root-level `package.json`):
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,15 +16,34 @@ include_directories("${GTEST_SOURCE_DIR}/googletest/include" "${GTEST_SOURCE_DIR
 
 # coverage (opt-in)
 # https://gcovr.com/en/stable/guide/compiling.html#compiler-options
-# Gating: the gcov flags require libgcov (gcc) or libclang_rt.profile (clang).
-# msys2's mingw-w64-ucrt-x86_64-clang package does not ship the profile runtime,
-# so unconditional instrumentation breaks the Windows-clang build. CI no longer
-# uploads coverage artifacts, so leave this OFF by default and let local
+#
+# Gating: the gcov flags require a profile runtime at link time -- libgcov
+# (gcc) or libclang_rt.profile (clang). On MSYS2 the base
+# mingw-w64-<toolchain>-clang package ships headers only; the runtime lives
+# in the separate mingw-w64-<toolchain>-compiler-rt package. Without that
+# package the link fails outright with
+#   cannot find .../libclang_rt.profile.a: No such file or directory
+# rather than degrading quietly, so leave this OFF by default and let
 # coverage runs opt in via -DBUILD_TESTS_WITH_COVERAGE=ON.
+# .github/workflows/coverage-windows.yml installs compiler-rt and does exactly
+# that. (clang finds the package's legacy-layout
+# lib/clang/<v>/lib/windows/libclang_rt.profile-x86_64.a via its per-target
+# runtime-dir fallback, so the layout difference is not a problem.)
 option(BUILD_TESTS_WITH_COVERAGE "Instrument tests with gcov-style coverage flags" OFF)
 if(BUILD_TESTS_WITH_COVERAGE)
-    set(CMAKE_CXX_FLAGS "-fprofile-arcs -ftest-coverage -ggdb -O0")
-    set(CMAKE_C_FLAGS "-fprofile-arcs -ftest-coverage -ggdb -O0")
+    # Append rather than assign. A bare set() discarded everything the
+    # toolchain file and the environment had already put in CMAKE_CXX_FLAGS
+    # (CI passes CXXFLAGS=-fms-extensions) for every source compiled in this
+    # directory -- which is not just tests/, but the whole of src/, since
+    # SUNSHINE_TARGET_FILES is compiled into test_sunshine here.
+    string(APPEND CMAKE_CXX_FLAGS " -fprofile-arcs -ftest-coverage -ggdb -O0")
+    string(APPEND CMAKE_C_FLAGS " -fprofile-arcs -ftest-coverage -ggdb -O0")
+
+    # Instrumented objects emit references to the profile runtime
+    # (llvm_gcda_* / __gcov_*), which the compiler driver only links in when a
+    # coverage flag is on the *link* line too. State it explicitly instead of
+    # relying on the generator threading CMAKE_CXX_FLAGS into the link rule.
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " --coverage")
 endif()
 
 # Find the correct libgcov library path matching the gcc compiler version


### PR DESCRIPTION
## The problem

`Windows-AMD64 Coverage` uploaded a **structurally complete but entirely empty** report. From run [33310686530](https://github.com/NortheBridge/luminalshine/actions/runs/33310686530) (PR #159):

- 0 of 167 files had a single covered line; overall line-rate `0.0`.
- The gcovr `--verbose` log referenced **17,314 `.gcno`** files and **zero `.gcda`**.
- `codecov/patch` therefore reported `0.00% of diff hit (target 25.00%)` on every C++ PR regardless of test quality — #156 and #159 both failed this way.

## Root cause — not the profile runtime

The standing hypothesis (in `CLAUDE.md`) was that MSYS2's clang lacks the gcov profile runtime. **That is not what happened**, and the workflow already installs `compiler-rt`.

gcov writes its `.gcda` counters from an **`atexit` handler**. A process killed by a signal contributes *nothing*, however many tests passed first. The instrumented binary segfaulted 0.2s in:

```
[ RUN      ] SimpleWebLifetime.KeepAliveAndForeignThreadSseStress
Segmentation fault    ./test_sunshine.exe      → exit 139
```

With no `.gcda`, gcovr reconstructed the entire file tree from the `.gcno` compile-time notes alone. **Nothing in the resulting XML distinguishes that from "genuinely untested"**, so it uploaded clean — and `continue-on-error: true` on the test step meant the job still showed green.

That test is a Boost.Asio threading stress test with deliberately aggressive 1s/2s timeouts. It **passes in the optimized ci-windows/nightly builds (~3055 ms)** but dies within ~25 ms under `Debug -O0 -fprofile-arcs`, whose overhead invalidates its timing assumptions.

## Ruled out, with evidence

| Hypothesis | Verdict |
|---|---|
| MSYS2 clang lacks the profile runtime | **No.** The base `clang` package ships headers only, but the workflow installs `compiler-rt`, which provides `libclang_rt.profile-x86_64.a`. Verified by linking with that package's resource-dir: `exit 0`. |
| `compiler-rt`'s legacy dir layout breaks clang 22 | **No.** clang wants `lib/<triple>/libclang_rt.profile.a`, the package ships `lib/windows/libclang_rt.profile-x86_64.a`, and clang's per-target runtime-dir **fallback** finds it. |
| `GCOV_PREFIX` / `GCOV_PREFIX_STRIP` / working directory | **Not involved.** Verified locally: `.gcda` is written to the absolute **object-directory** path baked in at compile time, never the runtime cwd. `working-directory: build/tests` is irrelevant and gcovr's recursive scan of `build/` already covers it. |

Confirmed end-to-end locally with the same toolchain (clang 22.1.8, ucrt64): clean exit → `.gcda` written; segfault → **0** `.gcda`.

## The fix

1. **Shard the run** into 6 sequential batches. libgcov merges each exiting process's counters into the existing `.gcda`, so a future crash costs **one shard** instead of the entire report. Sequential on purpose — concurrent shards would race on the same files.
2. **Add a `Verify coverage data was produced` guard** that hard-fails on zero `.gcda`, and stop the gcovr/Codecov steps from running under `always()`. A report with no runtime data is worse than no report, because it trains reviewers to ignore a red check.
3. **Filter `SimpleWebLifetime.*` out of the instrumented run only.** It exercises `third-party/Simple-Web-Server`, which the report excludes anyway, so this costs no reported coverage and it stays a gate in the builds where it is meaningful.
4. **`tests/CMakeLists.txt`:** append the coverage flags instead of assigning (the bare `set()` discarded everything the toolchain and environment had put in `CMAKE_CXX_FLAGS` — for all of `src/`, not just `tests/`), and put `--coverage` on the link line explicitly rather than relying on the generator threading `CMAKE_CXX_FLAGS` into the link rule.
5. Correct the stale profile-runtime claim in `CLAUDE.md` / `AGENTS.md` / `tests/CMakeLists.txt`.

## Verification

- [ ] Nonzero overall line-rate in the uploaded `coverage.xml`
- [ ] `codecov/patch` passing on a diff with covered C++ lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
