### PR TITLE
docs(codecov): correct the patch-target rationale to the measured baseline

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,13 +16,22 @@ coverage:
         target: auto
         threshold: 10%
         flags: [web]
-    # Patch coverage threshold. The project's overall C++ coverage is in the
-    # single digits because most of the codebase is Windows graphics-driver
-    # integration that cannot be unit-tested without real GPU / display
-    # hardware. Set the patch floor to 25% — roughly 3x the project baseline
-    # — so changes are expected to be meaningfully more testable than the
-    # repo average without demanding coverage levels that are structurally
-    # unreachable for hardware-bound code paths.
+    # Patch coverage threshold. The project's overall C++ coverage sits in the
+    # low teens (13.5% on main as of 2026-08-30) because most of the codebase
+    # is Windows graphics-driver integration that cannot be unit-tested
+    # without real GPU / display hardware. Set the patch floor to 25% —
+    # roughly 2x the project baseline — so changes are expected to be
+    # meaningfully more testable than the repo average without demanding
+    # coverage levels that are structurally unreachable for hardware-bound
+    # code paths.
+    #
+    # The "single digits / roughly 3x" figures this comment used to quote were
+    # never actually measured. The windows flag uploaded an all-zero report
+    # until the coverage build was fixed (#160), so the C++ baseline was
+    # unknowable and 25% was really ~3x an assumption. It is ~1.9x the real
+    # number. The floor is left at 25% deliberately — it is still a meaningful
+    # step above the repo average — but re-check this ratio if the baseline
+    # moves materially.
     patch:
       default:
         target: 25%


### PR DESCRIPTION
Follow-up to #160. Comment-only; **the 25% patch floor is unchanged.**

The threshold's justification quoted two figures that were never measured:

> The project's overall C++ coverage is in the **single digits** … Set the patch floor to 25% — **roughly 3x** the project baseline

Neither could have been known when it was written. The `windows` flag uploaded an all-zero report until the coverage build was fixed in #160, so the C++ baseline was unobservable — 25% was really ~3x an *assumption*.

With real data flowing, `main` measures **13.5%** (6,437 of 47,770 lines, run [33342415971](https://github.com/NortheBridge/luminalshine/actions/runs/33342415971)), which makes the 25% floor about **1.9x** the baseline.

### Why the number itself is left alone

Raising the floor to ~40% to preserve the original "3x" framing would be a policy change affecting every contributor, not a correction — so that's deliberately not in this PR. 25% is still a meaningful step above the repo average. The comment now states the real ratio and flags it for re-checking if the baseline moves.

If you'd rather restore the 3x intent, that's a one-line change to `target:` and I'm happy to do it — but it should be a conscious call, not a side effect of fixing a stale comment.
