### PR TITLE
[THROWAWAY probe] verify codecov/patch measures a real C++ diff

### DIFF
--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -214,12 +214,82 @@ jobs:
         # cases reliably fail even when the binaries are healthy. Don't gate the
         # workflow on test failures — coverage upload should still run so PRs
         # see the data either way.
+        #
+        # The suite runs in SHARDS rather than as one process because gcov only
+        # writes its .gcda counters from an atexit handler: a process killed by
+        # a signal contributes NOTHING, no matter how many tests passed first.
+        # That is the bug this step shipped with — one segfault
+        # (SimpleWebLifetime, see below) discarded the entire run, and gcovr
+        # then reconstructed a structurally complete but 0%-covered report from
+        # the .gcno compile-time notes alone. Nothing in that report says the
+        # runtime data is missing, so it uploaded clean and quietly failed
+        # codecov/patch on every C++ PR.
+        #
+        # Sharding bounds the blast radius of a future crash to one shard
+        # instead of the whole report; the "Verify coverage data" step below
+        # turns a total loss into a hard failure rather than a silent 0%.
+        # Shards run sequentially on purpose: libgcov merges each exiting
+        # process's counters into the existing .gcda files, so concurrent
+        # shards would race on the same files.
         continue-on-error: true
         working-directory: build/tests
-        run: ./test_sunshine.exe --gtest_color=yes --gtest_output=xml:test_results.xml
+        env:
+          # SimpleWebLifetime is a Boost.Asio threading stress test with
+          # deliberately aggressive 1s/2s timeouts. It passes in the optimized
+          # ci-windows / nightly builds (~3s) but segfaults within ~25ms under
+          # Debug -O0 + gcov instrumentation, whose overhead invalidates those
+          # timing assumptions. What it exercises is
+          # third-party/Simple-Web-Server, which the report excludes anyway, so
+          # skipping it here costs no reported coverage while leaving it a real
+          # gate in the builds where it is meaningful.
+          COVERAGE_GTEST_FILTER: '-SimpleWebLifetime.*'
+          COVERAGE_SHARDS: '6'
+        run: |
+          set +e
+          mkdir -p test_results
+          crashed=0
+          for i in $(seq 0 $((COVERAGE_SHARDS - 1))); do
+            GTEST_TOTAL_SHARDS="${COVERAGE_SHARDS}" GTEST_SHARD_INDEX="${i}" \
+              ./test_sunshine.exe \
+                --gtest_color=yes \
+                --gtest_filter="${COVERAGE_GTEST_FILTER}" \
+                --gtest_output="xml:test_results/shard_${i}.xml"
+            rc=$?
+            # Exit >=128 is a fatal signal (139 = SIGSEGV) and means this
+            # shard's counters were never flushed. Exit 1 is ordinary test
+            # failures, which still write .gcda normally.
+            if [ "${rc}" -ge 128 ]; then
+              echo "::warning::Coverage shard ${i} of ${COVERAGE_SHARDS} crashed (exit ${rc}); its counters were lost."
+              crashed=$((crashed + 1))
+            fi
+          done
+          if [ "${crashed}" -gt 0 ]; then
+            echo "::warning::${crashed} of ${COVERAGE_SHARDS} coverage shards crashed; reported coverage understates reality."
+          fi
+          exit 0
+
+      - name: Verify coverage data was produced
+        # The guard that keeps this gate honest. gcovr will happily emit a
+        # complete-looking 0% report from .gcno notes alone when no .gcda
+        # runtime data exists, and neither the XML nor the Codecov UI
+        # distinguishes that from "genuinely untested". Fail loudly here
+        # instead: uploading a run with no runtime data is worse than not
+        # uploading at all, because codecov/patch then reports "0.00% of diff
+        # hit" on every C++ PR until reviewers learn to ignore a red check.
+        working-directory: build
+        run: |
+          gcno=$(find . -name '*.gcno' | wc -l)
+          gcda=$(find . -name '*.gcda' | wc -l)
+          echo "Coverage notes (.gcno, compile time): ${gcno}"
+          echo "Coverage data  (.gcda, run time):     ${gcda}"
+          if [ "${gcda}" -eq 0 ]; then
+            echo "::error::No .gcda files were produced — the instrumented test binary never reached a clean exit, so every coverage counter was lost. See the 'Run tests' step for a crash. Refusing to upload a report that would show 0% for the entire tree."
+            exit 1
+          fi
 
       - name: Generate coverage XML
-        if: always() && steps.test.outcome != 'cancelled'
+        # No always() here: if the guard above failed there is no runtime data,
+        # and generating/uploading the report regardless is the original bug.
         working-directory: build
         run: |
           python -m gcovr \
@@ -242,11 +312,12 @@ jobs:
           name: coverage-windows
           path: |
             build/coverage.xml
-            build/tests/test_results.xml
+            build/tests/test_results/
           if-no-files-found: warn
 
       - name: Upload to Codecov
-        if: always() && steps.test.outcome != 'cancelled'
+        # Deliberately not always(): an upload with no runtime data is exactly
+        # the failure mode this workflow is being fixed for.
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -257,8 +328,8 @@ jobs:
           verbose: true
 
       - name: Upload test results to Codecov Test Analytics
-        # `--gtest_output=xml:test_results.xml` above already emits the
-        # JUnit-compatible XML; this step just ships it. Run even when
+        # `--gtest_output=xml:...` above already emits the JUnit-compatible
+        # XML (one file per shard); this step just ships them. Run even when
         # the test step exited non-zero (continue-on-error keeps the
         # workflow alive) so the Test Analytics dashboard records
         # failing / flaky tests — those are the ones worth tracking,
@@ -276,7 +347,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
-          files: build/tests/test_results.xml
+          files: build/tests/test_results/shard_0.xml,build/tests/test_results/shard_1.xml,build/tests/test_results/shard_2.xml,build/tests/test_results/shard_3.xml,build/tests/test_results/shard_4.xml,build/tests/test_results/shard_5.xml
           flags: windows
           name: windows-amd64-results
           # Non-blocking: a test-results upload failure is observability

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Key CMake options (`cmake/prep/options.cmake`):
 
 - `SUNSHINE_ENABLE_WEBRTC=ON` — Windows-only; links against a separately-built libwebrtc wrapper. See `docs/building.md` and `scripts/build_mingw_webrtc.ps1`. The build cache lives at `%LOCALAPPDATA%\LuminalShine\deps\libwebrtc\{src,out}` and is **shared across worktrees** — wiping `build/` does not invalidate it.
 - `BUILD_DOCS=OFF` — required on Windows CI because the `third-party/doxyconfig` submodule pin is dead. Default is ON; flip OFF if doxygen build fails.
-- `BUILD_TESTS_WITH_COVERAGE=ON` — opt-in gcov instrumentation. Off by default because MSYS2's clang lacks the profile runtime, which would break the Windows-clang build if unconditional.
+- `BUILD_TESTS_WITH_COVERAGE=ON` — opt-in gcov instrumentation (`-fprofile-arcs -ftest-coverage`, forced `-O0`). Off by default because the flags need a profile runtime at link time and the base `mingw-w64-<toolchain>-clang` package ships headers only — without `mingw-w64-<toolchain>-compiler-rt` the link fails outright (`cannot find …/libclang_rt.profile.a`), so making it unconditional would break the Windows-clang build. Install `compiler-rt` to use it; `.github/workflows/coverage-windows.yml` does. Note that gcov writes its `.gcda` counters from an `atexit` handler, so a test process that dies on a signal contributes **nothing** — gcovr then silently reconstructs a 0%-covered report from the `.gcno` notes alone. That workflow shards the run and hard-fails on zero `.gcda` for exactly this reason; keep both if you touch it.
 
 Web UI commands run from `src_assets/common/assets/web/` (where its own `package.json` lives — there is no root-level `package.json`):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Key CMake options (`cmake/prep/options.cmake`):
 
 - `SUNSHINE_ENABLE_WEBRTC=ON` — Windows-only; links against a separately-built libwebrtc wrapper. See `docs/building.md` and `scripts/build_mingw_webrtc.ps1`. The build cache lives at `%LOCALAPPDATA%\LuminalShine\deps\libwebrtc\{src,out}` and is **shared across worktrees** — wiping `build/` does not invalidate it.
 - `BUILD_DOCS=OFF` — required on Windows CI because the `third-party/doxyconfig` submodule pin is dead. Default is ON; flip OFF if doxygen build fails.
-- `BUILD_TESTS_WITH_COVERAGE=ON` — opt-in gcov instrumentation. Off by default because MSYS2's clang lacks the profile runtime, which would break the Windows-clang build if unconditional.
+- `BUILD_TESTS_WITH_COVERAGE=ON` — opt-in gcov instrumentation (`-fprofile-arcs -ftest-coverage`, forced `-O0`). Off by default because the flags need a profile runtime at link time and the base `mingw-w64-<toolchain>-clang` package ships headers only — without `mingw-w64-<toolchain>-compiler-rt` the link fails outright (`cannot find …/libclang_rt.profile.a`), so making it unconditional would break the Windows-clang build. Install `compiler-rt` to use it; `.github/workflows/coverage-windows.yml` does. Note that gcov writes its `.gcda` counters from an `atexit` handler, so a test process that dies on a signal contributes **nothing** — gcovr then silently reconstructs a 0%-covered report from the `.gcno` notes alone. That workflow shards the run and hard-fails on zero `.gcda` for exactly this reason; keep both if you touch it.
 
 Web UI commands run from `src_assets/common/assets/web/` (where its own `package.json` lives — there is no root-level `package.json`):
 

--- a/src/utility.h
+++ b/src/utility.h
@@ -124,6 +124,27 @@ struct argument_type<T(U)> {
 
 namespace util {
 
+  /**
+   * @brief Clamp a requested frame rate into a supported range.
+   * @param requested The frame rate the client asked for.
+   * @param minimum Lowest frame rate the host will serve.
+   * @param maximum Highest frame rate the host will serve.
+   * @return `requested` clamped to [minimum, maximum]; `minimum` if the bounds
+   *         are inverted.
+   */
+  inline int clamp_fps(int requested, int minimum, int maximum) {
+    if (maximum < minimum) {
+      return minimum;
+    }
+    if (requested < minimum) {
+      return minimum;
+    }
+    if (requested > maximum) {
+      return maximum;
+    }
+    return requested;
+  }
+
   template<template<typename...> class X, class... Y>
   struct __instantiation_of: public std::false_type {};
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,15 +16,34 @@ include_directories("${GTEST_SOURCE_DIR}/googletest/include" "${GTEST_SOURCE_DIR
 
 # coverage (opt-in)
 # https://gcovr.com/en/stable/guide/compiling.html#compiler-options
-# Gating: the gcov flags require libgcov (gcc) or libclang_rt.profile (clang).
-# msys2's mingw-w64-ucrt-x86_64-clang package does not ship the profile runtime,
-# so unconditional instrumentation breaks the Windows-clang build. CI no longer
-# uploads coverage artifacts, so leave this OFF by default and let local
+#
+# Gating: the gcov flags require a profile runtime at link time -- libgcov
+# (gcc) or libclang_rt.profile (clang). On MSYS2 the base
+# mingw-w64-<toolchain>-clang package ships headers only; the runtime lives
+# in the separate mingw-w64-<toolchain>-compiler-rt package. Without that
+# package the link fails outright with
+#   cannot find .../libclang_rt.profile.a: No such file or directory
+# rather than degrading quietly, so leave this OFF by default and let
 # coverage runs opt in via -DBUILD_TESTS_WITH_COVERAGE=ON.
+# .github/workflows/coverage-windows.yml installs compiler-rt and does exactly
+# that. (clang finds the package's legacy-layout
+# lib/clang/<v>/lib/windows/libclang_rt.profile-x86_64.a via its per-target
+# runtime-dir fallback, so the layout difference is not a problem.)
 option(BUILD_TESTS_WITH_COVERAGE "Instrument tests with gcov-style coverage flags" OFF)
 if(BUILD_TESTS_WITH_COVERAGE)
-    set(CMAKE_CXX_FLAGS "-fprofile-arcs -ftest-coverage -ggdb -O0")
-    set(CMAKE_C_FLAGS "-fprofile-arcs -ftest-coverage -ggdb -O0")
+    # Append rather than assign. A bare set() discarded everything the
+    # toolchain file and the environment had already put in CMAKE_CXX_FLAGS
+    # (CI passes CXXFLAGS=-fms-extensions) for every source compiled in this
+    # directory -- which is not just tests/, but the whole of src/, since
+    # SUNSHINE_TARGET_FILES is compiled into test_sunshine here.
+    string(APPEND CMAKE_CXX_FLAGS " -fprofile-arcs -ftest-coverage -ggdb -O0")
+    string(APPEND CMAKE_C_FLAGS " -fprofile-arcs -ftest-coverage -ggdb -O0")
+
+    # Instrumented objects emit references to the profile runtime
+    # (llvm_gcda_* / __gcov_*), which the compiler driver only links in when a
+    # coverage flag is on the *link* line too. State it explicitly instead of
+    # relying on the generator threading CMAKE_CXX_FLAGS into the link rule.
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " --coverage")
 endif()
 
 # Find the correct libgcov library path matching the gcc compiler version

--- a/tests/unit/test_coverage_probe.cpp
+++ b/tests/unit/test_coverage_probe.cpp
@@ -1,0 +1,34 @@
+/**
+ * @file tests/unit/test_coverage_probe.cpp
+ * @brief Unit tests for util::clamp_fps.
+ */
+
+// lib includes
+#include <gtest/gtest.h>
+
+// local includes
+#include "../tests_common.h"
+#include "src/utility.h"
+
+namespace {
+  TEST(ClampFps, RequestInsideRangeIsUnchanged) {
+    EXPECT_EQ(60, util::clamp_fps(60, 30, 120));
+  }
+
+  TEST(ClampFps, RequestBelowMinimumClampsUp) {
+    EXPECT_EQ(30, util::clamp_fps(10, 30, 120));
+  }
+
+  TEST(ClampFps, RequestAboveMaximumClampsDown) {
+    EXPECT_EQ(120, util::clamp_fps(240, 30, 120));
+  }
+
+  TEST(ClampFps, InvertedBoundsFallBackToMinimum) {
+    EXPECT_EQ(30, util::clamp_fps(60, 30, 10));
+  }
+
+  TEST(ClampFps, BoundsAreInclusive) {
+    EXPECT_EQ(30, util::clamp_fps(30, 30, 120));
+    EXPECT_EQ(120, util::clamp_fps(120, 30, 120));
+  }
+}  // namespace


### PR DESCRIPTION
**Do not merge — this PR exists only to verify the coverage gate fixed in #160, and will be closed.**

#160 restored real coverage data (overall line-rate `0.0` → `0.1322`, 0 → 6,304 covered lines). But `codecov/patch` passed on #160 *trivially*, because that diff contains no coverable C++ lines. This PR stacks a well-covered pure function (`util::clamp_fps`, 5 tests covering every branch) on top of the fix so `codecov/patch` has a real C++ diff to measure.

Expected: `codecov/patch` reports ~100% of diff hit, instead of the `0.00% of diff hit (target 25.00%)` that every C++ PR got before.
