### PR TITLE
Web UI: point the Discord link at the Moonlight server invite

### DIFF
--- a/src_assets/common/assets/web/ResourceCard.vue
+++ b/src_assets/common/assets/web/ResourceCard.vue
@@ -28,6 +28,34 @@
           </div>
         </n-card>
       </div>
+      <div
+        class="rounded-lg border border-line bg-white/[0.02] px-3 py-2.5 text-xs leading-relaxed"
+      >
+        <p class="font-semibold text-ink">
+          {{
+            withFallback(
+              'resource_card.discord_experimental',
+              'LuminalShine is Experimental on the Official Moonlight Server. Please be sure to Enable View of the Experimental Category.',
+            )
+          }}
+        </p>
+        <p class="mt-1.5 text-ink-3">
+          {{
+            withFallback(
+              'resource_card.discord_experimental_hint',
+              'The Discord link above joins the Moonlight community server. In the server’s channel browser (Channels & Roles), turn on the Experimental category to see the LuminalShine channel.',
+            )
+          }}
+        </p>
+        <p class="mt-1 text-ink-3">
+          {{
+            withFallback(
+              'resource_card.discord_experimental_hint2',
+              'When asking for help there, paste the diagnostics report from this page (Copy as Markdown).',
+            )
+          }}
+        </p>
+      </div>
     </section>
 
     <section class="min-w-0 space-y-3">
@@ -77,10 +105,13 @@ function withFallback(key: string, fallback: string) {
 
 const resources = computed(() => [
   {
-    href: 'https://discord.com/channels/352065098472488960/1528712503054303423',
+    href: 'https://discord.gg/EWNGkAATR',
     icon: 'fab fa-discord',
     title: 'Discord',
-    description: withFallback('resource_card.discord_desc', 'Join the community'),
+    description: withFallback(
+      'resource_card.discord_desc',
+      'Moonlight community server · LuminalShine lives in the Experimental category',
+    ),
     avatarStyle: 'background-color: rgba(0, 180, 216, 0.15); color: rgb(0, 180, 216);',
   },
   {

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -1347,12 +1347,15 @@
     "warning_msg": "Make sure you have access to the client you are pairing with. This software can give total control to your computer, so be careful!"
   },
   "resource_card": {
+    "discord_experimental": "LuminalShine is Experimental on the Official Moonlight Server. Please be sure to Enable View of the Experimental Category.",
+    "discord_experimental_hint": "The Discord link above joins the Moonlight community server. In the server’s channel browser (Channels & Roles), turn on the Experimental category to see the LuminalShine channel.",
+    "discord_experimental_hint2": "When asking for help there, paste the diagnostics report from this page (Copy as Markdown).",
     "github_discussions": "GitHub Discussions",
     "legal": "Legal",
     "legal_desc": "By continuing to use this software you agree to the terms and conditions in the following documents.",
     "license": "License",
     "resources": "Resources",
-    "discord_desc": "Join the community",
+    "discord_desc": "Moonlight community server · LuminalShine lives in the Experimental category",
     "resources_desc": "Resources for LuminalShine!",
     "third_party_notice": "Third Party Notice"
   },


### PR DESCRIPTION
Follow-up to #170: this commit was pushed to the phase 3 branch a few minutes after that PR merged, so it never reached main.

The Web links card (Diagnostics -> About this host) now links to https://discord.gg/EWNGkAATR and carries the note **LuminalShine is Experimental on the Official Moonlight Server. Please be sure to Enable View of the Experimental Category.** plus two plain lines: how to enable the Experimental category in the server channel browser, and a hint to paste the diagnostics report when asking for help. Three en.json keys added; the discord_desc string updated.

Verified in the built UI (static preview of build/assets/web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)