### PR TITLE
fix(capture): hold the cursor visible while the OS visibility flag flaps

### DIFF
--- a/src/platform/windows/cursor_visibility_filter.h
+++ b/src/platform/windows/cursor_visibility_filter.h
@@ -1,0 +1,242 @@
+/**
+ * @file src/platform/windows/cursor_visibility_filter.h
+ * @brief Pure decision logic that keeps a flapping OS cursor-visibility flag from blinking the streamed cursor.
+ */
+#pragma once
+
+// standard includes
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+namespace platf::dxgi {
+
+  /**
+   * @brief Rate filter for the OS-reported mouse cursor visibility flag.
+   *
+   * Every capture path blends the cursor only while Windows says it is visible
+   * (DDA `PointerPosition.Visible`, the LuminalVGD hardware-cursor plane's
+   * `IsCursorVisible`). That is the right contract: a game hides its cursor and
+   * the stream must follow within a frame.
+   *
+   * Windows 11 Insider flights have shipped a fault in which "the mouse cursor
+   * gets into a state where it blinks repeatedly" (Microsoft's known-issue text
+   * for build 29648.1000; the same fault was fixed on the 26300 line in
+   * 26300.8935). The OS toggles that flag on and off, the capture path mirrors
+   * it faithfully, and the client sees a blinking cursor.
+   *
+   * The two are told apart by rate. A legitimate visibility change happens at
+   * human cadence — a menu opening, a game grabbing the mouse — a few times a
+   * minute at most. A blink is periodic and sustained. So:
+   *  - Every report passes straight through until `flap_threshold` hide
+   *    transitions land inside `flap_window`: no added latency in the normal case.
+   *  - Once they do, the filter HOLDS the cursor visible and ignores hidden
+   *    reports: a cursor the OS cannot stop toggling is one the user is using.
+   *  - The hold ends once the reported state has been stable (no transition at
+   *    all) for `settle_time`, and the reported state is honoured again. A game
+   *    that hides the cursor while a hold is active gets its hidden cursor
+   *    within `settle_time`; a resumed blink re-arms the hold after another
+   *    `flap_threshold` cycles.
+   *  - The hold is therefore bounded by `settle_time` AFTER THE FLAG STOPS
+   *    CHANGING, not by `flap_window`: while the OS keeps toggling, the
+   *    cursor stays visible, which is what the local display shows too.
+   *  - A caller that only hears from the OS on pointer updates (DDA) must
+   *    tick() between reports so a hold can end while the mouse is still.
+   *  - take_stats() reports transition counts per `stats_interval`, so a
+   *    flap that never reaches the threshold still shows up in the log.
+   *
+   * Removal criterion: drop this once no supported Windows build reports the
+   * flap (fixed on the 26300 line in 26300.8935, documented open on 29648.1000).
+   *
+   * Pure and allocation-free: the ring capture path calls it at its 1 kHz
+   * claim-poll cadence.
+   */
+  class cursor_visibility_filter_t {
+  public:
+    using clock = std::chrono::steady_clock;
+
+    struct config_t {
+      /// Hide transitions must all land inside this window to count as a flap
+      /// (3 hides in 3 s = a blink period of 1.5 s or faster).
+      std::chrono::milliseconds flap_window {3000};
+      /// Number of visible->hidden transitions inside `flap_window` that starts a hold (2..8).
+      int flap_threshold {3};
+      /// A hold ends once the reported flag has not changed for this long.
+      std::chrono::milliseconds settle_time {2000};
+      /// How often take_stats() has something to say (only when the flag moved).
+      std::chrono::milliseconds stats_interval {30000};
+    };
+
+    enum class event_e {
+      hold_started,
+      hold_ended,
+    };
+
+    /// One-shot notification for the caller's log line (see take_event()).
+    struct event_t {
+      event_e kind;
+      /// hold_started: hides inside the window. hold_ended: hides suppressed during the hold.
+      int hide_count;
+      /// hold_started: span covered by those hides. hold_ended: hold duration.
+      std::chrono::milliseconds span;
+    };
+
+    /// Periodic transition telemetry (see take_stats()).
+    struct stats_t {
+      /// Visibility transitions (either direction) inside the interval.
+      int transitions;
+      /// Shortest gap between consecutive transitions seen in the interval.
+      std::chrono::milliseconds min_gap;
+      /// Actual length of the interval reported.
+      std::chrono::milliseconds interval;
+    };
+
+    cursor_visibility_filter_t() = default;
+
+    explicit cursor_visibility_filter_t(config_t cfg):
+        _cfg(cfg) {}
+
+    /**
+     * @brief Feed one OS report and get the visibility the frame should use.
+     * @param reported_visible The flag as the OS reported it.
+     * @param now Monotonic time of the report.
+     * @return The effective visibility for this frame.
+     */
+    bool apply(bool reported_visible, clock::time_point now) {
+      if (_last_reported && *_last_reported != reported_visible) {
+        if (_transition_count > 0) {
+          const auto gap = std::chrono::duration_cast<std::chrono::milliseconds>(now - _last_transition_at);
+          _stats_min_gap = _stats_min_gap ? std::min(*_stats_min_gap, gap) : gap;
+        }
+        ++_transition_count;
+        ++_stats_transitions;
+        _last_transition_at = now;
+        if (!reported_visible) {
+          push_hide(now);
+          if (_holding) {
+            ++_hides_during_hold;
+          }
+        }
+      }
+      _last_reported = reported_visible;
+
+      if (!_holding) {
+        const int n = threshold();
+        if (_hide_count >= n) {
+          const auto oldest = nth_most_recent_hide(n);
+          if (now - oldest <= _cfg.flap_window) {
+            _holding = true;
+            ++_holds_started;
+            _hold_started_at = now;
+            _hides_during_hold = 1;  // the hide that tripped the threshold is suppressed too
+            _event = event_t {event_e::hold_started, n, std::chrono::duration_cast<std::chrono::milliseconds>(now - oldest)};
+          }
+        }
+      } else if (now - _last_transition_at >= _cfg.settle_time) {
+        _holding = false;
+        _event = event_t {event_e::hold_ended, _hides_during_hold, std::chrono::duration_cast<std::chrono::milliseconds>(now - _hold_started_at)};
+        // Forget the flap's hides so an unrelated later hide cannot combine
+        // with stale ones and re-arm the hold on its own.
+        _hide_count = 0;
+        _hides_during_hold = 0;
+      }
+
+      roll_stats(now);
+      return _holding ? true : reported_visible;
+    }
+
+    /**
+     * @brief Re-evaluate without a new report (the OS only speaks on pointer updates).
+     * @return The effective visibility, or nullopt before the first report.
+     */
+    std::optional<bool> tick(clock::time_point now) {
+      if (!_last_reported) {
+        return std::nullopt;
+      }
+      return apply(*_last_reported, now);  // same value: no transition is recorded
+    }
+
+    /// True while hidden reports are being overridden.
+    bool holding() const {
+      return _holding;
+    }
+
+    /// Number of holds started since construction (the first one is the interesting log line).
+    int holds_started() const {
+      return _holds_started;
+    }
+
+    /// Drain the pending hold_started / hold_ended notification, if any.
+    std::optional<event_t> take_event() {
+      auto e = _event;
+      _event.reset();
+      return e;
+    }
+
+    /// Drain the pending per-interval telemetry; set only when the flag moved in that interval.
+    std::optional<stats_t> take_stats() {
+      auto s = _stats;
+      _stats.reset();
+      return s;
+    }
+
+  private:
+    static constexpr std::size_t kCapacity = 8;
+
+    int threshold() const {
+      return std::clamp(_cfg.flap_threshold, 2, static_cast<int>(kCapacity));
+    }
+
+    void push_hide(clock::time_point at) {
+      _hides[_hide_head] = at;
+      _hide_head = (_hide_head + 1) % kCapacity;
+      _hide_count = std::min(_hide_count + 1, static_cast<int>(kCapacity));
+    }
+
+    /// Timestamp of the n-th most recent hide (n == 1 is the newest); caller guarantees _hide_count >= n.
+    clock::time_point nth_most_recent_hide(int n) const {
+      return _hides[(_hide_head + kCapacity - static_cast<std::size_t>(n)) % kCapacity];
+    }
+
+    /// Close the telemetry interval when it has elapsed; publish only if the flag moved.
+    void roll_stats(clock::time_point now) {
+      if (_stats_window_started == clock::time_point {}) {
+        _stats_window_started = now;
+        return;
+      }
+      const auto elapsed = now - _stats_window_started;
+      if (elapsed < _cfg.stats_interval) {
+        return;
+      }
+      if (_stats_transitions > 0) {
+        _stats = stats_t {_stats_transitions, _stats_min_gap.value_or(std::chrono::milliseconds {0}), std::chrono::duration_cast<std::chrono::milliseconds>(elapsed)};
+      }
+      _stats_transitions = 0;
+      _stats_min_gap.reset();
+      _stats_window_started = now;
+    }
+
+    config_t _cfg {};
+    std::optional<bool> _last_reported;
+    clock::time_point _last_transition_at {};
+    std::array<clock::time_point, kCapacity> _hides {};
+    std::size_t _hide_head = 0;
+    int _hide_count = 0;
+    bool _holding = false;
+    clock::time_point _hold_started_at {};
+    int _hides_during_hold = 0;
+    int _holds_started = 0;
+    std::optional<event_t> _event;
+    /// Total transitions ever seen (the first one has no predecessor to measure a gap against).
+    std::uint64_t _transition_count = 0;
+    clock::time_point _stats_window_started {};
+    int _stats_transitions = 0;
+    /// Shortest gap between consecutive transitions in the current interval (unset until two have been seen).
+    std::optional<std::chrono::milliseconds> _stats_min_gap;
+    std::optional<stats_t> _stats;
+  };
+
+}  // namespace platf::dxgi

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -24,6 +24,7 @@
 #include "src/platform/common.h"
 #include "src/platform/windows/ipc/pipes.h"
 #include "src/platform/windows/ipc/process_handler.h"
+#include "src/platform/windows/cursor_visibility_filter.h"
 #include "src/platform/windows/vgd_ring_liveness.h"
 #include "src/utility.h"
 #include "src/video.h"
@@ -518,6 +519,8 @@ namespace platf::dxgi {
 
     duplication_t dup;
     cursor_t cursor;
+    /// Rate filter on the OS-reported cursor visibility (Insider cursor-blink fault).
+    cursor_visibility_filter_t cursor_visibility_filter;
   };
 
   /**
@@ -541,6 +544,8 @@ namespace platf::dxgi {
 
     gpu_cursor_t cursor_alpha;
     gpu_cursor_t cursor_xor;
+    /// Rate filter on the OS-reported cursor visibility (Insider cursor-blink fault).
+    cursor_visibility_filter_t cursor_visibility_filter;
 
     texture2d_t old_surface_delayed_destruction;
     std::chrono::steady_clock::time_point old_surface_timestamp;
@@ -852,6 +857,8 @@ namespace platf::dxgi {
     vs_t _cursor_vs;
     gpu_cursor_t _cursor_alpha;
     gpu_cursor_t _cursor_xor;
+    /// Rate filter on the OS-reported cursor visibility (Insider cursor-blink fault).
+    cursor_visibility_filter_t _cursor_visibility_filter;
     std::vector<std::uint8_t> _cursor_shape_buf;
     /// Shape generation currently uploaded to the GPU cursors.
     uint32_t _cursor_shape_generation = 0;

--- a/src/platform/windows/display_ram.cpp
+++ b/src/platform/windows/display_ram.cpp
@@ -4,6 +4,7 @@
  */
 // local includes
 #include "display.h"
+#include "display_vram.h"
 #include "misc.h"
 #include "src/logging.h"
 
@@ -215,8 +216,12 @@ namespace platf::dxgi {
     if (frame_info.LastMouseUpdateTime.QuadPart) {
       cursor.x = frame_info.PointerPosition.Position.x;
       cursor.y = frame_info.PointerPosition.Position.y;
-      cursor.visible = frame_info.PointerPosition.Visible;
+      // Same flap filter as the VRAM paths (cursor_visibility_filter.h).
+      cursor.visible = cursor_visibility_filter.apply(frame_info.PointerPosition.Visible != FALSE, std::chrono::steady_clock::now());
+    } else if (const auto visible = cursor_visibility_filter.tick(std::chrono::steady_clock::now())) {
+      cursor.visible = *visible;
     }
+    log_cursor_visibility_event("DDA", cursor_visibility_filter);
 
     if (frame_update_flag) {
       {

--- a/src/platform/windows/display_vgd.cpp
+++ b/src/platform/windows/display_vgd.cpp
@@ -673,8 +673,13 @@ namespace platf::dxgi {
       // A failed fetch (driver mid-rewrite) retries on the next snapshot.
     }
 
-    _cursor_alpha.set_pos(state.x, state.y, width_before_rotation, height_before_rotation, display_rotation, state.visible != 0);
-    _cursor_xor.set_pos(state.x, state.y, width_before_rotation, height_before_rotation, display_rotation, state.visible != 0);
+    // The OS flag goes through the flap filter first: Windows 11 Insider
+    // flights toggle it on and off (a known OS issue), and mirroring that
+    // faithfully blinks the streamed cursor. See cursor_visibility_filter.h.
+    const bool visible = _cursor_visibility_filter.apply(state.visible != 0, std::chrono::steady_clock::now());
+    log_cursor_visibility_event("LuminalVGD", _cursor_visibility_filter);
+    _cursor_alpha.set_pos(state.x, state.y, width_before_rotation, height_before_rotation, display_rotation, visible);
+    _cursor_xor.set_pos(state.x, state.y, width_before_rotation, height_before_rotation, display_rotation, visible);
   }
 
   void display_vgd_vram_t::blend_cursor_into(img_d3d_t &d3d_img) {

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -226,6 +226,48 @@ namespace platf::dxgi {
     }
   };
 
+  namespace {
+    /// The running OS build, read once: a field report of a cursor flap is
+    /// only useful if it can be matched against Microsoft's release notes.
+    std::uint32_t windows_build_number() {
+      static const std::uint32_t build = [] {
+        return query_windows_version().build_number.value_or(0u);
+      }();
+      return build;
+    }
+  }  // namespace
+
+  void log_cursor_visibility_event(const char *backend, cursor_visibility_filter_t &filter) {
+    if (const auto stats = filter.take_stats()) {
+      // Emitted only for intervals in which the flag moved at all, so a
+      // flap too slow to arm the hold is still visible in the log.
+      BOOST_LOG(info) << backend << " capture: the OS cursor-visibility flag changed " << stats->transitions
+                      << " times in the last " << stats->interval.count() / 1000 << " s (shortest gap "
+                      << stats->min_gap.count() << " ms)" << (filter.holding() ? "; hold active." : ".");
+    }
+    const auto event = filter.take_event();
+    if (!event) {
+      return;
+    }
+    switch (event->kind) {
+      case cursor_visibility_filter_t::event_e::hold_started: {
+        // The first hold per display is a warning; a bursty flap re-arms
+        // every few seconds and must not flood the log at that level.
+        auto &hold_logger = filter.holds_started() == 1 ? warning : info;
+        BOOST_LOG(hold_logger) << backend << " capture: the OS cursor-visibility flag is flapping ("
+                               << event->hide_count << " hides in " << event->span.count()
+                               << " ms) on Windows build " << windows_build_number()
+                               << "; holding the cursor visible until the flag settles. This is the pattern of "
+                                  "the cursor-blink fault Microsoft documents for some Windows 11 Insider flights.";
+        break;
+      }
+      case cursor_visibility_filter_t::event_e::hold_ended:
+        BOOST_LOG(info) << backend << " capture: cursor visibility settled after " << event->span.count()
+                        << " ms (" << event->hide_count << " hides suppressed); following the OS flag again.";
+        break;
+    }
+  }
+
   util::buffer_t<std::uint8_t> make_cursor_xor_image(const util::buffer_t<std::uint8_t> &img_data, DXGI_OUTDUPL_POINTER_SHAPE_INFO shape_info) {
     constexpr std::uint32_t inverted = 0xFFFFFFFF;
     constexpr std::uint32_t transparent = 0;
@@ -1364,10 +1406,20 @@ namespace platf::dxgi {
     }
 
     if (frame_info.LastMouseUpdateTime.QuadPart) {
-      cursor_alpha.set_pos(frame_info.PointerPosition.Position.x, frame_info.PointerPosition.Position.y, width, height, display_rotation, frame_info.PointerPosition.Visible);
+      // Same flap filter as the LuminalVGD path (cursor_visibility_filter.h):
+      // DDA mirrors the same OS flag, and the same Insider fault blinks it.
+      const bool visible = cursor_visibility_filter.apply(frame_info.PointerPosition.Visible != FALSE, host_processing_timestamp);
+      cursor_alpha.set_pos(frame_info.PointerPosition.Position.x, frame_info.PointerPosition.Position.y, width, height, display_rotation, visible);
 
-      cursor_xor.set_pos(frame_info.PointerPosition.Position.x, frame_info.PointerPosition.Position.y, width, height, display_rotation, frame_info.PointerPosition.Visible);
+      cursor_xor.set_pos(frame_info.PointerPosition.Position.x, frame_info.PointerPosition.Position.y, width, height, display_rotation, visible);
+    } else if (const auto visible = cursor_visibility_filter.tick(host_processing_timestamp); visible && *visible != cursor_alpha.visible) {
+      // No pointer update this frame: DDA only reports the flag on pointer
+      // updates, so without this a hold could outlive the flap for as long
+      // as the mouse stays still. Position is unchanged; only the bit moves.
+      cursor_alpha.visible = *visible;
+      cursor_xor.visible = *visible;
     }
+    log_cursor_visibility_event("DDA", cursor_visibility_filter);
 
     const bool blend_mouse_cursor_flag = (cursor_alpha.visible || cursor_xor.visible) && cursor_visible;
 

--- a/src/platform/windows/display_vram.h
+++ b/src/platform/windows/display_vram.h
@@ -50,5 +50,7 @@ namespace platf::dxgi {
   util::buffer_t<std::uint8_t> make_cursor_alpha_image(const util::buffer_t<std::uint8_t> &img_data, DXGI_OUTDUPL_POINTER_SHAPE_INFO shape_info);
   util::buffer_t<std::uint8_t> make_cursor_xor_image(const util::buffer_t<std::uint8_t> &img_data, DXGI_OUTDUPL_POINTER_SHAPE_INFO shape_info);
   bool set_cursor_texture(device_t::pointer device, gpu_cursor_t &cursor, util::buffer_t<std::uint8_t> &&cursor_img, DXGI_OUTDUPL_POINTER_SHAPE_INFO &shape_info);
+  /// Drain the filter's pending hold_started / hold_ended notification into the log.
+  void log_cursor_visibility_event(const char *backend, cursor_visibility_filter_t &filter);
 
 }  // namespace platf::dxgi

--- a/tests/unit/test_cursor_visibility_filter.cpp
+++ b/tests/unit/test_cursor_visibility_filter.cpp
@@ -1,0 +1,265 @@
+/**
+ * @file tests/unit/test_cursor_visibility_filter.cpp
+ * @brief Unit tests for the cursor visibility flap filter.
+ *
+ * Windows 11 Insider flights (Microsoft's known-issue text for build
+ * 29648.1000; fixed earlier on the 26300 line in 26300.8935) toggle the
+ * OS cursor-visibility flag on and off, and every capture path mirrors that
+ * flag into whether the cursor is blended, so the client sees the cursor
+ * blink. These tests pin the filter's contract:
+ *  - Normal visibility changes pass through with no added latency, including
+ *    a game hiding the cursor and a couple of quick toggles.
+ *  - A sustained flap (`flap_threshold` hides inside `flap_window`) starts a
+ *    hold that keeps the cursor visible while the flag keeps toggling.
+ *  - The hold ends only once the flag has been stable for `settle_time`, and
+ *    the reported state, hidden included, is honoured again.
+ *  - A flap's hides never combine with a later unrelated hide.
+ */
+#include "../tests_common.h"
+#include "src/platform/windows/cursor_visibility_filter.h"
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+using platf::dxgi::cursor_visibility_filter_t;
+using filter_clock = cursor_visibility_filter_t::clock;
+
+namespace {
+
+  filter_clock::time_point base() {
+    // A fixed origin keeps the arithmetic readable; the filter only ever looks at differences.
+    return filter_clock::time_point {} + 1h;
+  }
+
+  /// Feed alternating hidden/visible reports every `half_period`, starting with a hide at `t`.
+  /// Returns the time after the last report.
+  filter_clock::time_point blink(cursor_visibility_filter_t &f, filter_clock::time_point t, std::chrono::milliseconds half_period, int cycles) {
+    for (int i = 0; i < cycles; ++i) {
+      f.apply(false, t);
+      t += half_period;
+      f.apply(true, t);
+      t += half_period;
+    }
+    return t;
+  }
+
+}  // namespace
+
+TEST(CursorVisibilityFilter, SteadyStatesPassThrough) {
+  cursor_visibility_filter_t f;
+  auto t = base();
+  for (int i = 0; i < 100; ++i) {
+    EXPECT_TRUE(f.apply(true, t));
+    t += 1ms;
+  }
+  EXPECT_FALSE(f.holding());
+  for (int i = 0; i < 100; ++i) {
+    EXPECT_FALSE(f.apply(false, t));
+    t += 1ms;
+  }
+  EXPECT_FALSE(f.holding());
+  EXPECT_FALSE(f.take_event().has_value());
+}
+
+TEST(CursorVisibilityFilter, GameHidingCursorIsHonouredImmediately) {
+  cursor_visibility_filter_t f;
+  auto t = base();
+  EXPECT_TRUE(f.apply(true, t));
+  t += 5s;
+  // The very report that hides the cursor is honoured: no debounce latency.
+  EXPECT_FALSE(f.apply(false, t));
+  t += 30s;
+  EXPECT_FALSE(f.apply(false, t));
+  t += 1ms;
+  EXPECT_TRUE(f.apply(true, t));
+  EXPECT_FALSE(f.holding());
+}
+
+TEST(CursorVisibilityFilter, TwoQuickTogglesDoNotStartAHold) {
+  cursor_visibility_filter_t f;
+  auto t = base();
+  f.apply(true, t);
+  t = blink(f, t, 100ms, 2);  // two hides inside 400 ms: below the threshold of three
+  EXPECT_FALSE(f.holding());
+  EXPECT_TRUE(f.apply(true, t));
+  EXPECT_FALSE(f.take_event().has_value());
+  // A third hide well outside the window (hides at 0, 200 and 3900 ms span
+  // more than 3 s) is an ordinary hide and passes through.
+  t += 3500ms;
+  EXPECT_FALSE(f.apply(false, t));
+  EXPECT_FALSE(f.holding());
+}
+
+TEST(CursorVisibilityFilter, SustainedFlapStartsAHoldOnTheThirdHide) {
+  cursor_visibility_filter_t f;
+  auto t = base();
+  f.apply(true, t);
+  t = blink(f, t, 400ms, 2);  // hides at 0 and 800 ms, both honoured
+  EXPECT_FALSE(f.holding());
+  // Third hide at 1600 ms: 3 hides inside 1.6 s -> hold starts, and this hide is suppressed.
+  EXPECT_TRUE(f.apply(false, t));
+  EXPECT_TRUE(f.holding());
+  auto ev = f.take_event();
+  ASSERT_TRUE(ev.has_value());
+  EXPECT_EQ(ev->kind, cursor_visibility_filter_t::event_e::hold_started);
+  EXPECT_EQ(ev->hide_count, 3);
+  EXPECT_EQ(ev->span, 1600ms);
+  EXPECT_FALSE(f.take_event().has_value());  // one-shot
+  EXPECT_EQ(f.holds_started(), 1);
+}
+
+TEST(CursorVisibilityFilter, HoldKeepsCursorVisibleWhileFlagKeepsToggling) {
+  cursor_visibility_filter_t f;
+  auto t = base();
+  f.apply(true, t);
+  t = blink(f, t, 400ms, 3);
+  ASSERT_TRUE(f.holding());
+  (void) f.take_event();
+  // A minute of blinking: every report, hidden or visible, comes back visible.
+  for (int i = 0; i < 75; ++i) {
+    EXPECT_TRUE(f.apply(false, t));
+    t += 400ms;
+    EXPECT_TRUE(f.apply(true, t));
+    t += 400ms;
+  }
+  EXPECT_TRUE(f.holding());
+  EXPECT_FALSE(f.take_event().has_value());  // no churn while the hold simply continues
+}
+
+TEST(CursorVisibilityFilter, HoldEndsAfterSettleTimeAndHonoursHidden) {
+  cursor_visibility_filter_t f;
+  auto t = base();
+  f.apply(true, t);
+  t = blink(f, t, 400ms, 3);
+  ASSERT_TRUE(f.holding());
+  (void) f.take_event();
+  // The OS settles on hidden (a game grabbed the mouse mid-flap). The flag
+  // stays overridden until it has been stable for settle_time, then honoured.
+  const auto hidden_at = t;
+  EXPECT_TRUE(f.apply(false, hidden_at));
+  EXPECT_TRUE(f.apply(false, hidden_at + 1999ms));
+  EXPECT_TRUE(f.holding());
+  EXPECT_FALSE(f.apply(false, hidden_at + 2000ms));
+  EXPECT_FALSE(f.holding());
+  auto ev = f.take_event();
+  ASSERT_TRUE(ev.has_value());
+  EXPECT_EQ(ev->kind, cursor_visibility_filter_t::event_e::hold_ended);
+  EXPECT_GE(ev->hide_count, 1);
+  EXPECT_GE(ev->span, 2000ms);
+}
+
+TEST(CursorVisibilityFilter, HoldEndsQuietlyWhenFlagSettlesVisible) {
+  cursor_visibility_filter_t f;
+  auto t = base();
+  f.apply(true, t);
+  t = blink(f, t, 400ms, 3);
+  ASSERT_TRUE(f.holding());
+  (void) f.take_event();
+  // Last report was visible; nothing changes for settle_time -> hold ends, output unchanged.
+  EXPECT_TRUE(f.apply(true, t + 2000ms));
+  EXPECT_FALSE(f.holding());
+  auto ev = f.take_event();
+  ASSERT_TRUE(ev.has_value());
+  EXPECT_EQ(ev->kind, cursor_visibility_filter_t::event_e::hold_ended);
+  // And a legitimate hide afterwards passes straight through again.
+  EXPECT_FALSE(f.apply(false, t + 5s));
+}
+
+TEST(CursorVisibilityFilter, HidesOutsideTheWindowNeverCombine) {
+  cursor_visibility_filter_t f;
+  auto t = base();
+  f.apply(true, t);
+  // A hide every 1.6 s: any three span 3.2 s, more than the 3 s window, so never a hold.
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_FALSE(f.apply(false, t));
+    t += 800ms;
+    EXPECT_TRUE(f.apply(true, t));
+    t += 800ms;
+  }
+  EXPECT_FALSE(f.holding());
+}
+
+TEST(CursorVisibilityFilter, FlapHistoryIsDroppedWhenAHoldEnds) {
+  cursor_visibility_filter_t f;
+  auto t = base();
+  f.apply(true, t);
+  t = blink(f, t, 400ms, 3);
+  ASSERT_TRUE(f.holding());
+  t += 2000ms;
+  EXPECT_TRUE(f.apply(true, t));
+  ASSERT_FALSE(f.holding());
+  (void) f.take_event();
+  // Two more hides right after the hold ended must not re-arm it by combining
+  // with the flap's old hides: they are a fresh count of two.
+  t += 10ms;
+  EXPECT_FALSE(f.apply(false, t));
+  t += 100ms;
+  EXPECT_TRUE(f.apply(true, t));
+  t += 100ms;
+  EXPECT_FALSE(f.apply(false, t));
+  EXPECT_FALSE(f.holding());
+}
+
+TEST(CursorVisibilityFilter, TickEndsAHoldWithoutANewReport) {
+  cursor_visibility_filter_t f;
+  auto t = base();
+  EXPECT_FALSE(f.tick(t).has_value());  // nothing reported yet
+  f.apply(true, t);
+  t = blink(f, t, 400ms, 2);
+  EXPECT_TRUE(f.apply(false, t));  // third hide -> hold; last report is hidden
+  ASSERT_TRUE(f.holding());
+  (void) f.take_event();
+  // The pointer goes quiet (DDA reports nothing more). Ticks alone must end
+  // the hold once settle_time has passed and hand back the last reported state.
+  auto v = f.tick(t + 1999ms);
+  ASSERT_TRUE(v.has_value());
+  EXPECT_TRUE(*v);
+  EXPECT_TRUE(f.holding());
+  v = f.tick(t + 2000ms);
+  ASSERT_TRUE(v.has_value());
+  EXPECT_FALSE(*v);
+  EXPECT_FALSE(f.holding());
+  auto ev = f.take_event();
+  ASSERT_TRUE(ev.has_value());
+  EXPECT_EQ(ev->kind, cursor_visibility_filter_t::event_e::hold_ended);
+}
+
+TEST(CursorVisibilityFilter, StatsReportTransitionsPerInterval) {
+  cursor_visibility_filter_t f;
+  auto t = base();
+  f.apply(true, t);
+  EXPECT_FALSE(f.take_stats().has_value());
+  // A quiet interval produces nothing.
+  EXPECT_TRUE(f.apply(true, t + 30s));
+  EXPECT_FALSE(f.take_stats().has_value());
+  // Two slow toggles (never a hold) inside the next interval.
+  f.apply(false, t + 35s);
+  f.apply(true, t + 40s);
+  f.apply(false, t + 47s);
+  f.apply(true, t + 50s);
+  EXPECT_FALSE(f.holding());
+  EXPECT_FALSE(f.take_stats().has_value());  // interval not over yet
+  EXPECT_TRUE(f.apply(true, t + 60s));
+  auto s = f.take_stats();
+  ASSERT_TRUE(s.has_value());
+  EXPECT_EQ(s->transitions, 4);
+  EXPECT_EQ(s->min_gap, 3000ms);
+  EXPECT_EQ(s->interval, 30000ms);
+  EXPECT_FALSE(f.take_stats().has_value());  // one-shot
+}
+
+TEST(CursorVisibilityFilter, ConfigIsHonoured) {
+  cursor_visibility_filter_t::config_t cfg;
+  cfg.flap_window = 500ms;
+  cfg.flap_threshold = 2;
+  cfg.settle_time = 300ms;
+  cursor_visibility_filter_t f {cfg};
+  auto t = base();
+  f.apply(true, t);
+  EXPECT_FALSE(f.apply(false, t + 100ms));
+  EXPECT_TRUE(f.apply(true, t + 200ms));
+  EXPECT_TRUE(f.apply(false, t + 300ms));  // second hide inside 500 ms -> hold
+  EXPECT_TRUE(f.holding());
+  EXPECT_FALSE(f.apply(false, t + 600ms));  // stable hidden for 300 ms -> hold ends
+  EXPECT_FALSE(f.holding());
+}


### PR DESCRIPTION
## Summary

The streamed mouse cursor blinks on Windows 11 Insider build 29648.1000. That is an OS fault, not a capture bug: Microsoft's [release notes for 29648.1000](https://learn.microsoft.com/en-us/windows-insider/release-notes/experimental-future-platforms/preview-build-29648-1000) list "The mouse cursor getting into a state where it blinks repeatedly for some Insiders" as a known issue, and the same fault was fixed on the 26300 line in [26300.8935](https://learn.microsoft.com/en-us/windows-insider/release-notes/experimental/preview-build-26300-8935) ("Fixed an issue causing the mouse cursor to blink repeatedly"). Upstream Sunshine has a matching report from a Dev-channel host ([LizardByte/Sunshine#5293](https://github.com/LizardByte/Sunshine/issues/5293)).

We show the blink because every capture path mirrors the OS cursor-visibility flag verbatim into whether the cursor is blended: the LuminalVGD hardware-cursor plane republishes IddCx `IsCursorVisible` into the shared cursor section, `display_vgd.cpp` `sync_cursor()` copies it into `gpu_cursor_t::visible`, the DDA paths copy `PointerPosition.Visible`, and the cursor-only redelivery path re-encodes a frame on every flip. The blend chain itself (seqlock shape hand-off, blend states, render targets, keyed-mutex ordering) was reviewed end to end and is sound.

## Change

- **`src/platform/windows/cursor_visibility_filter.h`**: `cursor_visibility_filter_t`, a pure, allocation-free rate filter. Reports pass straight through (a game hiding its cursor is honoured on the same frame) until 3 visible→hidden transitions land inside 3 s; the filter then holds the cursor visible until the flag has been stable for 2 s, then honours the OS flag again. The hold is bounded by that settle time *after the flag stops changing*, not by the window. `tick()` re-evaluates without a new report (DDA only hears from the OS on pointer updates). `take_stats()` gives per-30 s transition telemetry.
- **Wired into** the LuminalVGD ring path (`display_vgd.cpp`), the DDA VRAM path (`display_vram.cpp`, with a per-frame tick on frames without a pointer update) and the DDA software path (`display_ram.cpp`). WGC composes the cursor itself and cannot be filtered host-side; pre-cursor VGD drivers likewise compose it into frames.
- **Logging** (`log_cursor_visibility_event`): first hold per display is a `warning` naming the running Windows build, later holds are `info`; a 30 s `info` line reports transition counts whenever the flag moved at all, so a blink too slow to arm the hold is still visible in the log. This is also the field confirmation of the diagnosis.
- **Tests**: `tests/unit/test_cursor_visibility_filter.cpp` (12 cases: pass-through, arming on the third hide, hold while toggling, settle to hidden/visible, window boundary, history reset, tick, stats, config).

## Trade-offs

- While the OS keeps toggling, a game that wants its cursor hidden shows a cursor in the stream, which is what the local display shows too. Once the flag settles the hidden state is honoured within 2 s.
- Three legitimate hides inside 3 s (e.g. rapid monitor crossings) arm a hold that ends 2 s after the last transition; cost is a briefly visible cursor.
- Removal criterion: drop the filter once no supported Windows build reports the flap.

## Verification

- 12/12 unit tests pass (`test_sunshine --gtest_filter='CursorVisibilityFilter.*'`).
- Full `test_sunshine` run: 687 ran, 669 passed, 9 skipped, 9 failed. The 9 failures are the pre-existing environment-sensitive set on this host (1 `ConfigHttpCheckAuthTest` allowed-IP case, 8 `PlayniteSync`/`PlayniteAutosync` cases), identical to the baseline before this change; no new failures.
- Header passes clang and g++ under `-Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion`.
- Independent design review (fresh subagent): "ship with changes"; its blocking finding (DDA hold outliving the flap while the mouse is still) and its recommendations (3 s window, telemetry, software path, log wording) are all applied.
- Host build 29648.1000 is the reproducer; the new `... cursor-visibility flag is flapping ...` warning on the next stream is the expected field confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
