### PR TITLE
fix(video): don't lose a whole encoder when one codec's probe faults

### DIFF
--- a/src/encoder_probe_suppression.h
+++ b/src/encoder_probe_suppression.h
@@ -1,0 +1,156 @@
+/**
+ * @file src/encoder_probe_suppression.h
+ * @brief Per-encoder, per-codec suppression of codecs that faulted during probing.
+ *
+ * The encoder probe validates H.264, then HEVC, then AV1 against one
+ * encoder_t. A graphics-driver fault anywhere in that sequence is caught by
+ * the SEH / C++ shield in video.cpp, which then discards the whole encoder —
+ * so a driver bug specific to one codec costs the user every codec on that
+ * encoder, and they fall back to software encoding. Because the probe re-runs
+ * on every launch and resume and negative results are deliberately not cached,
+ * that repeats forever.
+ *
+ * Nothing about the faulted probe's state can be trusted to fix this in place.
+ * Capability bits are fail-OPEN — validate_encoder starts with
+ * `capabilities.set()` (every bit 1) and only corrects downward — and a codec
+ * whose probe was cut short therefore reads as fully supported, HDR and 4:4:4
+ * included. H.264's own bits are not finalised until after the AV1 probe has
+ * run, so even "H.264 already passed" is not a safe thing to keep. On Windows
+ * the shield is a bare __except and the build has no /EHa, so no destructors
+ * ran either: the encode session and display from the faulted attempt are
+ * leaked, not released.
+ *
+ * So this registry does not rescue the faulted pass. That pass still discards
+ * everything and still falls back exactly as before. It records which codec
+ * was in flight, and the *next* probe pass skips that one codec for that one
+ * encoder — reusing the same lever as the H264_ONLY flag — and therefore
+ * runs to completion with every capability bit properly written.
+ *
+ * Suppression is process-lifetime: it is cleared by a host restart, or by any
+ * restart of the service. Note that a GPU driver update alone does NOT clear
+ * it — installing a driver does not restart this service — so a driver that
+ * fixes the fault will not re-enable the codec until the service next starts.
+ * That is an accepted limitation rather than an oversight: only HEVC and AV1
+ * can be suppressed (see is_suppressible), so the worst case is one optional
+ * codec staying off slightly longer than strictly necessary.
+ */
+#pragma once
+
+// standard includes
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <string>
+#include <string_view>
+
+namespace video::probe_suppression {
+
+  /**
+   * @brief Which codec's probe was in flight when a fault happened.
+   */
+  enum class codec_e {
+    h264 = 0,
+    hevc = 1,
+    av1 = 2,
+    /**
+     * The fault happened in work that is not attributable to a single codec —
+     * the shared SDR->HDR display reset between codec probes, for example.
+     * Never suppresses anything: guessing here would disable a codec that is
+     * perfectly healthy, so the encoder is simply probed in full next pass.
+     */
+    unattributed = 3,
+  };
+
+  /**
+   * @brief Whether a fault on @p codec may be turned into a suppression.
+   *
+   * Only HEVC and AV1. H.264 is deliberately excluded, and that exclusion is
+   * load-bearing rather than conservatism:
+   *
+   * H.264 is mandatory — validate_encoder bails out entirely if it fails, and
+   * every encoder in the candidate list must pass it — so there is no partial
+   * result to preserve by skipping it, and suppression buys nothing. What it
+   * would cost is severe. The probe's shield catches faults from shared setup
+   * too (acquiring the display, creating the D3D device, DXGI duplication),
+   * and on Windows it is a bare __except, which also catches ordinary C++
+   * exceptions such as a std::bad_alloc out of a wedged display stack. A
+   * single transient fault of that kind sweeping the candidate list would
+   * suppress H.264 on every encoder including the last-resort `software`
+   * entry, leaving probe_encoders() with nothing to return — permanently,
+   * because unlike the per-pass encoder_list copy this registry outlives the
+   * pass. Every launch and resume would then answer HTTP 503 until the service
+   * was restarted.
+   *
+   * An H.264 fault therefore keeps the pre-existing, self-healing behaviour:
+   * discard the encoder for this pass and re-probe it in full on the next one.
+   */
+  constexpr bool is_suppressible(codec_e codec) {
+    return codec == codec_e::hevc || codec == codec_e::av1;
+  }
+
+  /// Human-readable codec name for log lines.
+  inline const char *codec_name(codec_e codec) {
+    switch (codec) {
+      case codec_e::h264:
+        return "H.264";
+      case codec_e::hevc:
+        return "HEVC";
+      case codec_e::av1:
+        return "AV1";
+      default:
+        return "an unattributed stage";
+    }
+  }
+
+  /**
+   * @brief Set of (encoder, codec) pairs whose probe faulted the driver.
+   *
+   * Thread-safe: probe_encoders() can run concurrently with a stream start.
+   */
+  class registry_t {
+  public:
+    /// Record that @p codec faulted while being probed on @p encoder_name.
+    /// Codecs that are not suppressible (H.264 and `unattributed`) are ignored.
+    void suppress(std::string_view encoder_name, codec_e codec) {
+      if (!is_suppressible(codec)) {
+        return;
+      }
+      const std::lock_guard lock {mutex_};
+      entries_[std::string {encoder_name}][index_of(codec)] = true;
+    }
+
+    /// Whether @p codec has previously faulted on @p encoder_name.
+    bool is_suppressed(std::string_view encoder_name, codec_e codec) const {
+      if (!is_suppressible(codec)) {
+        return false;
+      }
+      const std::lock_guard lock {mutex_};
+      const auto it = entries_.find(encoder_name);
+      return it != entries_.end() && it->second[index_of(codec)];
+    }
+
+    /// Drop every record. Exists for tests; nothing in the host calls it.
+    void clear() {
+      const std::lock_guard lock {mutex_};
+      entries_.clear();
+    }
+
+  private:
+    static std::size_t index_of(codec_e codec) {
+      return static_cast<std::size_t>(codec);
+    }
+
+    mutable std::mutex mutex_;
+    /// std::less<> so find() accepts a string_view without allocating.
+    std::map<std::string, std::array<bool, 3>, std::less<>> entries_;
+  };
+
+  /// The host-wide registry consulted by the encoder probe.
+  inline registry_t &process_registry() {
+    static registry_t registry;
+    return registry;
+  }
+
+}  // namespace video::probe_suppression

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -31,6 +31,7 @@ extern "C" {
 #include "config.h"
 #include "display_device.h"
 #include "encoder_probe_shield.h"
+#include "encoder_probe_suppression.h"
 #include "encoder_recovery_gate.h"
 #include "globals.h"
 #include "input.h"
@@ -3881,6 +3882,20 @@ namespace video {
   static thread_local std::shared_ptr<platf::display_t> cached_probe_display;
   static thread_local platf::mem_type_e cached_display_type = platf::mem_type_e::system;
 
+  /**
+   * @brief Which codec's probe is running on this thread right now.
+   *
+   * Read by validate_encoder_safe() after the shield catches a fault, so the
+   * fault can be attributed to a codec. Thread-local rather than an
+   * out-parameter because it has to survive a Windows SEH unwind: that unwind
+   * runs no destructors (the build sets no /EHa) and skips straight past
+   * validate_encoder's frame, but thread-local storage is untouched by it.
+   *
+   * validate_encoder_safe() resets it before each probe, so a stale value from
+   * a previous encoder can never be blamed for a new fault.
+   */
+  static thread_local probe_suppression::codec_e probe_codec_in_flight = probe_suppression::codec_e::unattributed;
+
   bool validate_encoder(encoder_t &encoder, bool expect_failure) {
     // During encoder probing, always use the current active display and do not
     // attempt to select/swap displays based on configured output_name. Display
@@ -3894,8 +3909,32 @@ namespace video {
       BOOST_LOG(info) << "Encoder ["sv << encoder.name << "] failed"sv;
     });
 
+    // Skip codecs that faulted the graphics driver on an earlier pass in this
+    // process. Suppressing the one bad codec lets this pass run to completion,
+    // which is the only way the capability bits end up trustworthy: they are
+    // fail-open (the set() below turns every bit on) and are only ever
+    // corrected downward, so a probe cut short leaves them claiming support the
+    // GPU does not have. See src/encoder_probe_suppression.h.
+    //
+    // Only HEVC and AV1 are ever suppressed; an H.264 fault keeps the existing
+    // self-healing behaviour of re-probing in full. See is_suppressible().
+    auto &suppression = probe_suppression::process_registry();
+
     auto test_hevc = active_hevc_mode >= 2 || (active_hevc_mode == 0 && !(encoder.flags & H264_ONLY));
     auto test_av1 = active_av1_mode >= 2 || (active_av1_mode == 0 && !(encoder.flags & H264_ONLY));
+
+    if (test_hevc && suppression.is_suppressed(encoder.name, probe_suppression::codec_e::hevc)) {
+      BOOST_LOG(warning) << "Encoder ["sv << encoder.name
+                         << "] faulted while probing HEVC earlier in this process; skipping HEVC so "
+                            "the remaining codecs can be validated."sv;
+      test_hevc = false;
+    }
+    if (test_av1 && suppression.is_suppressed(encoder.name, probe_suppression::codec_e::av1)) {
+      BOOST_LOG(warning) << "Encoder ["sv << encoder.name
+                         << "] faulted while probing AV1 earlier in this process; skipping AV1 so "
+                            "the remaining codecs can be validated."sv;
+      test_av1 = false;
+    }
 
     encoder.h264.capabilities.set();
     encoder.hevc.capabilities.set();
@@ -3932,6 +3971,12 @@ namespace video {
       return false;
     }
 
+    // Only now does codec-specific work begin. Everything above — acquiring
+    // the display, creating the D3D device, DXGI duplication, is_codec_supported
+    // — is shared setup for all three codecs and is also the most fault-prone
+    // part of the probe, so it must stay `unattributed` and incriminate nothing.
+    probe_codec_in_flight = probe_suppression::codec_e::h264;
+
     // If we're expecting failure, use the autoselect ref config first since that will always succeed
     // if the encoder is available.
     auto max_ref_frames_h264 = expect_failure ? -1 : validate_config(disp, encoder, config_max_ref_frames);
@@ -3958,6 +4003,7 @@ namespace video {
     encoder.h264[encoder_t::PASSED] = true;
 
     if (test_hevc) {
+      probe_codec_in_flight = probe_suppression::codec_e::hevc;
       config_max_ref_frames.videoFormat = 1;
       config_autoselect.videoFormat = 1;
 
@@ -3986,6 +4032,7 @@ namespace video {
     }
 
     if (test_av1) {
+      probe_codec_in_flight = probe_suppression::codec_e::av1;
       config_max_ref_frames.videoFormat = 2;
       config_autoselect.videoFormat = 2;
 
@@ -4016,6 +4063,7 @@ namespace video {
     // Test HDR and YUV444 support
     {
       // H.264 is special because encoders may support YUV 4:4:4 without supporting 10-bit color depth
+      probe_codec_in_flight = probe_suppression::codec_e::h264;
       if (encoder.flags & YUV444_SUPPORT) {
         // All 13 config_t fields must be spelled out: an earlier 11-value
         // initializer silently landed the trailing 1 on prefer_sdr_10bit,
@@ -4032,7 +4080,10 @@ namespace video {
 
       // Reset the display since we're switching from SDR to HDR. Keep probing on the
       // current active display without attempting a display swap.
-      // Clear the cache since we need a fresh display for HDR testing
+      // Clear the cache since we need a fresh display for HDR testing.
+      // This reset and reset_display() are shared setup, not any one codec's
+      // work, so a fault here must not incriminate a codec.
+      probe_codec_in_flight = probe_suppression::codec_e::unattributed;
       cached_probe_display.reset();
       reset_display(disp, encoder.platform_formats->dev_type, probe_display_name, generic_hdr_config);
       if (!disp) {
@@ -4074,8 +4125,11 @@ namespace video {
       // HDR is not supported with H.264. Don't bother even trying it.
       encoder.h264[encoder_t::DYNAMIC_RANGE] = false;
 
+      probe_codec_in_flight = probe_suppression::codec_e::hevc;
       test_hdr_and_yuv444(encoder.hevc, 1);
+      probe_codec_in_flight = probe_suppression::codec_e::av1;
       test_hdr_and_yuv444(encoder.av1, 2);
+      probe_codec_in_flight = probe_suppression::codec_e::unattributed;
     }
 
     encoder.h264[encoder_t::VUI_PARAMETERS] = encoder.h264[encoder_t::VUI_PARAMETERS] && !config::sunshine.flags[config::flag::FORCE_VIDEO_HEADER_REPLACE];
@@ -4149,6 +4203,34 @@ namespace video {
   // video::probe_shield::run_cpp_exception_shield so the same policy can
   // be unit-tested against stub probes without real encoder hardware.
   bool validate_encoder_safe(encoder_t &encoder, bool expect_failure) {
+    // Attribute the fault to whichever codec was in flight, so the NEXT probe
+    // pass can skip just that codec instead of losing the encoder again.
+    //
+    // Note what this deliberately does NOT do: it does not keep any part of
+    // this probe's result. reset_state() still clears all three codecs and the
+    // caller still erases the encoder, exactly as before — this pass falls
+    // back to the next candidate unchanged. Salvaging the faulted pass in
+    // place is not possible: capability bits are fail-open, H.264's own bits
+    // are not finalised until after the AV1 probe, and on Windows the shield
+    // is a bare __except under a build with no /EHa, so no destructors ran and
+    // the encode session and display from the faulted attempt are leaked
+    // rather than released. The only trustworthy result is a probe that ran to
+    // completion, which is what suppression buys on the next pass.
+    auto note_probe_fault = [&]() {
+      const auto faulted = probe_codec_in_flight;
+      if (faulted == probe_suppression::codec_e::unattributed) {
+        BOOST_LOG(warning) << "Encoder probe for ["sv << encoder.name
+                           << "] faulted outside any single codec's probe; the encoder will be "
+                              "retried in full on the next probe pass."sv;
+        return;
+      }
+      probe_suppression::process_registry().suppress(encoder.name, faulted);
+      BOOST_LOG(warning) << "Encoder ["sv << encoder.name << "] faulted while probing "sv
+                         << probe_suppression::codec_name(faulted)
+                         << "; that codec will be skipped for this encoder for the rest of this "
+                            "process so the next probe pass can validate the others."sv;
+    };
+
     auto reset_state = [&]() {
       encoder.h264.capabilities.reset();
       encoder.hevc.capabilities.reset();
@@ -4164,18 +4246,21 @@ namespace video {
     // SEH first: graphics-driver faults arrive as Windows SEH access
     // violations, not C++ exceptions, and must be caught by __except in
     // a frame with no C++ unwind targets.
+    probe_codec_in_flight = probe_suppression::codec_e::unattributed;
     seh_validate_encoder_args_t args {&encoder, expect_failure, false};
     const auto seh = seh_invoke_validate_encoder_(&args);
     if (seh != 0) {
       BOOST_LOG(warning) << "Encoder probe for [" << encoder.name
                          << "] terminated by SEH 0x" << std::hex << seh << std::dec
                          << " (likely a graphics-driver fault during encoder init); skipping this encoder.";
+      note_probe_fault();
       reset_state();
       return false;
     }
     return args.result;
 #else
     // Non-Windows: the C++ exception shield is sufficient.
+    probe_codec_in_flight = probe_suppression::codec_e::unattributed;
     const auto shield = probe_shield::run_cpp_exception_shield([&] {
       return validate_encoder(encoder, expect_failure);
     });
@@ -4190,6 +4275,7 @@ namespace video {
       BOOST_LOG(warning) << "Encoder probe for [" << encoder.name
                          << "] threw an unknown exception; skipping this encoder.";
     }
+    note_probe_fault();
     reset_state();
     return false;
 #endif

--- a/tests/unit/test_encoder_probe_suppression.cpp
+++ b/tests/unit/test_encoder_probe_suppression.cpp
@@ -1,0 +1,180 @@
+/**
+ * @file tests/unit/test_encoder_probe_suppression.cpp
+ * @brief Per-encoder, per-codec probe-fault suppression.
+ *
+ * The behaviour this protects: a graphics-driver fault while probing ONE codec
+ * used to cost the user the whole encoder on every probe pass, forever, because
+ * the probe re-runs on each launch and resume and negative results are not
+ * cached. Recording the faulted codec lets the next pass skip just that codec
+ * and validate the rest, so an AV1-specific driver bug no longer means software
+ * encoding for H.264 and HEVC too.
+ *
+ * The registry is deliberately pure so the policy is testable without a GPU,
+ * a display, or a driver fault to trigger.
+ */
+
+// standard includes
+#include <thread>
+#include <vector>
+
+// lib includes
+#include <gtest/gtest.h>
+
+// local includes
+#include "../tests_common.h"
+#include "src/encoder_probe_suppression.h"
+
+namespace {
+
+  using video::probe_suppression::codec_e;
+  using video::probe_suppression::codec_name;
+  using video::probe_suppression::is_suppressible;
+  using video::probe_suppression::registry_t;
+
+  TEST(EncoderProbeSuppression, NothingIsSuppressedInitially) {
+    registry_t reg;
+    EXPECT_FALSE(reg.is_suppressed("nvenc", codec_e::h264));
+    EXPECT_FALSE(reg.is_suppressed("nvenc", codec_e::hevc));
+    EXPECT_FALSE(reg.is_suppressed("nvenc", codec_e::av1));
+  }
+
+  TEST(EncoderProbeSuppression, SuppressingOneCodecLeavesTheOthersProbeable) {
+    // The whole point of the change: an AV1 fault must not cost H.264/HEVC.
+    registry_t reg;
+    reg.suppress("nvenc", codec_e::av1);
+
+    EXPECT_TRUE(reg.is_suppressed("nvenc", codec_e::av1));
+    EXPECT_FALSE(reg.is_suppressed("nvenc", codec_e::h264));
+    EXPECT_FALSE(reg.is_suppressed("nvenc", codec_e::hevc));
+  }
+
+  TEST(EncoderProbeSuppression, SuppressionIsScopedToOneEncoder) {
+    // A driver bug in NVENC's AV1 path says nothing about AMF or QSV, which
+    // are separate vendors' code — they must still be probed normally.
+    registry_t reg;
+    reg.suppress("nvenc", codec_e::av1);
+
+    EXPECT_FALSE(reg.is_suppressed("amdvce", codec_e::av1));
+    EXPECT_FALSE(reg.is_suppressed("quicksync", codec_e::av1));
+    EXPECT_FALSE(reg.is_suppressed("software", codec_e::av1));
+  }
+
+  TEST(EncoderProbeSuppression, H264IsNeverSuppressible) {
+    // Load-bearing, not conservatism. H.264 is mandatory, so suppressing it
+    // buys no partial result — but it would cost everything: the probe's
+    // shield also catches faults from shared setup (display acquisition, D3D
+    // device creation, DXGI duplication) and, on Windows, ordinary C++
+    // exceptions such as a std::bad_alloc from a wedged display stack. One
+    // transient fault of that kind sweeping the candidate list would suppress
+    // H.264 on every encoder INCLUDING the last-resort "software" entry,
+    // leaving probe_encoders() nothing to return. Unlike the per-pass
+    // encoder_list copy, this registry outlives the pass, so every launch and
+    // resume would answer HTTP 503 until the service restarted.
+    EXPECT_FALSE(is_suppressible(codec_e::h264));
+    EXPECT_FALSE(is_suppressible(codec_e::unattributed));
+    EXPECT_TRUE(is_suppressible(codec_e::hevc));
+    EXPECT_TRUE(is_suppressible(codec_e::av1));
+
+    registry_t reg;
+    reg.suppress("nvenc", codec_e::h264);
+    reg.suppress("software", codec_e::h264);
+    EXPECT_FALSE(reg.is_suppressed("nvenc", codec_e::h264));
+    EXPECT_FALSE(reg.is_suppressed("software", codec_e::h264));
+  }
+
+  TEST(EncoderProbeSuppression, TheSoftwareFallbackCanNeverBeDisabled) {
+    // The last-resort encoder must survive any sequence of faults, or the host
+    // has no encoder at all and refuses every connection.
+    registry_t reg;
+    for (const auto codec : {codec_e::h264, codec_e::hevc, codec_e::av1, codec_e::unattributed}) {
+      reg.suppress("software", codec);
+    }
+    EXPECT_FALSE(reg.is_suppressed("software", codec_e::h264));
+  }
+
+  TEST(EncoderProbeSuppression, UnattributedFaultsSuppressNothing) {
+    // Faults in shared setup (the SDR->HDR display reset between codec probes)
+    // cannot be blamed on a codec. Guessing would disable a healthy one, so the
+    // encoder is simply probed in full next pass.
+    registry_t reg;
+    reg.suppress("nvenc", codec_e::unattributed);
+
+    EXPECT_FALSE(reg.is_suppressed("nvenc", codec_e::h264));  // also non-suppressible by policy
+    EXPECT_FALSE(reg.is_suppressed("nvenc", codec_e::hevc));
+    EXPECT_FALSE(reg.is_suppressed("nvenc", codec_e::av1));
+    EXPECT_FALSE(reg.is_suppressed("nvenc", codec_e::unattributed));
+  }
+
+  TEST(EncoderProbeSuppression, RepeatedFaultsAreIdempotent) {
+    registry_t reg;
+    reg.suppress("nvenc", codec_e::hevc);
+    reg.suppress("nvenc", codec_e::hevc);
+
+    EXPECT_TRUE(reg.is_suppressed("nvenc", codec_e::hevc));
+    EXPECT_FALSE(reg.is_suppressed("nvenc", codec_e::h264));
+  }
+
+  TEST(EncoderProbeSuppression, CodecsAccumulateIndependently) {
+    // A second fault on a different codec must not clear the first.
+    registry_t reg;
+    reg.suppress("nvenc", codec_e::av1);
+    reg.suppress("nvenc", codec_e::hevc);
+
+    EXPECT_TRUE(reg.is_suppressed("nvenc", codec_e::av1));
+    EXPECT_TRUE(reg.is_suppressed("nvenc", codec_e::hevc));
+    EXPECT_FALSE(reg.is_suppressed("nvenc", codec_e::h264));
+  }
+
+  TEST(EncoderProbeSuppression, ClearDropsEverything) {
+    registry_t reg;
+    reg.suppress("nvenc", codec_e::av1);
+    reg.suppress("amdvce", codec_e::hevc);
+
+    reg.clear();
+
+    EXPECT_FALSE(reg.is_suppressed("nvenc", codec_e::av1));
+    EXPECT_FALSE(reg.is_suppressed("amdvce", codec_e::hevc));
+  }
+
+  TEST(EncoderProbeSuppression, ProcessRegistryIsASingleInstance) {
+    auto &a = video::probe_suppression::process_registry();
+    auto &b = video::probe_suppression::process_registry();
+    EXPECT_EQ(&a, &b);
+  }
+
+  TEST(EncoderProbeSuppression, ConcurrentAccessIsSafe) {
+    // probe_encoders() can run concurrently with a stream start, so the
+    // registry is consulted and written from more than one thread.
+    registry_t reg;
+    std::vector<std::thread> threads;
+    threads.reserve(8);
+    for (int i = 0; i < 8; ++i) {
+      threads.emplace_back([&reg, i] {
+        // Cycle through every enumerator, suppressible or not, so the
+        // non-suppressible early-outs are exercised under contention too.
+        const auto codec = static_cast<codec_e>(i % 4);
+        for (int n = 0; n < 200; ++n) {
+          reg.suppress("nvenc", codec);
+          (void) reg.is_suppressed("nvenc", codec);
+          (void) reg.is_suppressed("amdvce", codec);
+        }
+      });
+    }
+    for (auto &t : threads) {
+      t.join();
+    }
+
+    EXPECT_TRUE(reg.is_suppressed("nvenc", codec_e::hevc));
+    EXPECT_TRUE(reg.is_suppressed("nvenc", codec_e::av1));
+    EXPECT_FALSE(reg.is_suppressed("nvenc", codec_e::h264));
+    EXPECT_FALSE(reg.is_suppressed("amdvce", codec_e::hevc));
+  }
+
+  TEST(EncoderProbeSuppression, CodecNamesAreLoggable) {
+    EXPECT_STREQ(codec_name(codec_e::h264), "H.264");
+    EXPECT_STREQ(codec_name(codec_e::hevc), "HEVC");
+    EXPECT_STREQ(codec_name(codec_e::av1), "AV1");
+    EXPECT_STREQ(codec_name(codec_e::unattributed), "an unattributed stage");
+  }
+
+}  // namespace


### PR DESCRIPTION
## Summary

Follow-up to #159, closing the last item flagged there.

The encoder probe validates H.264 → HEVC → AV1 against one `encoder_t`, with the whole sequence inside a single SEH / C++ exception shield. A graphics-driver fault anywhere in it makes `validate_encoder_safe` discard **every** codec, and the caller then erases the encoder outright — so a driver bug specific to one codec costs the user hardware encoding entirely and drops them to `libx264`. Since the probe re-runs on every launch and resume and negative results are deliberately not cached, that repeats forever instead of self-healing.

This records which codec was in flight when the fault hit, and has the *next* probe pass skip that one codec for that one encoder — the same lever `H264_ONLY` already pulls. That pass then runs to completion, which is what makes its capability bits trustworthy.

## What it deliberately does not do

It does not salvage the faulted pass. That pass still resets all three codecs, still erases the encoder, and still falls back exactly as before.

An earlier version of this change *did* try to keep the codecs that had already passed. Independent review killed it, for three reasons worth recording:

- **Capability bits are fail-open.** `validate_encoder` starts with `capabilities.set()` — every bit 1 — and only ever corrects downward. A probe cut short leaves a codec claiming full support, HDR and 4:4:4 included.
- **H.264's own bits are not finalised until after the AV1 probe.** `YUV444` (~4025), `DYNAMIC_RANGE` (~4074) and the `VUI_PARAMETERS` mask (~4080) are all written later, so "H.264 already passed" is not a safe predicate. Keeping it would have re-shipped the exact bug the comment at 4020-4023 records — H.264 4:4:4 advertised on GPUs that can't encode it — plus H.264 HDR, which the code two lines on says outright is unsupported.
- **Returning `true` doesn't keep the encoder, it selects it.** At 4324 and 4389 a `true` return is immediately followed by `adjust_encoder_constraints(); new_encoder = encoder; break;`, so a faulted encoder would beat candidates that would have probed cleanly.

Also, on Windows the shield is a bare `__except` in a build with no `/EHa`, so no destructors run: the encode session and display from the faulted attempt are leaked, not released. There is no trustworthy result except a probe that ran to completion.

## H.264 is never suppressed

This is load-bearing, not conservatism. H.264 is mandatory, so skipping it preserves no partial result — while suppressing it would be catastrophic.

The shield also catches faults from **shared setup** (acquiring the display, creating the D3D device, DXGI duplication), and on Windows it catches ordinary C++ exceptions too — so a `std::bad_alloc` out of a wedged display stack qualifies. A single transient fault of that kind sweeping the candidate list would suppress H.264 on every encoder **including the last-resort `software` entry**, leaving `probe_encoders()` nothing to return. Unlike the per-pass `encoder_list` copy, this registry outlives the pass, so every launch and resume would answer **HTTP 503 until the service restarted**.

This was a real defect in the first draft of this PR, caught in review. It is now closed two ways: `is_suppressible()` excludes H.264 structurally, and the attribution window opens only *after* the display is acquired, so shared setup stays `unattributed` and incriminates no codec. Both are pinned by tests.

## Verification

**Unit** — 12 new tests. The registry is pure, so the policy is testable without a GPU or a fault to trigger: per-codec isolation, per-encoder isolation (an NVENC AV1 fault must not touch AMF's AV1), unattributed-suppresses-nothing, concurrency, and two regression tests for the defect above — `H264IsNeverSuppressible` and `TheSoftwareFallbackCanNeverBeDisabled`.

**Suite** — 665 tests, 644 passed, 9 skipped, 12 failed: the same 12 environment-sensitive auth/Playnite/locale failures present on unmodified `main`.

**Real hardware (RTX 5080)** — the NVENC probe is unchanged: 5 native D3D12 selections and the same six encoders with identical flags, HDR/10-bit and 4:4:4 variants included, zero faults, zero suppression events. On a clean run this change does nothing at all — the only additions that execute are enum stores nothing reads and lookups against an empty map.

**Reviewed for non-interference** with encode paths, HDR, D3D11 / D3D12 / D3D11onD3D12, and connection establishment. Transport selection reads none of this state; the `yuv444p16` D3D11-on-CUDA exemption keys on chroma/dynamic-range, not codec. A suppressed codec has its capabilities zeroed and is demoted to mode 1 (advertised nowhere), so serverinfo and DESCRIBE simply drop it and an ANNOUNCE for it gets the standard RTSP 400 — an AV1-suppressed host looks exactly like a Turing card. The probe cache is not poisoned: it already refuses to serve cached negatives.

## Known limitations

- Suppression is process-lifetime and a **GPU driver update does not clear it**, because installing a driver doesn't restart the service. Documented in the header. Bounded impact now that only HEVC/AV1 can be suppressed.
- A suppressed pass issues fewer `nvEncInitializeEncoder` calls, so it may leave `d3d12_nvenc_rejected` unlatched where a full pass would have set it. Cost is one failed D3D12 init on the first real stream, then the existing runtime fallback degrades in place.

## Pre-existing, raised separately

The WebRTC signaling layer has no capability gate — `confighttp.cpp` validates the codec string only, never against the active modes. The isolated video worker still rejects a codec missing from the validated snapshot, so this is negotiation quality rather than a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
