### PR TITLE
Installer: restart page when the LuminalVGD driver is updated

### DIFF
--- a/packaging/windows/bootstrapper/LuminalShineInstaller.cs
+++ b/packaging/windows/bootstrapper/LuminalShineInstaller.cs
@@ -806,7 +806,8 @@ namespace LuminalShineInstaller {
       });
 
       tipsStack.Children.Add(new TextBlock {
-        Text = "You can install or upgrade LuminalShine while actively streaming. No system restart is required. "
+        Text = "You can install or upgrade LuminalShine while actively streaming. No system restart is required "
+          + "unless the LuminalVGD display driver itself is updated — the installer tells you at the end if that happened. "
           + "After you click Install or Upgrade, the current streaming session will end, then you can usually "
           + "start streaming again after about 1–2 minutes without issues.",
         FontSize = 12.5,
@@ -1395,6 +1396,40 @@ namespace LuminalShineInstaller {
         "LuminalShine uninstall completed.");
     }
 
+    /// <summary>
+    /// Final page when this run replaced the LuminalVGD driver: instead of the
+    /// auto-closing "Complete" overlay, ask for a Windows restart. "Restart
+    /// Later" needs a second confirmation; either way Windows already knows a
+    /// restart is pending (RunInstallAttempt registered it), so "Later" only
+    /// changes the exit code and leaves the machine up.
+    /// </summary>
+    private async Task RunVgdRestartFlowAsync(string previousVersion, string newVersion) {
+      var page = "LuminalShine is installed.\n\n"
+        + "The LuminalVGD Driver has been Updated from " + previousVersion + " to " + newVersion + ". "
+        + "To ensure Windows is using the latest LuminalVGD Driver, please restart Windows.";
+      while (true) {
+        var restartNow = await ShowOverlayConfirmAsync("LuminalVGD Driver Updated", page, "Restart Now", "Restart Later", false);
+        if (restartNow) {
+          ProcessExitCode = 0;
+          SetStatus("Restarting Windows...", "Windows restarts in about 10 seconds to load LuminalVGD " + newVersion + ".", _statusSuccessBrush);
+          VgdUpdateMarker.InitiateRestart();
+          Close();
+          return;
+        }
+        var later = await ShowOverlayConfirmAsync(
+          "Restart Windows later?",
+          "LuminalVGD will not operate with the latest updates and fixes until Windows restart. Are you sure?",
+          "Okay",
+          "Go Back",
+          true);
+        if (later) {
+          ProcessExitCode = 3010;
+          Close();
+          return;
+        }
+      }
+    }
+
     private async Task RunOperationAsync(Func<Task<InstallerResult>> actionFactory, string actionLabel, string inProgressText, string successText) {
       SetBusyState(true);
       SetStatus(inProgressText, "This can take a minute.", _statusBusyBrush);
@@ -1403,6 +1438,13 @@ namespace LuminalShineInstaller {
         var result = await actionFactory();
         if (result.Succeeded) {
           ProcessExitCode = 0;
+          // Read the marker here rather than trusting the result object: the
+          // elevated-child install path hands results back through a snapshot
+          // that does not carry the driver fields.
+          var vgdPreviousVersion = string.Empty;
+          var vgdNewVersion = string.Empty;
+          var vgdUpdated = result.Operation == InstallerOperation.Install
+            && VgdUpdateMarker.TryRead(out vgdPreviousVersion, out vgdNewVersion);
           if (result.Operation == InstallerOperation.Install && result.PartiallySucceeded) {
             var warningDetail = BuildComponentFailureDetail(result.ComponentFailures);
             if (!string.IsNullOrWhiteSpace(result.UserDetail)) {
@@ -1410,6 +1452,10 @@ namespace LuminalShineInstaller {
             }
             SetStatus("LuminalShine installation completed with warnings.", warningDetail, _statusWarningBrush);
             await ShowInstallPartialSuccessDialogAsync(result);
+            if (vgdUpdated) {
+              await RunVgdRestartFlowAsync(vgdPreviousVersion, vgdNewVersion);
+              return;
+            }
             Close();
             return;
           }
@@ -1420,6 +1466,10 @@ namespace LuminalShineInstaller {
             detail += "\n" + result.UserDetail;
           }
           SetStatus(successText, detail, _statusSuccessBrush);
+          if (vgdUpdated) {
+            await RunVgdRestartFlowAsync(vgdPreviousVersion, vgdNewVersion);
+            return;
+          }
           await ShowOverlayInfoAsync("Complete", _statusText.Text);
           Close();
           return;
@@ -2374,6 +2424,104 @@ namespace LuminalShineInstaller {
     }
     public bool PartiallySucceeded {
       get { return Succeeded && ComponentFailures != null && ComponentFailures.Count > 0; }
+    }
+    // Set when this install run moved the LuminalVGD driver package to a
+    // newer version (previous -> new); empty otherwise.
+    public string VgdPreviousVersion { get; set; }
+    public string VgdNewVersion { get; set; }
+    public bool VgdDriverUpdated {
+      get { return !string.IsNullOrWhiteSpace(VgdPreviousVersion) && !string.IsNullOrWhiteSpace(VgdNewVersion); }
+    }
+  }
+
+  /// <summary>
+  /// The LuminalVGD driver script (drivers\luminalvgd\install.ps1, run by the
+  /// MSI) records what it did under HKLM\SOFTWARE\NortheBridge\LuminalShine\LuminalVGD:
+  /// PreviousVersion, InstalledVersion and Updated (1 when the package moved
+  /// to a newer version). The installer clears those values before msiexec so
+  /// a stale marker from an earlier run can never trigger the restart page.
+  /// </summary>
+  internal static class VgdUpdateMarker {
+    private const string KeyPath = @"SOFTWARE\NortheBridge\LuminalShine\LuminalVGD";
+    private const int MoveFileDelayUntilReboot = 0x4;
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool MoveFileEx(string existingFileName, string newFileName, int flags);
+
+    public static void Clear() {
+      try {
+        using (var key = Registry.LocalMachine.OpenSubKey(KeyPath, true)) {
+          if (key == null) {
+            return;
+          }
+          foreach (var name in new[] { "PreviousVersion", "InstalledVersion", "Updated", "UpdatedAt" }) {
+            key.DeleteValue(name, false);
+          }
+        }
+      } catch {
+        // Best effort: a stale marker could only re-show the restart page,
+        // never suppress it.
+      }
+    }
+
+    public static bool TryRead(out string previousVersion, out string newVersion) {
+      previousVersion = string.Empty;
+      newVersion = string.Empty;
+      try {
+        using (var key = Registry.LocalMachine.OpenSubKey(KeyPath, false)) {
+          if (key == null) {
+            return false;
+          }
+          var updated = key.GetValue("Updated") as int?;
+          previousVersion = (key.GetValue("PreviousVersion") as string) ?? string.Empty;
+          newVersion = (key.GetValue("InstalledVersion") as string) ?? string.Empty;
+          return updated == 1
+            && !string.IsNullOrWhiteSpace(previousVersion)
+            && !string.IsNullOrWhiteSpace(newVersion)
+            && !string.Equals(previousVersion, newVersion, StringComparison.Ordinal);
+        }
+      } catch {
+        return false;
+      }
+    }
+
+    /// <summary>
+    /// Tells Windows a restart is pending the way installers do: a marker file
+    /// scheduled for delete-at-reboot lands in PendingFileRenameOperations —
+    /// what Windows itself, SCCM/Intune and Test-PendingReboot all check — and
+    /// it clears itself the moment the machine actually restarts.
+    /// </summary>
+    public static void RegisterPendingRestart(string previousVersion, string newVersion) {
+      try {
+        var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "LuminalShine");
+        Directory.CreateDirectory(dir);
+        var marker = Path.Combine(dir, "luminalvgd-restart-pending.txt");
+        File.WriteAllText(
+          marker,
+          "LuminalVGD driver updated " + previousVersion + " -> " + newVersion + " at " + DateTime.Now.ToString("o") + Environment.NewLine
+          + "Windows must restart before the new driver is in use. Windows removes this file at the next restart." + Environment.NewLine);
+        MoveFileEx(marker, null, MoveFileDelayUntilReboot);
+        using (var key = Registry.LocalMachine.CreateSubKey(KeyPath)) {
+          if (key != null) {
+            key.SetValue("RestartPending", 1, RegistryValueKind.DWord);
+          }
+        }
+      } catch {
+        // Best effort; the restart page itself already told the user.
+      }
+    }
+
+    /// <summary>Begins a normal Windows restart (planned, application-installation reason).</summary>
+    public static void InitiateRestart() {
+      var shutdown = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "shutdown.exe");
+      var psi = new ProcessStartInfo {
+        FileName = shutdown,
+        Arguments = "/r /t 10 /d p:4:1 /c \"LuminalShine: restarting Windows to load the updated LuminalVGD driver.\"",
+        UseShellExecute = false,
+        CreateNoWindow = true
+      };
+      using (Process.Start(psi)) {
+      }
     }
   }
 
@@ -3643,9 +3791,26 @@ namespace LuminalShineInstaller {
         "SUPPRESSMSGBOXES=1"
       };
 
+      if (installLuminalVgd) {
+        VgdUpdateMarker.Clear();
+      }
       var exitCode = RunMsiexec(args, true, false);
       if (exitCode == 0 && competingProductsRequireRestart) {
         exitCode = 3010;
+      }
+
+      var vgdPreviousVersion = string.Empty;
+      var vgdNewVersion = string.Empty;
+      var vgdUpdated = installLuminalVgd
+        && (exitCode == 0 || exitCode == 3010)
+        && VgdUpdateMarker.TryRead(out vgdPreviousVersion, out vgdNewVersion);
+      if (vgdUpdated) {
+        // The driver package moved to a newer version and Windows may keep
+        // the old image loaded until it restarts. Flag it like any installer
+        // would (3010 + pending-restart registration); the UI or the CLI
+        // caller decides when to restart.
+        exitCode = 3010;
+        VgdUpdateMarker.RegisterPendingRestart(vgdPreviousVersion, vgdNewVersion);
       }
 
       var componentFailures = CollectInstallComponentFailures(logPath, vddChoice);
@@ -3661,6 +3826,10 @@ namespace LuminalShineInstaller {
       }
 
       var resultMessage = BuildResultMessage("Install", exitCode, logPath);
+      if (vgdUpdated) {
+        resultMessage += " LuminalVGD driver updated " + vgdPreviousVersion + " -> " + vgdNewVersion
+          + "; restart Windows to load it.";
+      }
       if (saveInstallLogs) {
         if (!string.IsNullOrWhiteSpace(savedLogPath)) {
           resultMessage += " Saved log copy: " + savedLogPath;
@@ -3690,7 +3859,9 @@ namespace LuminalShineInstaller {
         Message = resultMessage,
         UserDetail = saveLogsDetail,
         LogPath = logPath,
-        ComponentFailures = componentFailures
+        ComponentFailures = componentFailures,
+        VgdPreviousVersion = vgdUpdated ? vgdPreviousVersion : string.Empty,
+        VgdNewVersion = vgdUpdated ? vgdNewVersion : string.Empty
       };
     }
 

--- a/src_assets/windows/drivers/luminalvgd/install.ps1
+++ b/src_assets/windows/drivers/luminalvgd/install.ps1
@@ -135,6 +135,56 @@ function Get-PublishedDriverPackages([string]$OriginalInfPattern, [string]$Provi
     $packages | Select-Object -Unique
 }
 
+function Get-StagedLuminalVgdVersion {
+    # Highest LuminalVGD package version currently in the driver store, from
+    # `pnputil /enum-drivers` ("Driver Version: 07/23/2026 0.1.0.8"). Works
+    # whether the devnode is present, phantom (service stopped — i.e. every
+    # upgrade) or absent, which is why the update marker uses it instead of
+    # a devnode property.
+    $out = pnputil /enum-drivers | Out-String
+    $best = $null
+    $inPackage = $false
+    foreach ($line in ($out -split "`r?`n")) {
+        if ($line -match 'Published Name:\s+oem\d+\.inf') { $inPackage = $false }
+        elseif ($line -match 'Original Name:\s+luminalvgd\.inf') { $inPackage = $true }
+        elseif ($inPackage -and $line -match 'Driver Version:\s+\S+\s+([0-9][0-9.]*)') {
+            try {
+                $v = [Version]$Matches[1]
+                if (-not $best -or $v -gt $best) { $best = $v }
+            } catch {}
+        }
+    }
+    $best
+}
+
+# --- Driver update marker ---------------------------------------------------
+# "What did this run do to the driver", for the installer UI: the bootstrapper
+# clears these values before msiexec and reads them afterwards, then offers a
+# Windows restart when the package actually moved to a newer version (some
+# hosts keep the old driver image loaded until they restart).
+$vgdMarkerKey = 'HKLM:\SOFTWARE\NortheBridge\LuminalShine\LuminalVGD'
+$script:vgdPreviousVer = $null
+$script:vgdBundledVer = $null
+
+function Write-VgdUpdateMarker {
+    New-Item -Path $vgdMarkerKey -Force | Out-Null
+    $prev = if ($script:vgdPreviousVer) { $script:vgdPreviousVer.ToString() } else { '' }
+    $new = if ($script:vgdBundledVer) { $script:vgdBundledVer.ToString() } else { '' }
+    $updated = 0
+    if ($script:vgdPreviousVer -and $script:vgdBundledVer -and $script:vgdBundledVer -gt $script:vgdPreviousVer) { $updated = 1 }
+    New-ItemProperty -Path $vgdMarkerKey -Name 'PreviousVersion' -Value $prev -PropertyType String -Force | Out-Null
+    New-ItemProperty -Path $vgdMarkerKey -Name 'InstalledVersion' -Value $new -PropertyType String -Force | Out-Null
+    New-ItemProperty -Path $vgdMarkerKey -Name 'Updated' -Value $updated -PropertyType DWord -Force | Out-Null
+    New-ItemProperty -Path $vgdMarkerKey -Name 'UpdatedAt' -Value ([DateTime]::UtcNow.ToString('o')) -PropertyType String -Force | Out-Null
+    # A previous "restart later" is satisfied once the marker file Windows
+    # deletes at reboot is gone.
+    $pendingFile = Join-Path $env:ProgramData 'LuminalShine\luminalvgd-restart-pending.txt'
+    if (-not (Test-Path $pendingFile)) {
+        Remove-ItemProperty -Path $vgdMarkerKey -Name 'RestartPending' -ErrorAction SilentlyContinue
+    }
+    if ($updated -eq 1) { Write-Host "[LuminalVGD] Driver package updated $prev -> $new; a Windows restart is recommended." }
+}
+
 function Remove-SudoVda {
     # Unconditional eviction: devices, driver packages, SudoMaker
     # publisher certs, and the SudoMaker registry key. Every step is
@@ -196,6 +246,16 @@ function Install-LuminalVgd {
     $dll = Join-Path $packageDir 'luminal_vgd_driver.dll'
     foreach ($f in @($inf, $cat, $dll)) {
         if (-not (Test-Path $f)) { throw "[LuminalVGD] missing driver artifact: $f" }
+    }
+
+    # What is staged right now vs. what we bundle — recorded by
+    # Write-VgdUpdateMarker once the install pass is done.
+    if ((Get-Content $inf -Raw) -match 'DriverVer\s*=\s*[^,]+,\s*([0-9][0-9.]*)') {
+        try { $script:vgdBundledVer = [Version]$Matches[1] } catch {}
+    }
+    $script:vgdPreviousVer = Get-StagedLuminalVgdVersion
+    if ($script:vgdPreviousVer) {
+        Write-Host "[LuminalVGD] Previously staged driver: $($script:vgdPreviousVer); bundled: $($script:vgdBundledVer)"
     }
 
     $build = [Environment]::OSVersion.Version.Build
@@ -301,6 +361,7 @@ try {
             Write-Warning "[LuminalVGD] ETW AutoLogger removal failed (continuing): $($_.Exception.Message)"
         }
         Remove-LuminalVgd
+        Remove-Item -Path $vgdMarkerKey -Recurse -Force -Confirm:$false -ErrorAction SilentlyContinue
     } else {
         # The sweep is best-effort by contract — its failure must never
         # abort the driver install (a terminating error here previously
@@ -311,6 +372,11 @@ try {
             Write-Warning "[LuminalVGD] SudoVDA sweep failed (continuing): $($_.Exception.Message)"
         }
         Install-LuminalVgd
+        try {
+            Write-VgdUpdateMarker
+        } catch {
+            Write-Warning "[LuminalVGD] Could not record the driver update marker (continuing): $($_.Exception.Message)"
+        }
         # Best-effort by contract, like the sweep: diagnostics must never
         # fail the driver install.
         try {


### PR DESCRIPTION
Some hosts keep the old LuminalVGD driver image loaded until Windows restarts. Until now the installer never said so: the MSI runs silently under the bootstrapper, the driver script swallows every reboot signal, and the window closed itself with "All selected changes were applied successfully."

## What changes

**Driver script** (`src_assets/windows/drivers/luminalvgd/install.ps1`)
- Before staging, reads the highest LuminalVGD package version already in the driver store (`pnputil /enum-drivers`), which works whether the devnode is present, phantom (service stopped, i.e. every upgrade) or absent.
- After the install pass, writes `HKLM\SOFTWARE\NortheBridge\LuminalShine\LuminalVGD` with `PreviousVersion`, `InstalledVersion`, `Updated` (1 only when the bundled package is strictly newer than what was staged) and `UpdatedAt`. Uninstall removes the key. The driver install itself is unchanged.

**Bootstrapper** (`packaging/windows/bootstrapper/LuminalShineInstaller.cs`)
- Clears the marker before `msiexec` (a stale marker can never re-trigger the page) and reads it afterwards.
- When the driver moved to a newer version: the result carries the two versions, the exit code becomes 3010, and a restart is registered with Windows the way installers do — a marker file under `%ProgramData%\LuminalShine` scheduled with `MoveFileEx(..., MOVEFILE_DELAY_UNTIL_REBOOT)`, which lands in `PendingFileRenameOperations` (what Windows, Intune/SCCM and `Test-PendingReboot` check) and disappears at the next restart.
- Instead of the auto-closing "Complete" overlay, the UI ends on a page: *The LuminalVGD Driver has been Updated from &lt;previous&gt; to &lt;new&gt;. To ensure Windows is using the latest LuminalVGD Driver, please restart Windows.* with **Restart Now** / **Restart Later**.
  - **Restart Later** asks once more: *LuminalVGD will not operate with the latest updates and fixes until Windows restart. Are you sure?* with **Okay** / **Go Back**. Okay closes with exit code 3010 and leaves the pending-restart registration in place; Go Back returns to the page.
  - **Restart Now** starts a normal planned Windows restart (`shutdown /r /t 10 /d p:4:1`) and closes.
- Silent installs (`/quiet`) get no page: exit code 3010 plus the pending-restart registration, so winget/Intune report "restart required".
- The "No system restart is required" quick tip now says that a restart is only needed when the LuminalVGD driver itself is updated.

## Not changed
- No WiX authoring or custom-action rows (the MSI golden baseline is untouched).
- First installs (no previously staged package) and same-version reinstalls never show the page.

## Verification
- `install.ps1` parses (PowerShell AST).
- The bootstrapper compiles with Roslyn at `-langversion:7.3` against the .NET Framework 4.x WPF assemblies, zero errors.
- Not yet exercised end to end on a host with an older staged driver; the next driver bump is the natural test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
