### PR TITLE
fix(tests): root-cause the SimpleWebLifetime coverage segfault

### DIFF
--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -219,7 +219,7 @@ jobs:
         # writes its .gcda counters from an atexit handler: a process killed by
         # a signal contributes NOTHING, no matter how many tests passed first.
         # That is the bug this step shipped with — one segfault
-        # (SimpleWebLifetime, see below) discarded the entire run, and gcovr
+        # (SimpleWebLifetime) discarded the entire run, and gcovr
         # then reconstructed a structurally complete but 0%-covered report from
         # the .gcno compile-time notes alone. Nothing in that report says the
         # runtime data is missing, so it uploaded clean and quietly failed
@@ -234,15 +234,19 @@ jobs:
         continue-on-error: true
         working-directory: build/tests
         env:
-          # SimpleWebLifetime is a Boost.Asio threading stress test with
-          # deliberately aggressive 1s/2s timeouts. It passes in the optimized
-          # ci-windows / nightly builds (~3s) but segfaults within ~25ms under
-          # Debug -O0 + gcov instrumentation, whose overhead invalidates those
-          # timing assumptions. What it exercises is
-          # third-party/Simple-Web-Server, which the report excludes anyway, so
-          # skipping it here costs no reported coverage while leaving it a real
-          # gate in the builds where it is meaningful.
-          COVERAGE_GTEST_FILTER: '-SimpleWebLifetime.*'
+          # No --gtest_filter here: the whole suite runs under coverage.
+          #
+          # SimpleWebLifetime used to be excluded because it segfaulted within
+          # ~25ms in this build while passing in the optimized ci-windows /
+          # nightly builds. That was never a timing or instrumentation
+          # artifact: the test's SSE leg drove the Simple-Web-Server *client*
+          # into a use-after-free that only -O0 makes fatal (-O1 and above
+          # happen to survive it), and gcov was an innocent bystander — it
+          # writes .gcda from an atexit handler, so the signal merely made the
+          # loss visible. Fixed twice over: at the source in the fork
+          # (NortheBridge/Simple-Web-Server#3, picked up by the submodule bump)
+          # and in tests/unit/test_simpleweb_lifetime.cpp, which now issues
+          # that request over a raw socket. The test gates this build again.
           COVERAGE_SHARDS: '6'
         run: |
           set +e
@@ -252,7 +256,6 @@ jobs:
             GTEST_TOTAL_SHARDS="${COVERAGE_SHARDS}" GTEST_SHARD_INDEX="${i}" \
               ./test_sunshine.exe \
                 --gtest_color=yes \
-                --gtest_filter="${COVERAGE_GTEST_FILTER}" \
                 --gtest_output="xml:test_results/shard_${i}.xml"
             rc=$?
             # Exit >=128 is a fatal signal (139 = SIGSEGV) and means this

--- a/tests/unit/test_simpleweb_lifetime.cpp
+++ b/tests/unit/test_simpleweb_lifetime.cpp
@@ -117,10 +117,47 @@ namespace {
             }
             // Odd threads also open an SSE stream and abandon it early,
             // forcing server-side response drops with writes in flight.
+            //
+            // Deliberately a raw socket rather than HttpClient, for two
+            // reasons.
+            //
+            // An abrupt half-read disconnect is the closer match to the real
+            // early-dropping client this test models: it drops the connection
+            // mid-stream rather than letting a client library shut it down
+            // tidily.
+            //
+            // It also keeps the test independent of the SSE path in
+            // Simple-Web-Server's client. On "Content-Type:
+            // text/event-stream" that client switches into a server-sent-event
+            // read loop which kept invoking the request completion callback
+            // once per event — long after ClientBase::sync_request() had
+            // returned and destroyed the response/promise locals the callback
+            // captured by reference, so the late invocations read a dangling
+            // shared_ptr and called Response::close() through it. Optimized
+            // builds happened to survive that; -O0 did not, which is why this
+            // whole suite used to die here under the coverage build, and why
+            // the run was excluded from it. Fixed in the fork by
+            // NortheBridge/Simple-Web-Server#3 and picked up by the submodule
+            // bump alongside this change — but that was a client-side bug,
+            // unrelated to the server-side lifetime hazard this test exists to
+            // guard, and nothing here needs the client to reach the hazard.
             if (t % 2 == 1) {
               try {
-                client.request("GET", "/sse");
+                SimpleWeb::io_context io;
+                SimpleWeb::asio::ip::tcp::socket socket(io);
+                socket.connect(SimpleWeb::asio::ip::tcp::endpoint(SimpleWeb::make_address("127.0.0.1"), port.load()));
+
+                const std::string req = "GET /sse HTTP/1.1\r\nHost: " + host + "\r\n\r\n";
+
+                SimpleWeb::asio::write(socket, SimpleWeb::asio::buffer(req));
                 requests.fetch_add(1);
+
+                // Read part of the stream, then drop the connection while the
+                // server's detached thread still has sends queued.
+                char buf[64];
+                SimpleWeb::error_code ec;
+                socket.read_some(SimpleWeb::asio::buffer(buf), ec);
+                socket.close(ec);
               } catch (...) {
                 // Early disconnects / timeouts are expected here.
               }


### PR DESCRIPTION
Root-causes the `SimpleWebLifetime.KeepAliveAndForeignThreadSseStress` segfault that [#160](https://github.com/NortheBridge/luminalshine/pull/160) routed around, and removes the exclusion it added.

## It wasn't gcov, and it wasn't the server

#160 attributed the crash to "Debug -O0 + gcov instrumentation, whose overhead invalidates those timing assumptions". That was wrong on both counts. It is a **use-after-free in the Simple-Web-Server *client***.

`ClientBase::sync_request()` passes the async chain a lambda capturing `response` and `response_promise` **by reference** — both locals of its own stack frame — and only sets its `stop_future_handlers` guard after `set_exception()`, never after `set_value()`.

The test's `/sse` endpoint replies `Content-Type: text/event-stream`, so the client enters `read_server_sent_event()` and re-invokes that callback **once per event, indefinitely, always with a clear `error_code`** — long after `sync_request()` returned and destroyed the frame. Instrumented: **~190 such invocations per 3-second run**. Each reads the dangling `response`, computes garbage streambuf sizes, takes the `message_size` branch, and calls `Response::close()` through a freed pointer:

```
#0  std::_Sp_counted_base<...>::_M_get_use_count (this=0xfeababababababab)
#5  std::weak_ptr<ClientBase<...>::Connection>::lock ()
#6  ClientBase<...>::Response::close ()                 client_http.hpp:128
#7  ClientBase<...>::sync_request<...>::{lambda#1}()    client_http.hpp:446
#17 ClientBase<...>::read_server_sent_event(...)        client_http.hpp:813
```

The `eof` invocation then hits `set_exception()` on a destroyed promise — the second observed symptom, `std::future_error: Promise already satisfied`.

**Debug `-O0` alone reproduces it.** gcov is irrelevant to the cause; it only made the damage *visible*, because it writes `.gcda` from an `atexit` handler that a signal skips.

| flags | crash rate |
|---|---|
| `-O0` | **5/5** |
| `-O1` | 0/5 |
| `-O2` | 0/5 |
| `-O3` | 0/5 |

So the optimized ci-windows / nightly builds have been passing on luck, not correctness.

## Fixed at the source and in the test

- **Submodule bump** to pick up [NortheBridge/Simple-Web-Server#3](https://github.com/NortheBridge/Simple-Web-Server/pull/3), which sets `stop_future_handlers` after `set_value()` exactly as the error path already does.
- **The test's SSE leg now uses a raw socket** (connect, write, `read_some`, close) instead of `HttpClient`. This is not just belt-and-braces: an abrupt half-read disconnect is a closer match to the early-dropping client the test models, and it keeps a server regression test from depending on the client's SSE path at all.
- **`COVERAGE_GTEST_FILTER` removed** from `coverage-windows.yml`, so the test gates the coverage build again. The comment recording the wrong cause is corrected.

## Verification

All against the real test file built with GoogleTest at `-O0` with `-fprofile-arcs -ftest-coverage`:

| check | before | after |
|---|---|---|
| crash rate | 8/8 | **0/8**, plus 20/20 soak clean |
| `.gcda` emitted | **0** | written, test passes in ~3.1s |
| `-O2` (ci-windows path) | passes | passes |
| server hazard intensity | ~470 dropped/run | ~420 dropped/run |

The client fix **alone** also takes the *unmodified* test from 8/8 crashes to 8/8 passes, confirming it addresses the root cause rather than masking it.

Upstream `sws_io_test` (including its async event-stream cases), `sws_parse_test` and `sws_status_code_test` all pass with the client fix.

## Note on scope

`SimpleWeb::Client` appears nowhere in `src/` — LuminalShine ships only the server halves — so this was never a product-facing bug, only a test-harness one. The fork fix is still worth having so the next consumer of that client doesn't rediscover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
